### PR TITLE
feat: add AI provider types and settings management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,13 @@
 # Optional. Where the SQLite file lives. Defaults to ./data/studio.db
 # DATABASE_PATH=./data/studio.db
+
+# Document analysis is configured in the app — the gear in the sidebar — not
+# here: provider, model, endpoint and key all live in the database.
+#
+# These variables are only a way to keep the key OUT of the data directory.
+# When one is set and no key has been typed into the dialog, it is used, and
+# the dialog says so. You still choose the provider and the model there.
+# ANTHROPIC_API_KEY=sk-ant-...
+# OPENAI_API_KEY=sk-...
+# GEMINI_API_KEY=AIza...
+# NVIDIA_API_KEY=nvapi-...

--- a/README.md
+++ b/README.md
@@ -95,6 +95,24 @@ browser to get a PDF.
 
 **Import** — accepts JSON or a `window.ARCHITECTURE = {…}` data file. Paste it or pick the file.
 
+**Read a document** *(off until you configure a model)* — hand it a design document, an RFC or an
+onboarding guide as PDF or Markdown, and it drafts the diagram the document describes: scopes, layers,
+components, dependencies, and the role and responsibilities of each. The same reading can be run
+against a project that already exists — **Enrich** in the editor — where it can only add: new
+components, missing dependencies, and text in the fields you left empty. Nothing you have written
+is ever overwritten, and applying leaves a named version in History to go back to.
+
+Nothing is written until you have read what came back. The review screen states what the model
+had to assume, what it could not answer, and what had to be repaired before the document could be
+opened — a dependency on a component it never defined, an icon that does not exist. Treat all of
+it as a draft: it is one reading of one document, and the dependencies especially deserve a
+second pair of eyes.
+
+This is the one feature that leaves your machine, so it is opt-in and it is yours to point:
+choose a provider in **Settings** — Anthropic, OpenAI, Google Gemini, NVIDIA NIM, or anything
+that speaks the OpenAI API, including a model running on your own hardware. Configure nothing and
+both entry points do not exist. See [Reading documents](#reading-documents).
+
 ---
 
 ## Templates
@@ -332,14 +350,18 @@ src/app/                  Next.js 15 App Router
   projects/[id]/page.tsx  editor (server)    → components/Editor
   projects/[id]/document/ the printable design document — plan, renderer, print CSS
   api/                    folders, projects, templates, export, import, revisions
-src/components/           Workspace, Editor, Inspector, History, Icon, Brand (the mark)
+  api/ai, api/settings    document analysis, and which model does it
+src/components/           Workspace, Editor, Inspector, History, Analyse, Settings, Icon, Brand
 src/lib/
   db.ts                   node:sqlite connection + schema
   store.ts                every query in the app lives here
+  settings.ts             operator configuration; the only place a key is handled
   types.ts                the document contract
   defaults.ts             blank document, palette, normalisation
   links.ts                the dependency-kind table — stroke, labels, legend
   diff.ts                 two documents → what changed, in words
+  ai/                     schema, prompts, convert, merge
+  ai/providers/           one shape for five providers, three adapters
   templates/              the six templates and instantiate()
   document/               the ADD outline (plan.ts) and its chapter preset
   exportHtml.ts           document → self-contained HTML
@@ -376,6 +398,62 @@ checkpoint during an autosave otherwise leaves two rows in the same second with 
 The full surface is `GET/POST/PATCH/DELETE /api/projects/:id/revisions`, driven by the **History**
 button in the editor. What that panel shows is computed by `src/lib/diff.ts`, which turns two
 documents into sentences rather than a JSON diff.
+
+---
+
+## Reading documents
+
+Nothing is configured out of the box. Open **Settings** — the gear at the foot of the sidebar —
+and choose who reads your documents:
+
+| Provider | Endpoint | PDFs | Token count before a run |
+|---|---|---|---|
+| Anthropic | built in | yes | exact |
+| Google Gemini | built in | yes | exact |
+| OpenAI | built in | text only | estimated |
+| NVIDIA NIM | built in | text only | estimated |
+| OpenAI-compatible | yours | text only | estimated |
+
+The last row is the interesting one: anything that speaks `/v1/chat/completions` — Ollama, LM
+Studio, vLLM, Groq, Together, OpenRouter, a model on your own GPU — is a base URL away, and needs
+no key at all when it is local and unauthenticated.
+
+**Test before you trust it.** Two buttons in the dialog: *Load models* asks the provider what it
+can serve, and *Test* runs a real schema-constrained request. The second is the one that matters —
+the analysis depends on the model honouring a JSON schema, most current models do and small local
+ones often do not, and it is much better to learn that here than after uploading a 40-page
+document.
+
+**The key is stored in `data/studio.db`, in clear text.** There is no login in this application
+to encrypt it against, and a key derived from something on the machine would only look like
+encryption — so: anyone who can read that file, or a backup of it, can read the key. It is never
+sent back to the browser, which only ever sees the last four characters. To keep it out of the
+data directory entirely, set `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY` /
+`NVIDIA_API_KEY` in the environment and leave the field empty; the dialog then says it is reading
+the environment.
+
+**What it sends.** The file you choose, plus — for an enrichment — the id, name, scope and layer
+of each component already in *that one project*. Nothing else: not your other projects, not the
+database, not the file until you pick it. It goes to the endpoint you configured and nowhere else,
+from the server process, so the key never reaches the browser.
+
+**What it costs.** One request per run, on your own account. Providers do not publish their rates
+through their APIs, so no price is invented for you: enter one in Settings (dollars per million
+tokens, input and output) and the dialog shows what a run will cost before you start it. Leave it
+empty and it shows a token count instead.
+
+**What guarantees the output.** The answer is generated under a JSON Schema the provider enforces
+— `output_config.format` on Anthropic, `response_format: json_schema` with `strict: true` on the
+OpenAI surface, `responseSchema` on Gemini — so it cannot come back as prose or as half a
+document. That leaves exactly one failure mode, a document that is well-formed and *wrong*, which
+is why the result is shown for review rather than written, and why every repair is listed rather
+than made quietly. The schema lives in `src/lib/ai/schema.ts`, is checked against `types.ts` by a
+test, and is translated per provider in `src/lib/ai/providers/dialects.ts`.
+
+**What it does not do.** It does not write your chapters: `sections` are the editorial argument of
+the document and stay yours. It does not cite the source — the APIs reject citations and
+schema-constrained output in the same request, so tracing a component back to its paragraph would
+need a second pass, and pretending to trace it would be worse than not trying.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.117.1",
         "@dnd-kit/core": "^6.1.0",
         "@dnd-kit/sortable": "^8.0.0",
         "@dnd-kit/utilities": "^3.2.2",
@@ -25,6 +26,36 @@
       },
       "engines": {
         "node": ">=22.13"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.117.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.117.1.tgz",
+      "integrity": "sha512-Yn2QlXfyCiKJ5YGCOOay7ZE78ISvII2XY621WMCiflmG8IYgwx59IBwPExxki3Xk9jKUtnD/Sj6UvplWr0rZxg==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@dnd-kit/accessibility": {
@@ -1132,6 +1163,12 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -1256,6 +1293,12 @@
         "@esbuild/win32-x64": "0.28.2"
       }
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1269,6 +1312,19 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/nanoid": {
@@ -1469,6 +1525,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -1491,6 +1557,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/tslib": {
       "version": "2.8.1",

--- a/package.json
+++ b/package.json
@@ -8,11 +8,12 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "reset": "node -e \"require('fs').rmSync('data',{recursive:true,force:true});console.log('database removed \u2014 it will be recreated and re-seeded on next start')\"",
+    "reset": "node -e \"require('fs').rmSync('data',{recursive:true,force:true});console.log('database removed — it will be recreated and re-seeded on next start')\"",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test src/lib/*.test.ts src/lib/*/*.test.ts"
+    "test": "tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.117.1",
     "@dnd-kit/core": "^6.1.0",
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.2",

--- a/src/app/api/ai/analyse/route.ts
+++ b/src/app/api/ai/analyse/route.ts
@@ -1,0 +1,88 @@
+import { NextResponse } from 'next/server';
+import { MAX_UPLOAD_BYTES } from '@/lib/ai/config';
+import { analyse, estimate, type Source, type SourceKind } from '@/lib/ai/analyze';
+import { toArchitecture } from '@/lib/ai/convert';
+import { providerInfo } from '@/lib/ai/providers';
+import { resolveAiConfig } from '@/lib/settings';
+import { getProject } from '@/lib/store';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/* The only route that reaches the network. It reads a file and a project, and
+ * returns a *proposal* — it writes nothing. Applying the result is an ordinary
+ * create or update through the routes that already existed, which is what
+ * keeps the model's output on exactly the same footing as a hand-typed import:
+ * normalised on the way in, snapshotted in History, undoable. */
+
+const KINDS: SourceKind[] = ['pdf', 'text'];
+
+/** base64 inflates by 4/3; the guard is on what was actually uploaded. */
+const decodedSize = (kind: SourceKind, data: string): number =>
+  kind === 'pdf' ? Math.floor((data.length * 3) / 4) : Buffer.byteLength(data, 'utf8');
+
+export async function POST(req: Request) {
+  const cfg = resolveAiConfig();
+  if (!cfg) {
+    return NextResponse.json(
+      { error: 'No model is configured. Open Settings and choose a provider.' },
+      { status: 503 }
+    );
+  }
+
+  const body = await req.json().catch(() => ({}));
+  const kind = body.kind as SourceKind;
+  const data = String(body.data || '');
+  const filename = String(body.filename || 'document');
+
+  if (!KINDS.includes(kind)) return NextResponse.json({ error: 'Unsupported file type.' }, { status: 400 });
+  if (kind === 'pdf' && !providerInfo(cfg.provider).supportsPdf) {
+    return NextResponse.json(
+      { error: `${providerInfo(cfg.provider).label} is set up for text documents here. Convert the PDF to Markdown or plain text, or switch provider in Settings.` },
+      { status: 400 }
+    );
+  }
+  if (!data) return NextResponse.json({ error: 'The file is empty.' }, { status: 400 });
+  if (decodedSize(kind, data) > MAX_UPLOAD_BYTES) {
+    return NextResponse.json(
+      { error: `That file is over the ${Math.round(MAX_UPLOAD_BYTES / 1024 / 1024)} MB limit.` },
+      { status: 413 }
+    );
+  }
+
+  /* An enrichment is scoped to one project: the model is shown that project's
+   * inventory and nothing else in the workspace. */
+  let existing = null;
+  if (body.projectId) {
+    const project = getProject(String(body.projectId));
+    if (!project) return NextResponse.json({ error: 'Unknown project.' }, { status: 404 });
+    existing = project.data;
+  }
+
+  const source: Source = { kind, filename, data };
+
+  try {
+    if (body.estimate) {
+      return NextResponse.json(await estimate(cfg, source, existing));
+    }
+
+    const { analysis, usage, reduced } = await analyse(cfg, source, existing);
+    const { document, repairs } = toArchitecture(analysis.document);
+
+    return NextResponse.json({
+      document,
+      repairs,
+      assumptions: analysis.assumptions ?? [],
+      questions: analysis.questions ?? [],
+      reduced,
+      usage
+    });
+  } catch (e) {
+    /* The upstream message is the useful one — an invalid schema, a rate limit
+     * and a bad key each say so precisely, and hiding that behind "analysis
+     * failed" would leave the operator with nothing to act on. */
+    const err = e as { status?: number; message?: string };
+    const status = typeof err.status === 'number' && err.status >= 400 && err.status < 600 ? err.status : 502;
+    return NextResponse.json({ error: err.message || 'The analysis failed.' }, { status });
+  }
+}

--- a/src/app/api/ai/route.ts
+++ b/src/app/api/ai/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+import { MAX_UPLOAD_BYTES, acceptAttr } from '@/lib/ai/config';
+import { providerInfo } from '@/lib/ai/providers';
+import { publicAiSettings, resolveAiConfig } from '@/lib/settings';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/* Whether this install can analyse documents, and with what. The browser asks
+ * on every mount and hides every entry point when the answer is no, so an
+ * operator who has configured nothing never sees a button that would only tell
+ * them off for pressing it. */
+export async function GET() {
+  const cfg = resolveAiConfig();
+  const settings = publicAiSettings();
+  const info = providerInfo(settings.provider);
+
+  return NextResponse.json(
+    {
+      enabled: cfg !== null,
+      provider: settings.provider,
+      providerLabel: info.label,
+      model: settings.model,
+      supportsPdf: info.supportsPdf,
+      /* A provider that cannot read a PDF should not offer to be given one. */
+      accept: acceptAttr(info.supportsPdf),
+      maxBytes: MAX_UPLOAD_BYTES,
+      /* Null when no price is configured — the dialog then shows tokens only. */
+      priced: settings.inputPrice !== undefined || settings.outputPrice !== undefined
+    },
+    /* Explicitly uncacheable. With no freshness header a browser is free to
+     * reuse this answer, and it does — which leaves the buttons showing after
+     * the provider is cleared, and hidden after one is configured, until a hard
+     * reload. `dynamic = 'force-dynamic'` governs the server's own cache, not
+     * the client's; this is the half that reaches the browser. */
+    { headers: { 'Cache-Control': 'no-store' } }
+  );
+}

--- a/src/app/api/settings/ai/probe/route.ts
+++ b/src/app/api/settings/ai/probe/route.ts
@@ -1,0 +1,93 @@
+import { NextResponse } from 'next/server';
+import { adapterFor, foreignKeyOwner, providerInfo } from '@/lib/ai/providers';
+import { candidateAiConfig } from '@/lib/settings';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/* Trying the settings out before committing to them.
+ *
+ * Two actions, one route, because both answer the same question from different
+ * distances: *will this configuration work?* `models` asks the provider what it
+ * can serve; `test` runs an actual schema-constrained completion — the only
+ * thing that proves the model will honour the contract the analysis depends on.
+ * A provider that lists a hundred models and refuses `json_schema` on all of
+ * them passes the first and fails the second, and it is much better to learn
+ * that here than after uploading a 40-page document. */
+
+/** The smallest possible instance of what the analysis does. */
+const PING_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['ok'],
+  properties: { ok: { type: 'string', enum: ['yes'] } }
+};
+
+export async function POST(req: Request) {
+  const body = await req.json().catch(() => ({}));
+  const cfg = candidateAiConfig(body);
+
+  if (!cfg) {
+    return NextResponse.json(
+      { error: 'Choose a provider and give it a key first.' }, { status: 400 }
+    );
+  }
+
+  try {
+    if (body.action === 'models') {
+      return NextResponse.json({ models: await adapterFor(cfg).listModels(cfg) });
+    }
+
+    if (!cfg.model) {
+      return NextResponse.json({ error: 'Choose a model first.' }, { status: 400 });
+    }
+
+    const started = Date.now();
+    const result = await adapterFor(cfg).complete(cfg, {
+      system: 'You answer with the JSON object you are given a schema for. Nothing else.',
+      parts: [{ kind: 'text', text: 'Reply with ok: yes.' }],
+      schema: PING_SCHEMA,
+      /* Generous for a one-word answer: on a model that thinks before it
+       * writes, this budget covers the thinking too, and a truncated ping
+       * would read as a failure of the provider rather than of the budget. */
+      maxTokens: 2_000
+    });
+
+    const value = (result.json as { ok?: string } | null)?.ok;
+    if (value !== 'yes') {
+      return NextResponse.json(
+        { error: `${providerInfo(cfg.provider).label} answered, but not under the schema it was given. This model probably does not support JSON-schema output.` },
+        { status: 422 }
+      );
+    }
+
+    return NextResponse.json({
+      ok: true,
+      model: cfg.model,
+      ms: Date.now() - started,
+      inputTokens: result.inputTokens,
+      outputTokens: result.outputTokens
+    });
+  } catch (e) {
+    /* The provider's own message is the useful one — a bad key, an unknown
+     * model and an unsupported response format each say so precisely. */
+    const err = e as { status?: number; message?: string };
+    const status = typeof err.status === 'number' && err.status >= 400 && err.status < 600 ? err.status : 502;
+
+    /* Except for one case it cannot know about: a key that belongs to another
+     * vendor. "invalid x-api-key" names neither the key you pasted nor the
+     * service that refused it, and the reader is left checking a perfectly
+     * good key for typos. Say what it looks like instead. */
+    const foreign = foreignKeyOwner(cfg.provider, cfg.apiKey);
+    const hint = foreign
+      ? `That key belongs to ${foreign.label} (${foreign.keyPrefixes?.[0]}…), not ${providerInfo(cfg.provider).label}`
+        + `${foreign.envKey ? ` — put it in ${foreign.envKey}, or select ${foreign.label} above` : ''}.`
+      : '';
+
+    /* Two sentences from two places; the provider's rarely ends in a full stop. */
+    const said = err.message || 'The provider could not be reached.';
+    const message = hint ? `${said.replace(/[.\s]*$/, '')}. ${hint}` : said;
+
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/src/app/api/settings/ai/route.ts
+++ b/src/app/api/settings/ai/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server';
+import { PROVIDERS } from '@/lib/ai/providers';
+import { publicAiSettings, saveAiSettings, type AiSettingsPatch } from '@/lib/settings';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const noStore = { headers: { 'Cache-Control': 'no-store' } };
+
+/** The configuration, minus the key — which never leaves the server. */
+export async function GET() {
+  return NextResponse.json(
+    { settings: publicAiSettings(), providers: PROVIDERS },
+    noStore
+  );
+}
+
+/** A number field the operator may legitimately want to clear. */
+function price(raw: unknown): number | null | undefined {
+  if (raw === null || raw === '') return null;
+  if (raw === undefined) return undefined;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? n : undefined;
+}
+
+export async function PUT(req: Request) {
+  const body = await req.json().catch(() => ({}));
+
+  const patch: AiSettingsPatch = {
+    provider: body.provider,
+    model: typeof body.model === 'string' ? body.model : undefined,
+    baseUrl: typeof body.baseUrl === 'string' ? body.baseUrl : undefined,
+    /* Three states, and the difference matters: the field was left alone, the
+     * operator typed a new key, or the operator asked for the stored one to be
+     * forgotten. The browser never receives a key, so it cannot echo one back
+     * — an absent field has to mean "keep what you have". */
+    apiKey: body.clearKey ? null : typeof body.apiKey === 'string' && body.apiKey ? body.apiKey : undefined,
+    inputPrice: price(body.inputPrice),
+    outputPrice: price(body.outputPrice)
+  };
+
+  return NextResponse.json({ settings: saveAiSettings(patch) }, noStore);
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -785,3 +785,48 @@ input.input[type="color"] { height: 34px; padding: 3px; cursor: pointer; }
   .sidebar { display: none; }
   .inspector { position: fixed; right: 0; top: var(--topbar); bottom: 0; z-index: 60; box-shadow: var(--shadow-lg); }
 }
+
+/* ---------- Document analysis ---------- */
+/* The findings panel. Everything here is a claim a model made about someone's
+   system, so it is set as prose to be read rather than as data to be skimmed —
+   the one place in the studio where the reader is expected to disagree with
+   what is on screen. */
+.ai-list { margin: 4px 0 0; padding-left: 17px; font-size: 12.5px; color: var(--ink-2); line-height: 1.5; }
+.ai-list li { margin-bottom: 4px; }
+.ai-list li:last-child { margin-bottom: 0; }
+.ai-counts { font-size: 13px; margin: 2px 0 0; color: var(--ink-2); }
+/* The running state: a file name and a warning that nothing will happen for a
+   minute or two. Left-aligned because it is a sentence, not a status. */
+.ai-running { padding: 22px 20px; border: 1px dashed var(--line-3); background: var(--panel-2); margin-top: 14px; }
+.ai-running b { display: block; margin-bottom: 4px; font-size: 13.5px; }
+.ai-running span { font-size: 12.5px; color: var(--ink-2); }
+.ai-more { font-size: 12.5px; color: var(--ink-3); padding: 2px 0 2px 23px; }
+
+/* ---------- Settings ---------- */
+/* A link that is really a button — "Forget it" next to a stored key. Set as
+   prose because it belongs to the sentence around it, not to the toolbar. */
+.linkbtn {
+  border: 0; background: none; padding: 0; font: inherit; font-size: inherit; cursor: pointer;
+  color: var(--brand-ink); border-bottom: 1px solid color-mix(in srgb, var(--brand) 35%, transparent);
+}
+.linkbtn:hover { color: var(--ink); border-bottom-color: var(--ink); }
+.linkbtn:disabled { color: var(--ink-3); border-bottom-color: transparent; cursor: default; }
+/* The result of a connection test. Teal, because it is the one line here that
+   reports something the operator just made happen. */
+.ok-line {
+  display: inline-flex; align-items: center; gap: 7px; font-size: 12.5px; color: var(--brand-ink);
+}
+.ok-line svg { fill: none; stroke: currentColor; stroke-width: 1.9; }
+
+/* The named way into Settings. A labelled button rather than another icon in
+   the tray: this is where the model provider and its key are set, and an
+   unlabelled gear is only findable by someone who already knows. */
+.sidebar-foot { flex-wrap: wrap; }
+.footbtn {
+  display: inline-flex; align-items: center; gap: 7px; border: 1px solid var(--line-2);
+  background: var(--panel); color: var(--ink-2); font: inherit; font-size: 12px;
+  padding: 0 11px; height: 34px; border-radius: 0; cursor: pointer; transition: .12s;
+}
+.footbtn:hover { border-color: var(--ink-3); color: var(--ink); background: var(--panel-3); }
+.footbtn svg { width: 15px; height: 15px; fill: none; stroke: currentColor; stroke-width: 1.9; }
+.footnote { flex-basis: 100%; font-size: 11px; color: var(--ink-3); }

--- a/src/components/Analyse.tsx
+++ b/src/components/Analyse.tsx
@@ -1,0 +1,451 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { Icon } from './Icon';
+import { api } from '@/lib/api';
+import { byRepairKind, type Repair } from '@/lib/ai/convert';
+import { DEFAULT_MERGE, mergeProposal, type MergeOptions } from '@/lib/ai/merge';
+import { byArea, diffArchitecture, summarise } from '@/lib/diff';
+import type { Architecture } from '@/lib/types';
+
+/* Reading a written document into a diagram.
+ *
+ * Both entry points — a new project from a document, and enriching one that
+ * exists — are the same three beats: choose a file, see what it will cost,
+ * read what came back before any of it is written down. The third beat is the
+ * one that matters. A model's answer here is a claim about someone's system,
+ * and the whole design of this dialog is that a person reads the claim, with
+ * its assumptions and its unanswered questions beside it, while the database
+ * is still untouched. */
+
+interface AiStatus {
+  enabled: boolean; provider: string; providerLabel: string; model: string;
+  supportsPdf: boolean; accept: string; maxBytes: number; priced: boolean;
+}
+interface Source { kind: 'pdf' | 'text'; filename: string; data: string }
+interface Estimate { tokens: number; exact: boolean; lowCost: number | null; highCost: number | null }
+
+interface Proposal {
+  document: Partial<Architecture>;
+  repairs: Repair[];
+  assumptions: string[];
+  questions: string[];
+  /** The provider refused the full schema; flows and technologies were skipped. */
+  reduced?: boolean;
+  /** `cost` is null unless the settings carry a price for this model. */
+  usage: { inputTokens: number; outputTokens: number; cost: number | null };
+}
+
+/* Saving the settings has to move the buttons that the settings govern, in
+ * both places that show them, without either of them knowing the dialog
+ * exists. A module-level notification is the smallest thing that does it —
+ * a context provider for one boolean would be more machinery than fact. */
+const watchers = new Set<() => void>();
+export const aiStatusChanged = (): void => { watchers.forEach(w => w()); };
+
+/** Whether this install can analyse documents. Null while we are still asking. */
+export function useAiStatus(): AiStatus | null {
+  const [status, setStatus] = useState<AiStatus | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    const load = () => api.json<AiStatus>('/api/ai')
+      .then(s => { if (alive) setStatus(s); })
+      /* Fail closed: if the status cannot be read, the feature is treated as
+       * unavailable rather than offered and then failing on use. */
+      .catch(() => {
+        if (alive) setStatus({
+          enabled: false, provider: '', providerLabel: '', model: '',
+          supportsPdf: false, accept: '', maxBytes: 0, priced: false
+        });
+      });
+
+    load();
+    watchers.add(load);
+    return () => { alive = false; watchers.delete(load); };
+  }, []);
+
+  return status;
+}
+
+/* A PDF travels as base64 and everything else as its own text. Chunked because
+ * `String.fromCharCode(...bytes)` on a 10 MB file blows the argument limit. */
+async function readSource(file: File): Promise<Source> {
+  if (file.type === 'application/pdf' || /\.pdf$/i.test(file.name)) {
+    const bytes = new Uint8Array(await file.arrayBuffer());
+    let binary = '';
+    for (let i = 0; i < bytes.length; i += 0x8000) {
+      binary += String.fromCharCode(...bytes.subarray(i, i + 0x8000));
+    }
+    return { kind: 'pdf', filename: file.name, data: btoa(binary) };
+  }
+  return { kind: 'text', filename: file.name, data: await file.text() };
+}
+
+const money = (n: number) => `$${n.toFixed(2)}`;
+const thousands = (n: number) => n.toLocaleString('en-US');
+const plural = (n: number, one: string, many = `${one}s`) => `${n} ${n === 1 ? one : many}`;
+
+/* ------------------------------------------------------------------ pieces */
+
+function FilePicker({ status, source, onPick, disabled }: {
+  status: AiStatus; source: Source | null; onPick: (f: File) => void; disabled: boolean;
+}) {
+  return (
+    <label className="field"><span>Document</span>
+      <input className="input" type="file" accept={status.accept} disabled={disabled}
+        onChange={e => { const f = e.target.files?.[0]; if (f) onPick(f); }} />
+      <div className="hint">
+        {status.supportsPdf ? 'PDF, Markdown' : 'Markdown'} or plain text,
+        up to {Math.round(status.maxBytes / 1024 / 1024)} MB.
+        {source ? ` Reading ${source.filename}.` : ' A design document, an RFC, an onboarding guide — whatever states what the system is made of.'}
+      </div>
+    </label>
+  );
+}
+
+function Estimated({ estimate, status }: { estimate: Estimate | null; status: AiStatus }) {
+  if (!estimate) return null;
+  /* A price only when the settings carry one for this model. Providers do not
+   * publish rates through their APIs, and a number invented here would be
+   * worse than no number at all. */
+  const cost = estimate.lowCost !== null && estimate.highCost !== null
+    ? ` · about ${money(estimate.lowCost)}–${money(estimate.highCost)} on your ${status.providerLabel} account, once`
+    : '';
+  return (
+    <div className="hint" style={{ marginTop: 2 }}>
+      {estimate.exact ? '' : 'about '}{thousands(estimate.tokens)} tokens to read{cost}, with {status.model}.
+      {estimate.exact ? '' : ' Token count estimated — this provider does not measure one up front.'}
+    </div>
+  );
+}
+
+/** The counts, then everything the model wants the reader to know it did. */
+function Findings({ proposal }: { proposal: Proposal }) {
+  const doc = proposal.document;
+  const components = doc.components?.length ?? 0;
+  const deps = doc.components?.reduce((n, c) => n + (c.deps?.length ?? 0), 0) ?? 0;
+  const repairs = byRepairKind(proposal.repairs);
+
+  return (
+    <>
+      <div className="sect-label" style={{ marginTop: 14 }}>What it read
+        <span className="spacer" />
+        {proposal.usage.cost !== null && <span className="count">{money(proposal.usage.cost)}</span>}
+      </div>
+      <p className="ai-counts">
+        {plural(components, 'component')} · {plural(deps, 'dependency', 'dependencies')}
+        {doc.groups?.length ? ` · ${plural(doc.groups.length, 'scope')}` : ''}
+        {doc.layers?.length ? ` · ${plural(doc.layers.length, 'layer')}` : ''}
+        {doc.flows?.length ? ` · ${plural(doc.flows.length, 'flow')}` : ''}
+      </p>
+
+      {proposal.assumptions.length > 0 && (
+        <>
+          <div className="sect-label" style={{ marginTop: 14 }}>What it had to assume
+            <span className="spacer" /><span className="count">{proposal.assumptions.length}</span>
+          </div>
+          <ul className="ai-list">{proposal.assumptions.map((a, i) => <li key={i}>{a}</li>)}</ul>
+        </>
+      )}
+
+      {proposal.questions.length > 0 && (
+        <>
+          <div className="sect-label" style={{ marginTop: 14 }}>What it could not answer
+            <span className="spacer" /><span className="count">{proposal.questions.length}</span>
+          </div>
+          <ul className="ai-list">{proposal.questions.map((q, i) => <li key={i}>{q}</li>)}</ul>
+        </>
+      )}
+
+      {repairs.length > 0 && (
+        <>
+          <div className="sect-label" style={{ marginTop: 14 }}>Repaired before import</div>
+          {repairs.map(g => (
+            <div className="diffgroup" key={g.kind}>
+              <div className="sect-label">{g.label}<span className="spacer" />
+                <span className="count">{g.items.length}</span>
+              </div>
+              {g.items.slice(0, 6).map((d, i) => (
+                <div className="diffrow" key={i}>
+                  <i className="dkind removed">−</i><span className="what">{d}</span>
+                </div>
+              ))}
+              {g.items.length > 6 && <div className="ai-more">and {g.items.length - 6} more</div>}
+            </div>
+          ))}
+        </>
+      )}
+
+      {proposal.reduced && (
+        <div className="warn" style={{ marginTop: 14 }}>
+          <Icon name="layers" size={15} />
+          <span>
+            This provider could not compile the full schema, so a reduced one was used:
+            <b> business flows and the technology table were not extracted</b>. Everything else
+            was. You can add them by hand, or try a different model.
+          </span>
+        </div>
+      )}
+
+      <div className="warn" style={{ marginTop: 16 }}>
+        <Icon name="alert" size={15} />
+        <span>
+          A model read a document and wrote this down. It is a <b>draft to check</b>, not a
+          description of your system — the dependencies especially. Nothing here has been
+          verified against anything.
+        </span>
+      </div>
+    </>
+  );
+}
+
+function Running({ filename }: { filename: string }) {
+  return (
+    <div className="ai-running">
+      <b>Reading {filename}…</b>
+      <span>
+        One to three minutes. The whole document is read before anything comes back,
+        so there is nothing to show until it does.
+      </span>
+    </div>
+  );
+}
+
+/* ----------------------------------------------------- new from a document */
+
+export function AnalyseNewDialog({ folderId, onClose, onCreated }: {
+  folderId: string | null; onClose: () => void; onCreated: (id: string) => void;
+}) {
+  const status = useAiStatus();
+  const [source, setSource] = useState<Source | null>(null);
+  const [estimate, setEstimate] = useState<Estimate | null>(null);
+  const [proposal, setProposal] = useState<Proposal | null>(null);
+  const [name, setName] = useState('');
+  const [busy, setBusy] = useState<'' | 'estimating' | 'analysing' | 'creating'>('');
+  const [error, setError] = useState('');
+
+  async function pick(file: File) {
+    setError(''); setProposal(null); setEstimate(null);
+    try {
+      const s = await readSource(file);
+      setSource(s);
+      setBusy('estimating');
+      setEstimate(await api.json<Estimate>('/api/ai/analyse', {
+        method: 'POST', body: JSON.stringify({ ...s, estimate: true })
+      }));
+    } catch (e) { setError((e as Error).message); }
+    finally { setBusy(''); }
+  }
+
+  async function run() {
+    if (!source) return;
+    setBusy('analysing'); setError('');
+    try {
+      const p = await api.json<Proposal>('/api/ai/analyse', { method: 'POST', body: JSON.stringify(source) });
+      setProposal(p);
+      setName(p.document.meta?.name || source.filename.replace(/\.[^.]+$/, ''));
+    } catch (e) { setError((e as Error).message); }
+    finally { setBusy(''); }
+  }
+
+  async function create() {
+    if (!proposal) return;
+    if (!name.trim()) { setError('Give it a name first.'); return; }
+    setBusy('creating'); setError('');
+    try {
+      const p = await api.json<{ id: string }>('/api/projects', {
+        method: 'POST',
+        body: JSON.stringify({ name: name.trim(), folderId, data: proposal.document })
+      });
+      onCreated(p.id);
+    } catch (e) { setError((e as Error).message); setBusy(''); }
+  }
+
+  if (!status?.enabled) return null;
+
+  return (
+    <div className="modal-scrim" onClick={onClose}>
+      <div className="modal" onClick={e => e.stopPropagation()} style={{ maxHeight: '86vh', overflowY: 'auto' }}>
+        <h2>Read a document</h2>
+        <p className="lede">
+          A design document in, a first draft of the diagram out. Everything it produces is
+          yours to correct afterwards — nothing here is locked.
+        </p>
+
+        <FilePicker status={status} source={source} onPick={pick} disabled={busy !== ''} />
+        {!proposal && <Estimated estimate={estimate} status={status} />}
+
+        {busy === 'analysing' ? <Running filename={source?.filename ?? 'the document'} /> : proposal && (
+          <>
+            <Findings proposal={proposal} />
+            <label className="field" style={{ marginTop: 14 }}><span>Project name</span>
+              <input className="input" value={name} onChange={e => setName(e.target.value)}
+                onKeyDown={e => e.key === 'Enter' && create()} />
+            </label>
+          </>
+        )}
+
+        {error && <div className="err">{error}</div>}
+        <div className="modal-actions">
+          <button className="btn ghost" onClick={onClose}>Cancel</button>
+          {proposal ? (
+            <button className="btn primary" onClick={create} disabled={busy !== ''}>
+              {busy === 'creating' ? 'Creating…' : 'Create project'}
+            </button>
+          ) : (
+            <button className="btn primary" onClick={run} disabled={!source || busy !== ''}>
+              {busy === 'estimating' ? 'Measuring…' : busy === 'analysing' ? 'Reading…' : 'Analyse'}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------- enrich an existing one */
+
+const MERGE_LABELS: { key: keyof MergeOptions; label: string; hint: string }[] = [
+  { key: 'addComponents', label: 'Add what is missing',
+    hint: 'Components the document describes and this project does not have — with the scopes, layers, flows and technologies they need.' },
+  { key: 'fillGaps', label: 'Fill the blanks',
+    hint: 'Role, technologies and responsibilities on components that already exist — only where you have left the field empty. Nothing you have written is touched.' },
+  { key: 'addDeps', label: 'Add missing dependencies',
+    hint: 'Calls the document describes between components that exist. Existing dependencies are never removed.' }
+];
+
+export function EnrichDialog({ projectId, doc, onClose, onApply }: {
+  projectId: string; doc: Architecture; onClose: () => void; onApply: (merged: Architecture) => void;
+}) {
+  const status = useAiStatus();
+  const [source, setSource] = useState<Source | null>(null);
+  const [estimate, setEstimate] = useState<Estimate | null>(null);
+  const [proposal, setProposal] = useState<Proposal | null>(null);
+  const [opts, setOpts] = useState<MergeOptions>(DEFAULT_MERGE);
+  const [busy, setBusy] = useState<'' | 'estimating' | 'analysing' | 'applying'>('');
+  const [error, setError] = useState('');
+
+  /* Re-merged on every toggle, so the diff below is always the change that the
+   * button would actually apply — not a summary of the proposal in general. */
+  const merged = useMemo(
+    () => (proposal ? mergeProposal(doc, proposal.document, opts) : null),
+    [proposal, doc, opts]
+  );
+  const diff = useMemo(() => (merged ? diffArchitecture(doc, merged) : null), [doc, merged]);
+  const groups = useMemo(() => (diff ? byArea(diff) : []), [diff]);
+
+  async function pick(file: File) {
+    setError(''); setProposal(null); setEstimate(null);
+    try {
+      const s = await readSource(file);
+      setSource(s);
+      setBusy('estimating');
+      setEstimate(await api.json<Estimate>('/api/ai/analyse', {
+        method: 'POST', body: JSON.stringify({ ...s, projectId, estimate: true })
+      }));
+    } catch (e) { setError((e as Error).message); }
+    finally { setBusy(''); }
+  }
+
+  async function run() {
+    if (!source) return;
+    setBusy('analysing'); setError('');
+    try {
+      setProposal(await api.json<Proposal>('/api/ai/analyse', {
+        method: 'POST', body: JSON.stringify({ ...source, projectId })
+      }));
+    } catch (e) { setError((e as Error).message); }
+    finally { setBusy(''); }
+  }
+
+  async function apply() {
+    if (!merged) return;
+    setBusy('applying'); setError('');
+    try {
+      /* A named checkpoint of the document as it stands, before the merge. The
+       * automatic snapshot only fires five minutes after the last one, so
+       * without this an enrichment applied straight after an edit would have
+       * nothing in History to go back to — and "you can undo this" has to be
+       * true at the moment it is offered, not on average. */
+      await api.json(`/api/projects/${projectId}/revisions`, {
+        method: 'POST', body: JSON.stringify({ label: 'Before enrichment' })
+      });
+      /* The editor owns the write: handing it the merged document lets its own
+       * autosave persist it, rather than racing a second writer against it. */
+      onApply(merged);
+    } catch (e) { setError((e as Error).message); setBusy(''); }
+  }
+
+  if (!status?.enabled) return null;
+
+  return (
+    <div className="modal-scrim" onClick={onClose}>
+      <div className="modal wide" onClick={e => e.stopPropagation()} style={{ maxHeight: '86vh', overflowY: 'auto' }}>
+        <h2>Enrich from a document</h2>
+        <p className="lede">
+          Reads a document against this project. It can only add — what you have already
+          written is never overwritten, and applying leaves a version in History.
+        </p>
+
+        <FilePicker status={status} source={source} onPick={pick} disabled={busy !== ''} />
+        {!proposal && <Estimated estimate={estimate} status={status} />}
+
+        {busy === 'analysing' ? <Running filename={source?.filename ?? 'the document'} /> : proposal && (
+          <>
+            <Findings proposal={proposal} />
+
+            <div className="sect-label" style={{ marginTop: 16 }}>What to apply</div>
+            <div className="radio-row" style={{ flexWrap: 'wrap' }}>
+              {MERGE_LABELS.map(o => (
+                <button key={o.key} className={`radio${opts[o.key] ? ' on' : ''}`}
+                  aria-pressed={opts[o.key]} title={o.hint}
+                  onClick={() => setOpts(v => ({ ...v, [o.key]: !v[o.key] }))}>
+                  <i /> {o.label}
+                </button>
+              ))}
+            </div>
+            <div className="hint">{MERGE_LABELS.find(o => opts[o.key])?.hint ?? 'Nothing selected — there is nothing to apply.'}</div>
+
+            <div className="sect-label" style={{ marginTop: 16 }}>This will change
+              <span className="spacer" />
+              <span className="count">{diff && summarise(diff) ? summarise(diff) : 'nothing'}</span>
+            </div>
+            <div className="hist-diff" style={{ maxHeight: 260, overflowY: 'auto' }}>
+              {groups.length === 0 ? (
+                <p className="muted">Nothing — the document adds nothing this project does not already have.</p>
+              ) : groups.map(g => (
+                <div className="diffgroup" key={g.area}>
+                  <div className="sect-label">{g.label}<span className="spacer" />
+                    <span className="count">{g.changes.length}</span>
+                  </div>
+                  {g.changes.map((c, i) => (
+                    <div className="diffrow" key={i}>
+                      <i className={`dkind ${c.kind}`}>{c.kind === 'added' ? '+' : c.kind === 'removed' ? '−' : '~'}</i>
+                      <span className="what">{c.label}</span>
+                      {c.detail && <em>{c.detail}</em>}
+                    </div>
+                  ))}
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+
+        {error && <div className="err">{error}</div>}
+        <div className="modal-actions">
+          <button className="btn ghost" onClick={onClose}>Cancel</button>
+          {proposal ? (
+            <button className="btn primary" onClick={apply} disabled={busy !== '' || !diff?.total}>
+              {busy === 'applying' ? 'Applying…' : 'Apply to this project'}
+            </button>
+          ) : (
+            <button className="btn primary" onClick={run} disabled={!source || busy !== ''}>
+              {busy === 'estimating' ? 'Measuring…' : 'Analyse'}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -10,6 +10,7 @@ import { Icon } from './Icon';
 import Inspector from './Inspector';
 import ContentEditor from './ContentEditor';
 import History from './History';
+import { EnrichDialog, useAiStatus } from './Analyse';
 import { PALETTE, PALETTE_DARK, slugify } from '@/lib/defaults';
 import { dashFor, kindsInUse, LINK_DASH, LINK_KIND_LABELS, linkOf } from '@/lib/links';
 import type { Architecture, Component, ProjectWithData } from '@/lib/types';
@@ -28,6 +29,8 @@ export default function Editor({ project }: { project: ProjectWithData }) {
   const [link, setLink] = useState<{ from: string; x: number; y: number } | null>(null);
   const [hoverTarget, setHoverTarget] = useState<string | null>(null);
   const [history, setHistory] = useState(false);
+  const [enrich, setEnrich] = useState(false);
+  const ai = useAiStatus();
 
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
   const first = useRef(true);
@@ -183,6 +186,13 @@ export default function Editor({ project }: { project: ProjectWithData }) {
               <button aria-pressed={mode === 'preview'} onClick={() => setMode('preview')}>Preview</button>
             </div>
 
+            {ai?.enabled && (
+              <button className="btn" onClick={() => setEnrich(true)}
+                title="Read a document against this project and add what it is missing">
+                <Icon name="ai" size={15} />Enrich
+              </button>
+            )}
+
             <button className="btn" onClick={() => setHistory(true)}
               title="Earlier versions, and what changed since each one">
               <Icon name="clock" size={15} />History
@@ -255,6 +265,18 @@ export default function Editor({ project }: { project: ProjectWithData }) {
              * the autosave that follows is a no-op against what is on disk. */
             setDoc(data);
             setSelected(s => (data.components.some(c => c.id === s) ? s : null));
+          }} />
+      )}
+
+      {enrich && (
+        <EnrichDialog projectId={project.id} doc={doc}
+          onClose={() => setEnrich(false)}
+          onApply={merged => {
+            /* Adopted like a restore: the dialog has already checkpointed the
+             * document, and the autosave that follows this state change is the
+             * one and only write. */
+            setDoc(merged);
+            setEnrich(false);
           }} />
       )}
     </DndContext>

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,0 +1,277 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Icon } from './Icon';
+import { aiStatusChanged } from './Analyse';
+import { api } from '@/lib/api';
+
+/* Where the operator chooses who reads their documents.
+ *
+ * Five providers, one form. The two buttons that matter are **Load models**
+ * and **Test**: between them they answer "will this work?" before a document
+ * is ever uploaded — the first proves the key and the endpoint, the second
+ * proves the model will actually honour a JSON schema, which is the thing the
+ * whole analysis rests on and the thing that varies most between models.
+ *
+ * The key is written to the database and never read back out to this page. */
+
+interface ProviderInfo {
+  id: string; label: string; blurb: string;
+  keyUrl: string; keyPlaceholder: string; keyPrefixes?: string[];
+  defaultBaseUrl?: string; baseUrlEditable: boolean;
+  defaultModel?: string; supportsPdf: boolean; envKey?: string;
+}
+
+interface PublicSettings {
+  configured: boolean; provider: string; model: string; baseUrl: string;
+  hasKey: boolean; keyHint: string; keyFromEnv: boolean;
+  inputPrice?: number; outputPrice?: number;
+}
+
+interface TestResult { ok: true; model: string; ms: number; inputTokens: number; outputTokens: number }
+
+export function SettingsDialog({ onClose, reason }: {
+  onClose: () => void;
+  /** Why the dialog was opened, when it was opened *for* the reader rather
+   *  than *by* them — arriving here from a button that could not do its job. */
+  reason?: string;
+}) {
+  const [providers, setProviders] = useState<ProviderInfo[]>([]);
+  const [saved, setSaved] = useState<PublicSettings | null>(null);
+
+  const [provider, setProvider] = useState('anthropic');
+  const [model, setModel] = useState('');
+  const [baseUrl, setBaseUrl] = useState('');
+  const [apiKey, setApiKey] = useState('');
+  const [inputPrice, setInputPrice] = useState('');
+  const [outputPrice, setOutputPrice] = useState('');
+
+  const [models, setModels] = useState<string[] | null>(null);
+  const [test, setTest] = useState<TestResult | null>(null);
+  const [busy, setBusy] = useState<'' | 'loading' | 'models' | 'testing' | 'saving'>('loading');
+  const [error, setError] = useState('');
+  const [note, setNote] = useState('');
+
+  const info = providers.find(p => p.id === provider);
+
+  /* Noticed as it is typed rather than after a round trip: one vendor's key in
+   * another's field comes back as "invalid x-api-key", which names neither the
+   * key nor the service and sends you off checking a key that is perfectly
+   * good. Longest prefix first, so `sk-ant-` is not read as OpenAI's `sk-`. */
+  const foreign = apiKey.trim()
+    ? providers
+        .filter(p => p.keyPrefixes?.length && p.id !== provider)
+        .flatMap(p => p.keyPrefixes!.map(prefix => ({ p, prefix })))
+        .sort((a, b) => b.prefix.length - a.prefix.length)
+        .find(({ prefix }) => apiKey.trim().startsWith(prefix))?.p
+    : undefined;
+
+  useEffect(() => {
+    api.json<{ settings: PublicSettings; providers: ProviderInfo[] }>('/api/settings/ai')
+      .then(r => {
+        setProviders(r.providers);
+        setSaved(r.settings);
+        setProvider(r.settings.provider);
+        setModel(r.settings.model);
+        setBaseUrl(r.settings.baseUrl);
+        setInputPrice(r.settings.inputPrice?.toString() ?? '');
+        setOutputPrice(r.settings.outputPrice?.toString() ?? '');
+      })
+      .catch(e => setError((e as Error).message))
+      .finally(() => setBusy(''));
+  }, []);
+
+  /* Changing provider clears what belonged to the previous one rather than
+   * carrying a model name or a base URL across, where it would be silently
+   * wrong. The server does the same on save. */
+  function pickProvider(next: ProviderInfo) {
+    setProvider(next.id);
+    setModel(next.defaultModel ?? '');
+    setBaseUrl(next.defaultBaseUrl ?? '');
+    setApiKey('');
+    setModels(null);
+    setTest(null);
+    setError(''); setNote('');
+  }
+
+  const form = () => ({ provider, model, baseUrl, apiKey: apiKey || undefined });
+
+  async function probe(action: 'models' | 'test') {
+    setBusy(action === 'models' ? 'models' : 'testing');
+    setError(''); setNote(''); if (action === 'test') setTest(null);
+    try {
+      if (action === 'models') {
+        const r = await api.json<{ models: string[] }>('/api/settings/ai/probe', {
+          method: 'POST', body: JSON.stringify({ ...form(), action: 'models' })
+        });
+        setModels(r.models);
+        setNote(r.models.length ? `${r.models.length} models available.` : 'The provider returned no models.');
+      } else {
+        setTest(await api.json<TestResult>('/api/settings/ai/probe', {
+          method: 'POST', body: JSON.stringify({ ...form(), action: 'test' })
+        }));
+      }
+    } catch (e) { setError((e as Error).message); }
+    finally { setBusy(''); }
+  }
+
+  async function save(clearKey = false) {
+    setBusy('saving'); setError(''); setNote('');
+    try {
+      const r = await api.json<{ settings: PublicSettings }>('/api/settings/ai', {
+        method: 'PUT',
+        body: JSON.stringify({
+          provider, model, baseUrl,
+          apiKey: apiKey || undefined,
+          clearKey,
+          inputPrice: inputPrice === '' ? null : Number(inputPrice),
+          outputPrice: outputPrice === '' ? null : Number(outputPrice)
+        })
+      });
+      setSaved(r.settings);
+      setApiKey('');
+      /* The buttons in the workspace and the editor are governed by this. */
+      aiStatusChanged();
+      setNote(clearKey ? 'Key forgotten.' : r.settings.configured
+        ? 'Saved. Document analysis is on.'
+        : 'Saved — still missing something before a run can be made.');
+    } catch (e) { setError((e as Error).message); }
+    finally { setBusy(''); }
+  }
+
+  return (
+    <div className="modal-scrim" onClick={onClose}>
+      <div className="modal" onClick={e => e.stopPropagation()} style={{ maxHeight: '88vh', overflowY: 'auto' }}>
+        <h2>Model provider</h2>
+        <p className="lede">
+          Which model reads your documents, for <b>Read a document</b> and <b>Enrich</b>. Nothing
+          else in the studio uses it.
+        </p>
+        {reason && (
+          <div className="warn" style={{ marginTop: 0, marginBottom: 14 }}>
+            <Icon name="ai" size={15} /><span>{reason}</span>
+          </div>
+        )}
+
+        {busy === 'loading' ? <div className="empty" style={{ padding: 24 }}>Loading…</div> : (
+          <>
+            <div className="field"><span>Provider</span>
+              <div className="radio-row" style={{ flexWrap: 'wrap' }}>
+                {providers.map(p => (
+                  <button key={p.id} className={`radio${provider === p.id ? ' on' : ''}`}
+                    aria-pressed={provider === p.id} onClick={() => pickProvider(p)}>
+                    <i /> {p.label}
+                  </button>
+                ))}
+              </div>
+              {info && <div className="hint">{info.blurb}</div>}
+            </div>
+
+            {info?.baseUrlEditable && (
+              <label className="field"><span>Endpoint</span>
+                <input className="input" value={baseUrl} onChange={e => setBaseUrl(e.target.value)}
+                  placeholder="http://localhost:11434/v1" spellCheck={false} />
+                <div className="hint">The base URL, ending in <code>/v1</code>. Must be reachable from the server, not from your browser.</div>
+              </label>
+            )}
+
+            <label className="field"><span>API key</span>
+              <input className="input" type="password" value={apiKey} spellCheck={false}
+                autoComplete="off"
+                onChange={e => setApiKey(e.target.value)}
+                placeholder={saved?.hasKey ? `stored ${saved.keyHint} — type a new one to replace it` : info?.keyPlaceholder} />
+              {foreign && (
+                <div className="warn" style={{ marginTop: 8 }}>
+                  <Icon name="alert" size={15} />
+                  <span>
+                    That key belongs to <b>{foreign.label}</b>, not {info?.label ?? 'this provider'}.
+                    {' '}Pick <b>{foreign.label}</b> above, or paste a key that belongs here.
+                  </span>
+                </div>
+              )}
+              <div className="hint">
+                {saved?.keyFromEnv
+                  ? <>Currently reading <code>{info?.envKey}</code> from the environment. A key typed here takes over.</>
+                  : saved?.hasKey
+                    ? <>A key is stored. <button className="linkbtn" onClick={() => save(true)} disabled={busy !== ''}>Forget it</button></>
+                    : info?.keyUrl
+                      ? <>Get one at <a href={info.keyUrl} target="_blank" rel="noreferrer">{new URL(info.keyUrl).host}</a>.</>
+                      : 'Leave empty for a local server that does not authenticate.'}
+              </div>
+            </label>
+
+            <div className="field"><span>Model</span>
+              <div className="frow">
+                {models
+                  ? (
+                    <select className="input" value={model} onChange={e => setModel(e.target.value)}>
+                      <option value="">Choose a model…</option>
+                      {models.map(m => <option key={m} value={m}>{m}</option>)}
+                    </select>
+                  )
+                  : (
+                    <input className="input" value={model} spellCheck={false}
+                      onChange={e => setModel(e.target.value)}
+                      placeholder={info?.defaultModel || 'model id'} />
+                  )}
+                <button className="btn" onClick={() => probe('models')} disabled={busy !== ''}>
+                  {busy === 'models' ? 'Loading…' : 'Load models'}
+                </button>
+              </div>
+              <div className="hint">
+                It has to support JSON-schema output — most current models do, small local ones
+                often do not. Test below before trusting it with a document.
+              </div>
+            </div>
+
+            <div className="field"><span>Price, per million tokens (optional)</span>
+              <div className="frow">
+                <input className="input" inputMode="decimal" value={inputPrice}
+                  onChange={e => setInputPrice(e.target.value)} placeholder="input, e.g. 5" />
+                <input className="input" inputMode="decimal" value={outputPrice}
+                  onChange={e => setOutputPrice(e.target.value)} placeholder="output, e.g. 25" />
+              </div>
+              <div className="hint">
+                Only used to show what a run will cost before you start it. Left empty, the dialog
+                shows a token count and no price — no rate is invented for you.
+              </div>
+            </div>
+
+            <div className="frow" style={{ marginTop: 4 }}>
+              <button className="btn" onClick={() => probe('test')} disabled={busy !== ''}>
+                <Icon name="bolt" size={15} />{busy === 'testing' ? 'Testing…' : 'Test'}
+              </button>
+              {test && (
+                <span className="ok-line">
+                  <Icon name="eye" size={14} />
+                  {test.model} answered under the schema in {(test.ms / 1000).toFixed(1)}s.
+                </span>
+              )}
+            </div>
+
+            <div className="warn" style={{ marginTop: 16 }}>
+              <Icon name="lock" size={15} />
+              <span>
+                The key is stored <b>in clear text</b> in <code>data/studio.db</code>. There is no
+                login here to encrypt it against, so anyone who can read that file — or a backup of
+                it — can read the key. To keep it out of the data directory, set{' '}
+                <code>{info?.envKey ?? 'the provider’s key variable'}</code> in the environment
+                instead and leave this field empty.
+              </span>
+            </div>
+
+            {error && <div className="err">{error}</div>}
+            {note && !error && <div className="hint" style={{ marginTop: 10 }}>{note}</div>}
+          </>
+        )}
+
+        <div className="modal-actions">
+          <button className="btn ghost" onClick={onClose}>Close</button>
+          <button className="btn primary" onClick={() => save()} disabled={busy !== ''}>
+            {busy === 'saving' ? 'Saving…' : 'Save'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Workspace.tsx
+++ b/src/components/Workspace.tsx
@@ -8,6 +8,9 @@ import {
 } from '@dnd-kit/core';
 import { Icon } from './Icon';
 import { Lockup } from './Brand';
+import { AnalyseNewDialog, useAiStatus } from './Analyse';
+import { SettingsDialog } from './Settings';
+import { api } from '@/lib/api';
 import { FOLDER_COLORS, PALETTE } from '@/lib/defaults';
 /* `templates/types` carries no template bodies — importing the registry here
  * would ship every template's editorial content to the browser. */
@@ -16,17 +19,6 @@ import type { CloudTarget, Lang, TemplateSummary } from '@/lib/templates/types';
 import type { FolderRecord, ProjectSummary } from '@/lib/types';
 
 type Scope = { kind: 'all' } | { kind: 'unfiled' } | { kind: 'folder'; id: string };
-
-const api = {
-  async json<T>(url: string, init?: RequestInit): Promise<T> {
-    const res = await fetch(url, {
-      ...init,
-      headers: { 'Content-Type': 'application/json', ...(init?.headers || {}) }
-    });
-    if (!res.ok) throw new Error((await res.json().catch(() => ({}))).error || res.statusText);
-    return res.json();
-  }
-};
 
 export default function Workspace({
   initialFolders, initialProjects
@@ -39,7 +31,11 @@ export default function Workspace({
     Object.fromEntries(initialFolders.map(f => [f.id, true])));
   const [query, setQuery] = useState('');
   const [dragging, setDragging] = useState<ProjectSummary | null>(null);
-  const [dialog, setDialog] = useState<null | 'new' | 'import'>(null);
+  const [dialog, setDialog] = useState<null | 'new' | 'import' | 'analyse' | 'settings'>(null);
+  /* Null until the server answers, false on an install with no API key — the
+   * entry point is absent rather than disabled, because a button that only
+   * exists to explain why it cannot work is worse than no button. */
+  const ai = useAiStatus();
   const [busy, setBusy] = useState(false);
 
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }));
@@ -179,7 +175,14 @@ export default function Workspace({
             <button className="iconbtn" onClick={toggleTheme} title="Light / dark">
               <Icon name="moon" size={15} />
             </button>
-            <span style={{ fontSize: 11, color: 'var(--ink-3)' }}>Self-hosted · SQLite</span>
+            {/* Named, not a bare gear. This is where the model provider and its
+                key are set, and nobody hunts for an unlabelled icon to find
+                something they have not been told exists. */}
+            <button className="footbtn" onClick={() => setDialog('settings')}
+              title="Model provider for document analysis">
+              <Icon name="cog" size={15} />Settings
+            </button>
+            <span className="footnote">Self-hosted · SQLite</span>
           </div>
         </aside>
 
@@ -195,6 +198,19 @@ export default function Workspace({
               <input className="input" placeholder="Search projects…" value={query}
                 onChange={e => setQuery(e.target.value)} />
             </div>
+            {/* Shown whether or not a model is configured, and it leads to the
+                right place either way. Hiding it until configuration was done
+                left no path at all from "I want this" to "here is where you
+                turn it on" — the feature was invisible to anyone who had not
+                already read the README. */}
+            {ai && (
+              <button className="btn" onClick={() => setDialog(ai.enabled ? 'analyse' : 'settings')}
+                title={ai.enabled
+                  ? 'Draft a project from a written document'
+                  : 'Needs a model provider — set one up first'}>
+                <Icon name="ai" size={15} />Read a document
+              </button>
+            )}
             <button className="btn" onClick={() => setDialog('import')}>
               <Icon name="upload" size={15} />Import
             </button>
@@ -246,6 +262,19 @@ export default function Workspace({
           onClose={() => setDialog(null)}
           onCreated={id => router.push(`/projects/${id}`)}
         />
+      )}
+      {dialog === 'analyse' && (
+        <AnalyseNewDialog
+          folderId={currentFolderId}
+          onClose={() => setDialog(null)}
+          onCreated={id => router.push(`/projects/${id}`)}
+        />
+      )}
+      {dialog === 'settings' && (
+        <SettingsDialog onClose={() => setDialog(null)}
+          reason={ai && !ai.enabled
+            ? 'Reading documents needs a model. Choose a provider and give it a key, and “Read a document” starts working.'
+            : undefined} />
       )}
     </DndContext>
   );

--- a/src/lib/ai/analyze.ts
+++ b/src/lib/ai/analyze.ts
@@ -1,0 +1,131 @@
+import { AI_MAX_TOKENS } from './config';
+import { adapterFor, type AiConfig, type CompleteInput, type Part } from './providers';
+import { analysisSchema, type Analysis, type SchemaLevel } from './schema';
+import { ENRICH_SYSTEM_PROMPT, SYSTEM_PROMPT, inventoryBrief, userInstruction } from './prompt';
+import type { Architecture } from '@/lib/types';
+
+/* The one call this project makes to anything outside the machine it runs on.
+ *
+ * A single request: read a document, return an ArchStudio document under a
+ * schema the provider enforces during generation. No agent, no loop, no tools —
+ * there is nothing here for a model to explore, and a second round trip would
+ * only give it room to drift from the source it was handed.
+ *
+ * Which vendor answers is decided in the settings dialog and resolved by
+ * `adapterFor`; nothing below this line knows or cares. */
+
+export type SourceKind = 'pdf' | 'text';
+
+export interface Source {
+  kind: SourceKind;
+  filename: string;
+  /** base64 for a PDF, the text itself for anything else. */
+  data: string;
+}
+
+export interface Usage {
+  inputTokens: number;
+  outputTokens: number;
+  /** US dollars, only when the settings carry a price for this model. */
+  cost: number | null;
+}
+
+export interface AnalysisResult {
+  analysis: Analysis;
+  usage: Usage;
+  /** True when the provider refused the full schema and the lean one was used:
+   *  flows and the technology table were not asked for. Surfaced in review. */
+  reduced: boolean;
+}
+
+export interface Estimate {
+  tokens: number;
+  /** False when the number came from counting characters, not the provider. */
+  exact: boolean;
+  lowCost: number | null;
+  highCost: number | null;
+}
+
+function buildInput(source: Source, existing: Architecture | null, level: SchemaLevel = 'full'): CompleteInput {
+  const mode = existing ? 'enrich' : 'create';
+  const parts: Part[] = [];
+  if (existing) parts.push({ kind: 'text', text: inventoryBrief(existing) });
+  parts.push(source.kind === 'pdf'
+    ? { kind: 'pdf', filename: source.filename, base64: source.data }
+    : { kind: 'text', text: `<document name="${source.filename}">\n${source.data}\n</document>` });
+  parts.push({ kind: 'text', text: userInstruction(mode) });
+
+  return {
+    system: existing ? ENRICH_SYSTEM_PROMPT : SYSTEM_PROMPT,
+    parts,
+    schema: analysisSchema(level) as unknown as Record<string, unknown>,
+    maxTokens: AI_MAX_TOKENS
+  };
+}
+
+const price = (tokens: number, perMTok?: number): number | null =>
+  perMTok === undefined ? null : (tokens / 1_000_000) * perMTok;
+
+/** What this run will cost before it is started. The output half is a guess,
+ *  and is shown as a range: a document's worth of components lands somewhere
+ *  between 8k and 30k tokens, and nothing cheaper than the run itself knows. */
+export async function estimate(cfg: AiConfig, source: Source, existing: Architecture | null): Promise<Estimate> {
+  const input = buildInput(source, existing);
+  const counted = await adapterFor(cfg).countTokens(cfg, input);
+
+  const inCost = price(counted.tokens, cfg.inputPrice);
+  const out = (n: number) => price(n, cfg.outputPrice);
+  const total = (o: number | null) => (inCost === null && o === null ? null : (inCost ?? 0) + (o ?? 0));
+
+  return {
+    tokens: counted.tokens,
+    exact: counted.exact,
+    lowCost: total(out(8_000)),
+    highCost: total(out(30_000))
+  };
+}
+
+/* A provider compiles the schema into a grammar before it generates, and past
+ * a size none of them publishes it refuses outright — Anthropic says "the
+ * compiled grammar is too large". The schema is already written to keep that
+ * small (flat links, no icon enum), but "small enough" is not something this
+ * code can know for a given vendor and model. So when it happens, ask for less
+ * of the document rather than failing: the lean schema drops the flows and the
+ * technology table, which are the two deepest branches, and the reader is told
+ * what was skipped. */
+const GRAMMAR_TOO_BIG = /grammar is too large|too complex|schema is too large|exceeds.*complexity/i;
+
+export async function analyse(
+  cfg: AiConfig, source: Source, existing: Architecture | null
+): Promise<AnalysisResult> {
+  let reduced = false;
+  let result;
+  try {
+    result = await adapterFor(cfg).complete(cfg, buildInput(source, existing, 'full'));
+  } catch (e) {
+    if (!GRAMMAR_TOO_BIG.test((e as Error).message ?? '')) throw e;
+    reduced = true;
+    result = await adapterFor(cfg).complete(cfg, buildInput(source, existing, 'lean'));
+  }
+
+  /* The schema is enforced during generation, so this is the contract moving
+   * rather than the model wandering — but a compatible server that only
+   * pretends to support json_schema lands here too, which is exactly the case
+   * the settings dialog's Test button exists to catch first. */
+  if (!result.json || typeof result.json !== 'object') {
+    throw new Error('The provider returned something that is not the agreed document format.');
+  }
+
+  const inCost = price(result.inputTokens, cfg.inputPrice);
+  const outCost = price(result.outputTokens, cfg.outputPrice);
+
+  return {
+    analysis: result.json as Analysis,
+    reduced,
+    usage: {
+      inputTokens: result.inputTokens,
+      outputTokens: result.outputTokens,
+      cost: inCost === null && outCost === null ? null : (inCost ?? 0) + (outCost ?? 0)
+    }
+  };
+}

--- a/src/lib/ai/config.ts
+++ b/src/lib/ai/config.ts
@@ -1,0 +1,30 @@
+/* The limits that hold whatever the provider is.
+ *
+ * Everything vendor-specific — which model, which endpoint, which key, what a
+ * token costs — is operator configuration and lives in the database, set from
+ * the settings dialog. See `src/lib/settings.ts`. What stays here is what the
+ * studio itself decides: how much file it will read, and how long an answer it
+ * will wait for. */
+
+/** Thinking plus the answer. A 60-component document runs to ~25k. */
+export const AI_MAX_TOKENS = 48_000;
+
+/** What the analysis accepts, and how each kind reaches the model. */
+export const ACCEPTED_TYPES: { ext: string; mime: string; kind: 'pdf' | 'text' }[] = [
+  { ext: '.pdf', mime: 'application/pdf', kind: 'pdf' },
+  { ext: '.md', mime: 'text/markdown', kind: 'text' },
+  { ext: '.markdown', mime: 'text/markdown', kind: 'text' },
+  { ext: '.txt', mime: 'text/plain', kind: 'text' },
+  { ext: '.adoc', mime: 'text/plain', kind: 'text' },
+  { ext: '.rst', mime: 'text/plain', kind: 'text' }
+];
+
+/** The picker's filter, narrowed when the chosen provider cannot read a PDF. */
+export const acceptAttr = (supportsPdf: boolean): string =>
+  ACCEPTED_TYPES.filter(t => supportsPdf || t.kind !== 'pdf').map(t => t.ext).join(',');
+
+/* Anthropic caps a request at 32 MB and a PDF at 600 pages; other providers
+ * are stricter still. This sits under all of them: a design document that does
+ * not fit in 12 MB is a scan, and a scan is a worse input than the text it was
+ * made from. Enforced server-side — the browser check is a courtesy. */
+export const MAX_UPLOAD_BYTES = 12 * 1024 * 1024;

--- a/src/lib/ai/convert.test.ts
+++ b/src/lib/ai/convert.test.ts
@@ -1,0 +1,164 @@
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+
+import { toArchitecture } from './convert';
+import type { WireComponent, WireDocument, WireLink } from './schema';
+
+/* The model answers under a schema, so these tests are not about malformed
+ * JSON — they are about a well-formed answer that is *wrong*: an id that is
+ * not an id, a dependency on something never defined, a field filled with the
+ * empty string the schema forced it to send. Each of those has to become
+ * either a correct document or a reported repair, and never a silent loss. */
+
+const wireComponent = (over: Partial<WireComponent> = {}): WireComponent => ({
+  id: 'api', name: 'API', group: 'core', layer: 'services',
+  icon: 'server', badge: '', url: '', role: '',
+  tech: [], features: [], notes: [], deps: [], ...over
+});
+
+const link = (over: Partial<WireLink> = {}): WireLink =>
+  ({ from: 'api', to: 'db', kind: '', protocol: '', note: '', ...over });
+
+const wire = (over: Partial<WireDocument> = {}): WireDocument => ({
+  meta: { lang: 'en', name: 'Test', tagline: '', kicker: '', intro: '', principle: '' },
+  groups: [{ id: 'core', name: 'Core', short: '', description: '' }],
+  layers: [{ id: 'services', name: 'Services', desc: '' }],
+  components: [],
+  links: [],
+  technologies: [],
+  flows: [],
+  flowSteps: [],
+  ...over
+});
+
+test('the empty strings the schema forces are dropped, not written down', () => {
+  const { document } = toArchitecture(wire({ components: [wireComponent()] }));
+  const c = document.components![0];
+  assert.equal('role' in c, false);
+  assert.equal('url' in c, false);
+  assert.equal('badge' in c, false);
+  assert.equal(document.meta!.tagline, undefined);
+  /* The lists stay, empty: the editor expects them to exist. */
+  assert.deepEqual(c.tech, []);
+});
+
+test('a dependency on a component that was never defined is dropped and reported', () => {
+  const { document, repairs } = toArchitecture(wire({
+    components: [wireComponent({ deps: ['db', 'ghost'] }), wireComponent({ id: 'db', name: 'Database' })]
+  }));
+  assert.deepEqual(document.components![0].deps, ['db']);
+  assert.equal(repairs.filter(r => r.kind === 'dep').length, 1);
+  assert.match(repairs.find(r => r.kind === 'dep')!.detail, /ghost/);
+});
+
+test('ids are slugified and every reference to them is repointed', () => {
+  const { document } = toArchitecture(wire({
+    groups: [{ id: 'Core Domain', name: 'Core', short: '', description: '' }],
+    layers: [{ id: 'Service Tier', name: 'Services', desc: '' }],
+    components: [
+      wireComponent({ id: 'Payments API', name: 'Payments', group: 'Core Domain', layer: 'Service Tier', deps: ['Ledger DB'] }),
+      wireComponent({ id: 'Ledger DB', name: 'Ledger', group: 'Core Domain', layer: 'Service Tier' })
+    ],
+    flows: [{ id: 'Take a payment', name: 'Payment', sub: '', group: 'Core Domain', note: '' }],
+    flowSteps: [{ flow: 'Take a payment', component: 'Payments API', title: 'Charge', description: '' }]
+  }));
+
+  const [payments, ledger] = document.components!;
+  assert.equal(payments.id, 'payments-api');
+  assert.equal(ledger.id, 'ledger-db');
+  assert.deepEqual(payments.deps, ['ledger-db']);
+  assert.equal(payments.group, 'core-domain');
+  assert.equal(payments.layer, 'service-tier');
+  assert.equal(document.flows![0].steps[0].component, 'payments-api');
+});
+
+test('an unknown scope is rebased on the first one, and says so', () => {
+  const { document, repairs } = toArchitecture(wire({
+    components: [wireComponent({ group: 'invented' })]
+  }));
+  assert.equal(document.components![0].group, 'core');
+  assert.equal(repairs.filter(r => r.kind === 'scope').length, 1);
+});
+
+test('an annotation cannot outlive the dependency it describes', () => {
+  const { document } = toArchitecture(wire({
+    components: [wireComponent({ deps: ['db'] }), wireComponent({ id: 'db', name: 'Database' })],
+    links: [
+      link({ to: 'db', kind: 'sync', protocol: 'SQL' }),
+      link({ to: 'ghost', kind: 'async', protocol: 'Kafka' })
+    ]
+  }));
+  assert.deepEqual(document.components![0].links, [{ to: 'db', kind: 'sync', protocol: 'SQL' }]);
+});
+
+test('a flat annotation is filed against the component it comes from', () => {
+  /* The links arrive in one list rather than inside each component — the
+   * schema is flattened to keep the compiled grammar small — so `from` is what
+   * decides where each one lands. */
+  const { document } = toArchitecture(wire({
+    components: [
+      wireComponent({ deps: ['db'] }),
+      wireComponent({ id: 'worker', name: 'Worker', deps: ['db'] }),
+      wireComponent({ id: 'db', name: 'Database' })
+    ],
+    links: [
+      link({ from: 'worker', to: 'db', protocol: 'batch load' }),
+      link({ from: 'nobody', to: 'db', protocol: 'from a component that does not exist' })
+    ]
+  }));
+  assert.equal(document.components![0].links, undefined);
+  assert.deepEqual(document.components![1].links, [{ to: 'db', protocol: 'batch load' }]);
+});
+
+test('"I do not know how it travels" is an empty kind, not an invented one', () => {
+  const { document } = toArchitecture(wire({
+    components: [wireComponent({ deps: ['db'] }), wireComponent({ id: 'db', name: 'Database' })],
+    links: [link({ to: 'db', protocol: 'REST' })]
+  }));
+  assert.deepEqual(document.components![0].links, [{ to: 'db', protocol: 'REST' }]);
+});
+
+test('an icon outside the studio’s set is dropped rather than drawn', () => {
+  const { document, repairs } = toArchitecture(wire({
+    components: [wireComponent({ icon: 'rocket' })]
+  }));
+  assert.equal('icon' in document.components![0], false);
+  assert.equal(repairs.filter(r => r.kind === 'icon').length, 1);
+});
+
+test('a flow whose every step points nowhere is dropped, not kept empty', () => {
+  const { document, repairs } = toArchitecture(wire({
+    components: [wireComponent()],
+    flows: [{ id: 'f1', name: 'Ghost flow', sub: '', group: 'core', note: '' }],
+    flowSteps: [{ flow: 'f1', component: 'nobody', title: 'Step', description: '' }]
+  }));
+  assert.equal(document.flows!.length, 0);
+  assert.equal(repairs.filter(r => r.kind === 'flow-step').length, 1);
+});
+
+test('flat steps keep their order and land in the right flow', () => {
+  const { document } = toArchitecture(wire({
+    components: [wireComponent(), wireComponent({ id: 'db', name: 'Database' })],
+    flows: [
+      { id: 'buy', name: 'Purchase', sub: '', group: 'core', note: '' },
+      { id: 'signup', name: 'Signup', sub: '', group: 'core', note: '' }
+    ],
+    flowSteps: [
+      { flow: 'buy', component: 'api', title: 'One', description: '' },
+      { flow: 'signup', component: 'api', title: 'Elsewhere', description: '' },
+      { flow: 'buy', component: 'db', title: 'Two', description: '' }
+    ]
+  }));
+
+  const buy = document.flows!.find(f => f.name === 'Purchase')!;
+  assert.deepEqual(buy.steps.map(s => s.title), ['One', 'Two']);
+  assert.deepEqual(buy.steps.map(s => s.component), ['api', 'db']);
+  assert.equal(document.flows!.find(f => f.name === 'Signup')!.steps.length, 1);
+});
+
+test('a component cannot depend on itself', () => {
+  const { document } = toArchitecture(wire({
+    components: [wireComponent({ deps: ['api'] })]
+  }));
+  assert.deepEqual(document.components![0].deps, []);
+});

--- a/src/lib/ai/convert.ts
+++ b/src/lib/ai/convert.ts
@@ -1,0 +1,230 @@
+import { ICON_KEYS, slugify } from '@/lib/defaults';
+import { LINK_KINDS } from '@/lib/links';
+import type { Architecture, Component, Flow, Group, Layer, Link, LinkKind, Technology } from '@/lib/types';
+import type { WireDocument } from './schema';
+
+/* From the model's answer to a document the studio can open.
+ *
+ * Three jobs, in order: give every entity a well-formed id and repoint what
+ * referenced the old one, drop the empty strings that the schema requires the
+ * model to send for "I don't know", and record what had to be repaired.
+ *
+ * That last one is the point. `normalizeArchitecture` in the store already
+ * makes any document structurally safe — it drops dependencies that point
+ * nowhere and rebases unknown scopes — but it does so silently, which is right
+ * for an import the author typed and wrong for a document a model proposed.
+ * Here the same corrections are made explicitly and handed to the review
+ * screen, so "it invented a dependency on a component it never defined" is
+ * something the reader is told rather than something they have to notice. */
+
+export interface Repair {
+  /** Machine-readable so the review screen can group them; see REPAIR_LABELS. */
+  kind: 'dep' | 'scope' | 'layer' | 'flow-step' | 'flow-scope' | 'tech-scope' | 'icon';
+  detail: string;
+}
+
+export const REPAIR_LABELS: Record<Repair['kind'], string> = {
+  dep: 'Dependencies pointing at a component that was never defined',
+  scope: 'Components filed under a scope that was never defined',
+  layer: 'Components filed under a layer that was never defined',
+  'flow-step': 'Flow steps pointing at a component that was never defined',
+  'flow-scope': 'Flows filed under a scope that was never defined',
+  'tech-scope': 'Technologies attributed to a scope that was never defined',
+  icon: 'Icons outside the studio’s set'
+};
+
+export interface Converted {
+  document: Partial<Architecture>;
+  repairs: Repair[];
+}
+
+const clean = (s: unknown): string => (typeof s === 'string' ? s.trim() : '');
+const list = (a: unknown): string[] =>
+  Array.isArray(a) ? a.map(clean).filter(Boolean) : [];
+
+/** Stable, unique, url-safe ids — the model's are neither, reliably. */
+function idMap(entities: { id: string; name: string }[], prefix: string): Map<string, string> {
+  const taken = new Set<string>();
+  const map = new Map<string, string>();
+  entities.forEach((e, i) => {
+    const raw = clean(e.id) || clean(e.name) || `${prefix}-${i + 1}`;
+    const id = slugify(raw, taken) || `${prefix}-${i + 1}`;
+    taken.add(id);
+    /* Keyed on the model's own id so references can be repointed. A model that
+     * emits the same id twice loses the second one's references rather than
+     * silently merging two components — the duplicate is visible in review. */
+    if (!map.has(clean(e.id))) map.set(clean(e.id), id);
+  });
+  return map;
+}
+
+export function toArchitecture(wire: WireDocument): Converted {
+  const repairs: Repair[] = [];
+  const note = (kind: Repair['kind'], detail: string) => repairs.push({ kind, detail });
+
+  const groupIds = idMap(wire.groups || [], 'scope');
+  const layerIds = idMap(wire.layers || [], 'layer');
+  const compIds = idMap(wire.components || [], 'component');
+
+  const groups: Group[] = (wire.groups || []).map(g => ({
+    id: groupIds.get(clean(g.id))!,
+    name: clean(g.name) || clean(g.id) || 'Scope',
+    ...(clean(g.short) ? { short: clean(g.short) } : {}),
+    ...(clean(g.description) ? { description: clean(g.description) } : {})
+  }));
+
+  const layers: Layer[] = (wire.layers || []).map(l => ({
+    id: layerIds.get(clean(l.id))!,
+    name: clean(l.name) || clean(l.id) || 'Layer',
+    ...(clean(l.desc) ? { desc: clean(l.desc) } : {})
+  }));
+
+  const fallbackGroup = groups[0]?.id;
+  const fallbackLayer = layers[0]?.id;
+
+  const components: Component[] = (wire.components || []).map(c => {
+    const id = compIds.get(clean(c.id))!;
+    const name = clean(c.name) || id;
+
+    let group = groupIds.get(clean(c.group));
+    if (!group) {
+      if (clean(c.group)) note('scope', `${name} → “${clean(c.group)}”`);
+      group = fallbackGroup!;
+    }
+    let layer = layerIds.get(clean(c.layer));
+    if (!layer) {
+      if (clean(c.layer)) note('layer', `${name} → “${clean(c.layer)}”`);
+      layer = fallbackLayer!;
+    }
+
+    const deps: string[] = [];
+    for (const raw of list(c.deps)) {
+      const target = compIds.get(raw);
+      if (!target) { note('dep', `${name} → “${raw}”`); continue; }
+      if (target === id) continue;                       /* self-dependency */
+      if (!deps.includes(target)) deps.push(target);
+    }
+
+    const links: Link[] = [];
+    for (const l of wire.links || []) {
+      /* The annotations arrive in one flat list; each belongs to the component
+       * it is `from`. One per target, and only where the edge exists. */
+      if (compIds.get(clean(l?.from)) !== id) continue;
+      const to = compIds.get(clean(l.to));
+      if (!to || !deps.includes(to) || links.some(x => x.to === to)) continue;
+      const kind = clean(l.kind);
+      const link: Link = { to };
+      if (LINK_KINDS.includes(kind as LinkKind)) link.kind = kind as LinkKind;
+      if (clean(l.protocol)) link.protocol = clean(l.protocol);
+      if (clean(l.note)) link.note = clean(l.note);
+      if (link.kind || link.protocol || link.note) links.push(link);
+    }
+
+    let icon = clean(c.icon);
+    if (icon && !(ICON_KEYS as readonly string[]).includes(icon)) {
+      note('icon', `${name} → “${icon}”`);
+      icon = '';
+    }
+
+    return {
+      id, name, group, layer,
+      ...(icon ? { icon } : {}),
+      ...(clean(c.badge) ? { badge: clean(c.badge) } : {}),
+      ...(clean(c.url) ? { url: clean(c.url) } : {}),
+      ...(clean(c.role) ? { role: clean(c.role) } : {}),
+      tech: list(c.tech),
+      features: list(c.features),
+      notes: list(c.notes),
+      deps,
+      ...(links.length ? { links } : {})
+    };
+  });
+
+  const technologies: Technology[] = (wire.technologies || [])
+    .filter(t => clean(t.name))
+    .map(t => {
+      const scopes: string[] = [];
+      for (const raw of list(t.groups)) {
+        const g = groupIds.get(raw);
+        if (!g) { note('tech-scope', `${clean(t.name)} → “${raw}”`); continue; }
+        if (!scopes.includes(g)) scopes.push(g);
+      }
+      return {
+        name: clean(t.name),
+        ...(clean(t.category) ? { category: clean(t.category) } : {}),
+        ...(clean(t.description) ? { description: clean(t.description) } : {}),
+        ...(scopes.length ? { groups: scopes } : {})
+      };
+    });
+
+  const flowIds = idMap(wire.flows || [], 'flow');
+  const flows: Flow[] = (wire.flows || []).map(f => {
+    const name = clean(f.name) || 'Flow';
+    /* The steps arrive in one flat list; the ones belonging to this flow, in
+     * the order they were written. */
+    const steps = (wire.flowSteps || [])
+      .filter(s => clean(s?.flow) === clean(f.id))
+      .map(s => {
+        const component = compIds.get(clean(s.component));
+        if (!component) {
+          if (clean(s.component)) note('flow-step', `${name} → “${clean(s.component)}”`);
+          return null;
+        }
+        return {
+          component,
+          title: clean(s.title) || name,
+          ...(clean(s.description) ? { description: clean(s.description) } : {})
+        };
+      })
+      .filter((s): s is NonNullable<typeof s> => s !== null);
+
+    let group = groupIds.get(clean(f.group));
+    if (!group) {
+      if (clean(f.group)) note('flow-scope', `${name} → “${clean(f.group)}”`);
+      /* A flow's scope colours its card; borrowing the first step's is a
+       * better guess than the first scope in the document. */
+      group = steps.length
+        ? components.find(c => c.id === steps[0].component)?.group ?? fallbackGroup!
+        : fallbackGroup!;
+    }
+
+    return {
+      id: flowIds.get(clean(f.id))!,
+      name,
+      ...(clean(f.sub) ? { sub: clean(f.sub) } : {}),
+      group,
+      ...(clean(f.note) ? { note: clean(f.note) } : {}),
+      steps
+    };
+  }).filter(f => f.steps.length > 0);
+
+  const meta = wire.meta || ({} as WireDocument['meta']);
+  const document: Partial<Architecture> = {
+    meta: {
+      lang: meta.lang === 'fr' ? 'fr' : 'en',
+      name: clean(meta.name) || 'Analysed architecture',
+      ...(clean(meta.tagline) ? { tagline: clean(meta.tagline) } : {}),
+      ...(clean(meta.kicker) ? { kicker: clean(meta.kicker) } : {}),
+      ...(clean(meta.intro) ? { intro: clean(meta.intro) } : {}),
+      ...(clean(meta.principle) ? { principle: clean(meta.principle) } : {})
+    },
+    ...(groups.length ? { groups } : {}),
+    ...(layers.length ? { layers } : {}),
+    components,
+    technologies,
+    flows
+  };
+
+  return { document, repairs };
+}
+
+/** The repairs grouped for display, in the order REPAIR_LABELS declares them. */
+export function byRepairKind(repairs: Repair[]): { kind: Repair['kind']; label: string; items: string[] }[] {
+  return (Object.keys(REPAIR_LABELS) as Repair['kind'][])
+    .map(kind => ({
+      kind,
+      label: REPAIR_LABELS[kind],
+      items: repairs.filter(r => r.kind === kind).map(r => r.detail)
+    }))
+    .filter(g => g.items.length > 0);
+}

--- a/src/lib/ai/merge.test.ts
+++ b/src/lib/ai/merge.test.ts
@@ -1,0 +1,111 @@
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+
+import { blankArchitecture } from '../defaults';
+import { DEFAULT_MERGE, mergeProposal } from './merge';
+import type { Architecture, Component } from '../types';
+
+/* One property matters more than every other in this file: **the author's work
+ * survives.** Every test below is a way of asking that question — a filled
+ * field, an existing dependency, a component the proposal does not mention. */
+
+const comp = (id: string, over: Partial<Component> = {}): Component => ({
+  id, name: id, group: 'core', layer: 'services',
+  tech: [], features: [], notes: [], deps: [], ...over
+});
+
+const doc = (components: Component[]): Architecture => ({
+  ...blankArchitecture('Existing'),
+  groups: [{ id: 'core', name: 'Core' }],
+  layers: [{ id: 'services', name: 'Services' }, { id: 'data', name: 'Data' }],
+  components
+});
+
+test('a field the author has written in is never overwritten', () => {
+  const current = doc([comp('api', { role: 'Mine', tech: ['Go'] })]);
+  const merged = mergeProposal(current, {
+    components: [comp('api', { role: 'The model’s', tech: ['Rust'], features: ['Serves traffic'] })]
+  }, DEFAULT_MERGE);
+
+  const api = merged.components[0];
+  assert.equal(api.role, 'Mine');
+  assert.deepEqual(api.tech, ['Go']);
+  /* …but a field left empty is filled, which is the whole point. */
+  assert.deepEqual(api.features, ['Serves traffic']);
+});
+
+test('nothing is ever removed', () => {
+  const current = doc([comp('api', { deps: ['db'] }), comp('db', { layer: 'data' }), comp('legacy')]);
+  const merged = mergeProposal(current, { components: [comp('api')] }, DEFAULT_MERGE);
+
+  assert.equal(merged.components.length, 3);
+  assert.deepEqual(merged.components.find(c => c.id === 'api')!.deps, ['db']);
+});
+
+test('new components arrive with the scopes and layers they need', () => {
+  const current = doc([comp('api')]);
+  const merged = mergeProposal(current, {
+    groups: [{ id: 'payments', name: 'Payments' }],
+    layers: [{ id: 'vendors', name: 'Third parties' }],
+    components: [comp('psp', { group: 'payments', layer: 'vendors' })]
+  }, DEFAULT_MERGE);
+
+  assert.equal(merged.components.length, 2);
+  assert.ok(merged.groups.some(g => g.id === 'payments'));
+  /* Appended at the bottom: only the author knows where a new tier belongs. */
+  assert.equal(merged.layers[merged.layers.length - 1].id, 'vendors');
+});
+
+test('a dependency on a component that is not being added is dropped, not left dangling', () => {
+  const current = doc([comp('api')]);
+  const merged = mergeProposal(current, {
+    components: [comp('api', { deps: ['queue'] }), comp('queue')]
+  }, { addComponents: false, fillGaps: false, addDeps: true });
+
+  assert.equal(merged.components.length, 1);
+  assert.deepEqual(merged.components[0].deps, []);
+});
+
+test('an annotation only travels with an edge this merge actually drew', () => {
+  const current = doc([
+    comp('api', { deps: ['db'], links: [{ to: 'db', protocol: 'Mine' }] }),
+    comp('db', { layer: 'data' }),
+    comp('cache', { layer: 'data' })
+  ]);
+  const merged = mergeProposal(current, {
+    components: [comp('api', {
+      deps: ['db', 'cache'],
+      links: [{ to: 'db', protocol: 'The model’s' }, { to: 'cache', protocol: 'Redis' }]
+    })]
+  }, DEFAULT_MERGE);
+
+  const api = merged.components[0];
+  assert.deepEqual(api.deps, ['db', 'cache']);
+  assert.deepEqual(api.links, [{ to: 'db', protocol: 'Mine' }, { to: 'cache', protocol: 'Redis' }]);
+});
+
+test('each option can be turned off on its own', () => {
+  const current = doc([comp('api')]);
+  const proposal = {
+    components: [comp('api', { role: 'Filled in' , deps: ['new'] }), comp('new')]
+  };
+
+  const onlyGaps = mergeProposal(current, proposal, { addComponents: false, fillGaps: true, addDeps: false });
+  assert.equal(onlyGaps.components.length, 1);
+  assert.equal(onlyGaps.components[0].role, 'Filled in');
+  assert.deepEqual(onlyGaps.components[0].deps, []);
+
+  const onlyNew = mergeProposal(current, proposal, { addComponents: true, fillGaps: false, addDeps: false });
+  assert.equal(onlyNew.components.length, 2);
+  assert.equal(onlyNew.components[0].role, undefined);
+
+  const none = mergeProposal(current, proposal, { addComponents: false, fillGaps: false, addDeps: false });
+  assert.deepEqual(none, current);
+});
+
+test('the current document is not mutated', () => {
+  const current = doc([comp('api')]);
+  const before = JSON.stringify(current);
+  mergeProposal(current, { components: [comp('api', { role: 'x' }), comp('other')] }, DEFAULT_MERGE);
+  assert.equal(JSON.stringify(current), before);
+});

--- a/src/lib/ai/merge.ts
+++ b/src/lib/ai/merge.ts
@@ -1,0 +1,123 @@
+import type { Architecture, Component, Link } from '@/lib/types';
+
+/* Folding a proposal into a document that already exists.
+ *
+ * The rule the whole file follows: **what the author wrote wins.** A model that
+ * has read one PDF knows less about this system than the person who has been
+ * editing it, so nothing here overwrites a non-empty field, deletes anything,
+ * or reorders anything. Enrichment can only add — new components, new
+ * dependencies, and text in the gaps the author left empty.
+ *
+ * That makes the three options below safe to explain in a sentence each, which
+ * matters more than granularity: a per-change checklist would be a better
+ * feature and a worse thing to trust, because nobody audits forty checkboxes.
+ * The whole apply is one `updateProject`, which snapshots first — so the real
+ * undo is History, where the author can already see what changed and roll it
+ * back. */
+
+export interface MergeOptions {
+  /** New components, and the scopes, layers, flows and technologies they need. */
+  addComponents: boolean;
+  /** Fill fields that are empty on components that already exist. Never overwrites. */
+  fillGaps: boolean;
+  /** Dependencies the proposal has and the document does not. */
+  addDeps: boolean;
+}
+
+export const DEFAULT_MERGE: MergeOptions = { addComponents: true, fillGaps: true, addDeps: true };
+
+const clone = <T,>(v: T): T => JSON.parse(JSON.stringify(v)) as T;
+const filled = (s?: string): boolean => typeof s === 'string' && s.trim().length > 0;
+const has = (a?: unknown[]): boolean => Array.isArray(a) && a.length > 0;
+
+export function mergeProposal(
+  current: Architecture,
+  proposed: Partial<Architecture>,
+  opts: MergeOptions
+): Architecture {
+  const out = clone(current);
+  const proposedComponents = proposed.components ?? [];
+
+  /* Scopes and layers come first: a new component needs somewhere to live.
+   * Appended rather than inserted — a layer's position is its meaning (top is
+   * what people touch, bottom is what everything rests on) and only the author
+   * knows where a new tier belongs, so it lands at the bottom to be moved. */
+  if (opts.addComponents) {
+    for (const g of proposed.groups ?? []) {
+      if (!out.groups.some(x => x.id === g.id)) out.groups.push(clone(g));
+    }
+    for (const l of proposed.layers ?? []) {
+      if (!out.layers.some(x => x.id === l.id)) out.layers.push(clone(l));
+    }
+  }
+
+  const existing = new Map(out.components.map(c => [c.id, c]));
+
+  /* Which ids the finished document will hold — a dependency on a component
+   * that is not being added is dropped here rather than silently downstream,
+   * so the diff the reader approves is the change they actually get. */
+  const willExist = new Set(out.components.map(c => c.id));
+  if (opts.addComponents) for (const p of proposedComponents) willExist.add(p.id);
+
+  for (const p of proposedComponents) {
+    const target = existing.get(p.id);
+
+    if (!target) {
+      if (!opts.addComponents) continue;
+      const deps = opts.addDeps ? (p.deps ?? []).filter(d => willExist.has(d) && d !== p.id) : [];
+      out.components.push({
+        ...clone(p),
+        deps,
+        links: opts.addDeps ? (p.links ?? []).filter(l => deps.includes(l.to)) : undefined
+      });
+      continue;
+    }
+
+    if (opts.fillGaps) fillComponent(target, p);
+    if (opts.addDeps) addDependencies(target, p, willExist);
+  }
+
+  if (opts.addComponents) {
+    for (const t of proposed.technologies ?? []) {
+      if (!out.technologies.some(x => x.name.toLowerCase() === t.name.toLowerCase())) {
+        out.technologies.push(clone(t));
+      }
+    }
+    for (const f of proposed.flows ?? []) {
+      if (out.flows.some(x => x.id === f.id)) continue;
+      const steps = (f.steps ?? []).filter(s => willExist.has(s.component));
+      if (steps.length) out.flows.push({ ...clone(f), steps });
+    }
+  }
+
+  return out;
+}
+
+/** Only into the holes. A field the author has written in is never touched. */
+function fillComponent(target: Component, p: Component): void {
+  if (!filled(target.role) && filled(p.role)) target.role = p.role;
+  if (!filled(target.url) && filled(p.url)) target.url = p.url;
+  if (!filled(target.icon) && filled(p.icon)) target.icon = p.icon;
+  if (!filled(target.badge) && filled(p.badge)) target.badge = p.badge;
+  if (!has(target.tech) && has(p.tech)) target.tech = [...p.tech!];
+  if (!has(target.features) && has(p.features)) target.features = [...p.features!];
+  if (!has(target.notes) && has(p.notes)) target.notes = [...p.notes!];
+}
+
+function addDependencies(target: Component, p: Component, willExist: Set<string>): void {
+  const deps = target.deps ?? (target.deps = []);
+  const added: string[] = [];
+
+  for (const d of p.deps ?? []) {
+    if (d === target.id || !willExist.has(d) || deps.includes(d)) continue;
+    deps.push(d);
+    added.push(d);
+  }
+
+  /* An annotation only travels with an edge this merge just drew. Re-describing
+   * an edge the author already has would be overwriting their words. */
+  const newLinks = (p.links ?? []).filter(l => added.includes(l.to));
+  if (!newLinks.length) return;
+  const links: Link[] = target.links ?? (target.links = []);
+  for (const l of newLinks) if (!links.some(x => x.to === l.to)) links.push({ ...l });
+}

--- a/src/lib/ai/prompt.ts
+++ b/src/lib/ai/prompt.ts
@@ -1,0 +1,93 @@
+import { ICON_KEYS } from '@/lib/defaults';
+import type { Architecture } from '@/lib/types';
+
+/* What the model is told before it reads anything.
+ *
+ * The schema already guarantees the *shape* of the answer, so nothing here
+ * needs to describe JSON. What it has to do is harder: explain what each field
+ * means in this studio's terms, and set the standard that separates a useful
+ * document from a plausible one — which is almost entirely a matter of what
+ * the model refuses to write down when the source does not say it. */
+
+/* The icon set, named in the prompt rather than enumerated in the schema.
+ * A 38-way alternation inflates the compiled grammar — see schema.ts — and
+ * `convert.ts` validates the answer against this same list anyway, so the
+ * constraint is better spent as instruction than as grammar. */
+const ICON_LIST = ICON_KEYS.join(', ');
+
+export const SYSTEM_PROMPT = `You turn a written design or architecture document into an ArchStudio document: a layered component diagram with the editorial content that makes it worth reading.
+
+# The model you are filling in
+
+- **Scopes** (2 to 6) are the areas the system divides into as an organisation sees it — "Consumer platform", "Payments", "Data". Not layers, not teams: the parts a reader would name when asked what this system is made of.
+- **Layers** (3 to 6) are tiers, ordered from what people touch down to what everything rests on: clients, gateway/API, services, stores, infrastructure. Every component sits in exactly one.
+- **Components** are the units the document itself treats as units — a service, an application, a database, a third-party provider. If the source names it and says what it does, it is a component; if it is an internal function of something else, it is not.
+- **Dependencies** are runtime calls: A depends on B when A needs B to answer in order to do its job. Each component lists the ids it depends on in \`deps\`.
+- **Links** annotate a dependency that already exists. They live in one flat list, separate from the components: each carries \`from\` and \`to\` (both component ids), how the call travels (\`protocol\`, e.g. "REST/HTTPS", "gRPC", "SQL", "Kafka") and whether it waits for its answer (\`kind\`: synchronous, asynchronous, batch, or "" when the document does not say). Only write one where you have something to say; a dependency needs no link.
+- **Flows** are end-to-end paths through the system — a purchase, a signup. The flow itself goes in \`flows\`; its steps go in \`flowSteps\`, each naming its flow in \`flow\` and written in the order they happen. Only write one if the source describes the path.
+
+# The standard
+
+**Write only what the document supports.** This is the whole job. A component you inferred because systems like this usually have one is worse than no component: the reader cannot tell it apart from the ones that are really there. Where you had to decide something the source left open, do it once, note it in \`assumptions\`, and move on. Where you would need to ask a human, put the question in \`questions\` — plainly, as a question, naming what you could not resolve.
+
+**Dependencies are where invention is most tempting and most damaging.** Draw an edge only when the document states the call or makes it unmistakable. A diagram with eight correct edges is worth more than one with thirty plausible ones, and the reader has no way to audit the difference. Never point a dependency at a component you did not define.
+
+Field by field:
+
+- \`role\` — one or two sentences: what this does and why it exists. Not a restatement of its name.
+- \`features\` — its responsibilities, two to five, each a phrase not a paragraph.
+- \`notes\` — open questions, risks and known weaknesses **the document itself raises** about this component. Leave empty rather than inventing concerns.
+- \`tech\` — technologies the document names for this component. Never guess a stack.
+- \`url\` — a domain or endpoint only if the document gives one.
+- \`badge\` — a two-or-three-letter tag only where it earns the space ("B2B", "SaaS").
+- \`icon\` — the closest key from this set, exactly as spelled here: ${ICON_LIST}. Anything else is dropped, and there is no penalty for \`box\`.
+- \`meta.name\` — what the system is called. \`meta.tagline\`, \`meta.intro\` and \`meta.principle\` — the document's own framing, when it has one: what this system is, and the principle it is organised around.
+- \`meta.lang\` — the language the source is written in. Write **every** string you produce in that language.
+
+An empty string is a complete answer when the source is silent. Padding a role or inventing a responsibility to make a card look finished is the one failure this document cannot survive, because everything here is read as fact by someone who was not in the room.`;
+
+/** The extra brief for enriching a project that already exists. */
+export const ENRICH_SYSTEM_PROMPT = `${SYSTEM_PROMPT}
+
+# You are extending a document that already exists
+
+The studio will merge your answer into it, field by field, and **what the author already wrote always wins** — you cannot overwrite their work, so do not spend effort restating it. What you add is what is missing.
+
+The existing inventory is given to you below. When the source document describes something that is already in that inventory, **reuse its id exactly**: that is how the studio knows you mean the same component and files your findings against it rather than creating a duplicate beside it. Invent an id only for something genuinely new.
+
+The same rule applies to scopes and layers: reuse the existing ones unless the source describes an area or a tier that has no home in them.`;
+
+/** The existing document, as compactly as it can be stated and still be usable. */
+export function inventoryBrief(doc: Architecture): string {
+  const scopes = doc.groups.map(g => `- ${g.id} — ${g.name}`).join('\n') || '- (none)';
+  const layers = doc.layers.map(l => `- ${l.id} — ${l.name}`).join('\n') || '- (none)';
+  const components = doc.components.length
+    ? doc.components.map(c => {
+        const has = [
+          c.role ? 'role' : null,
+          c.tech?.length ? 'tech' : null,
+          c.features?.length ? 'responsibilities' : null,
+          c.deps?.length ? `${c.deps.length} dependencies` : null
+        ].filter(Boolean).join(', ');
+        return `- ${c.id} — ${c.name} [${c.group}/${c.layer}]${has ? ` (already has: ${has})` : ' (empty)'}`;
+      }).join('\n')
+    : '- (none)';
+
+  return `# Existing document — "${doc.meta?.name || 'Untitled'}"
+
+## Scopes
+${scopes}
+
+## Layers
+${layers}
+
+## Components
+${components}`;
+}
+
+/** The instruction that travels with the file itself. */
+export function userInstruction(mode: 'create' | 'enrich'): string {
+  return mode === 'create'
+    ? 'Read the attached document and produce the ArchStudio document it describes.'
+    : 'Read the attached document and produce what it adds to the existing inventory above — reusing existing ids wherever the source describes something already listed.';
+}

--- a/src/lib/ai/providers/anthropic.ts
+++ b/src/lib/ai/providers/anthropic.ts
@@ -1,0 +1,93 @@
+import Anthropic from '@anthropic-ai/sdk';
+import type { Adapter, AiConfig, CompleteInput, CompleteResult, Part, TokenCount } from './types';
+import { ProviderError } from './types';
+
+/* Claude, through the official SDK.
+ *
+ * The one adapter that does not hand-roll HTTP: the SDK is already a
+ * dependency, and it brings retries, streaming and the exact token counter
+ * with it. The other two adapters call REST directly — see openai.ts for why
+ * that is the right trade there and not here. */
+
+const client = (cfg: AiConfig) => new Anthropic({ apiKey: cfg.apiKey });
+
+/* The SDK's `message` is the whole response body — `401 {"type":"error",…}` —
+ * which is the right thing in a log and the wrong thing under a form field.
+ * The sentence the API actually wrote is one level in. */
+async function unwrap<T>(work: () => Promise<T>): Promise<T> {
+  try {
+    return await work();
+  } catch (e) {
+    if (e instanceof ProviderError) throw e;
+    const err = e as { status?: number; error?: { error?: { message?: string } }; message?: string };
+    throw new ProviderError(
+      err.error?.error?.message || err.message || 'The provider could not be reached.',
+      err.status
+    );
+  }
+}
+
+const toContent = (parts: Part[]): Anthropic.ContentBlockParam[] =>
+  parts.map(p => p.kind === 'text'
+    ? { type: 'text', text: p.text }
+    : {
+        type: 'document',
+        title: p.filename,
+        source: { type: 'base64', media_type: 'application/pdf', data: p.base64 }
+      });
+
+const params = (cfg: AiConfig, input: CompleteInput) => ({
+  model: cfg.model,
+  max_tokens: input.maxTokens,
+  system: input.system,
+  output_config: {
+    effort: 'high' as const,
+    format: { type: 'json_schema' as const, schema: input.schema }
+  },
+  messages: [{ role: 'user' as const, content: toContent(input.parts) }]
+});
+
+export const anthropicAdapter: Adapter = {
+  async listModels(cfg) {
+    return unwrap(async () => {
+      const out: string[] = [];
+      for await (const m of client(cfg).models.list()) out.push(m.id);
+      return out;
+    });
+  },
+
+  async countTokens(cfg, input): Promise<TokenCount> {
+    const { model, system, messages } = params(cfg, input);
+    const counted = await unwrap(() => client(cfg).messages.countTokens({ model, system, messages }));
+    return { tokens: counted.input_tokens, exact: true };
+  },
+
+  async complete(cfg, input): Promise<CompleteResult> {
+    /* Streamed because the answer is large: a non-streaming request at this
+     * max_tokens risks the SDK's HTTP timeout, and the run takes minutes. */
+    const message = await unwrap(() => client(cfg).messages.stream(params(cfg, input)).finalMessage());
+
+    if (message.stop_reason === 'refusal') {
+      throw new ProviderError(
+        'The model declined to analyse this document'
+        + (message.stop_details?.explanation ? `: ${message.stop_details.explanation}` : '.')
+      );
+    }
+    if (message.stop_reason === 'max_tokens') {
+      throw new ProviderError(
+        'The answer was cut off before it was complete — the document describes more than one run can return.'
+      );
+    }
+
+    const text = message.content
+      .filter((b): b is Anthropic.TextBlock => b.type === 'text')
+      .map(b => b.text)
+      .join('');
+
+    return {
+      json: JSON.parse(text),
+      inputTokens: message.usage.input_tokens + (message.usage.cache_read_input_tokens ?? 0),
+      outputTokens: message.usage.output_tokens
+    };
+  }
+};

--- a/src/lib/ai/providers/dialects.test.ts
+++ b/src/lib/ai/providers/dialects.test.ts
@@ -1,0 +1,112 @@
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+
+import { ANALYSIS_SCHEMA } from '../schema';
+import { toGeminiSchema, type GeminiSchema } from './dialects';
+import { PROVIDERS, providerInfo, baseUrlOf, foreignKeyOwner } from './types';
+
+/* The schema is the contract the whole feature rests on, and each provider
+ * accepts it in a different accent. Anthropic and the OpenAI-compatible
+ * surface take it unchanged — `schema.test.ts` already holds it to what
+ * `strict: true` demands. Gemini needs a translation, which is what this file
+ * watches. */
+
+const gemini = toGeminiSchema(ANALYSIS_SCHEMA as unknown as Record<string, unknown>);
+
+const find = (node: GeminiSchema, path: string[]): GeminiSchema => {
+  let cur = node;
+  for (const step of path) {
+    cur = step === '[]' ? cur.items! : cur.properties![step];
+    assert.ok(cur, `missing ${path.join('.')}`);
+  }
+  return cur;
+};
+
+test('types are upper-cased all the way down', () => {
+  assert.equal(gemini.type, 'OBJECT');
+  assert.equal(find(gemini, ['document', 'components']).type, 'ARRAY');
+  assert.equal(find(gemini, ['document', 'components', '[]', 'name']).type, 'STRING');
+  assert.equal(find(gemini, ['document', 'components', '[]', 'tech']).type, 'ARRAY');
+});
+
+test('additionalProperties is dropped — Gemini rejects it', () => {
+  const seen: string[] = [];
+  const walk = (n: GeminiSchema, path: string) => {
+    if ('additionalProperties' in n) seen.push(path);
+    if (n.items) walk(n.items, `${path}[]`);
+    for (const [k, v] of Object.entries(n.properties ?? {})) walk(v, `${path}.${k}`);
+  };
+  walk(gemini, 'root');
+  assert.deepEqual(seen, []);
+});
+
+test('required survives, so "unknown" still has to be an empty string', () => {
+  assert.deepEqual([...(gemini.required ?? [])].sort(), ['assumptions', 'document', 'questions']);
+  assert.ok(find(gemini, ['document', 'components', '[]']).required?.includes('deps'));
+});
+
+test('the enum that uses "" for “I don’t know” is not carried over', () => {
+  /* A link's kind may legitimately be empty, and an empty enum member on this
+   * surface is a bet not worth taking — convert.ts validates it instead. */
+  const kind = find(gemini, ['document', 'links', '[]', 'kind']);
+  assert.equal(kind.enum, undefined);
+  assert.equal(kind.type, 'STRING');
+
+  /* `meta.lang` has no empty member, so it keeps its constraint. */
+  const lang = find(gemini, ['document', 'meta', 'lang']);
+  assert.deepEqual(lang.enum, ['en', 'fr']);
+  assert.equal(lang.format, 'enum');
+});
+
+/* --------------------------------------------------------------- registry */
+
+test('every provider is complete enough to build a form and a request from', () => {
+  for (const p of PROVIDERS) {
+    assert.ok(p.label, `${p.id} needs a label`);
+    assert.ok(p.blurb, `${p.id} needs a blurb`);
+    assert.ok(['anthropic', 'openai', 'gemini'].includes(p.adapter), `${p.id} has no adapter`);
+    /* Only Anthropic's SDK carries its own endpoint; everything else is called
+     * over plain HTTP and needs somewhere to call. */
+    if (p.adapter !== 'anthropic') {
+      assert.ok(p.defaultBaseUrl || p.baseUrlEditable, `${p.id} has nowhere to send a request`);
+    }
+  }
+  assert.equal(new Set(PROVIDERS.map(p => p.id)).size, PROVIDERS.length, 'ids must be unique');
+});
+
+test('NVIDIA asks for a schema its own way, and only NVIDIA does', () => {
+  /* NIM does not implement `response_format` and documents `nvext.guided_json`
+   * instead. Sending the wrong one is not a loud failure — the field is
+   * ignored and the answer comes back unconstrained, which is the single
+   * outcome this feature exists to prevent. */
+  assert.equal(providerInfo('nvidia').structured, 'guided_json');
+  for (const p of PROVIDERS.filter(x => x.id !== 'nvidia')) {
+    assert.equal(p.structured, undefined, `${p.id} should use the default dialect`);
+  }
+});
+
+test('the base URL is normalised, and an unknown provider degrades to the first', () => {
+  assert.equal(
+    baseUrlOf({ provider: 'compatible', model: 'm', apiKey: '', baseUrl: 'http://box:1234/v1/' }),
+    'http://box:1234/v1'
+  );
+  /* Falls back to the registry's default when the config carries none. */
+  assert.match(baseUrlOf({ provider: 'openai', model: 'm', apiKey: 'k' }), /api\.openai\.com/);
+  assert.equal(providerInfo('nope' as never).id, PROVIDERS[0].id);
+});
+
+test('a key from another vendor is recognised as such', () => {
+  /* The failure this prevents: an NVIDIA key pasted into the Anthropic field
+   * comes back as "invalid x-api-key", which names neither vendor. */
+  assert.equal(foreignKeyOwner('anthropic', 'nvapi-abc123')?.id, 'nvidia');
+  assert.equal(foreignKeyOwner('gemini', 'sk-ant-abc123')?.id, 'anthropic');
+  /* Longest prefix wins: an Anthropic key must not read as OpenAI's `sk-`. */
+  assert.equal(foreignKeyOwner('openai', 'sk-ant-abc123')?.id, 'anthropic');
+  assert.equal(foreignKeyOwner('anthropic', 'sk-plain-openai-key')?.id, 'openai');
+
+  /* Silent when the key belongs where it is, is empty, or is a shape nobody
+   * claims — a vendor may change its format and must not be refused for it. */
+  assert.equal(foreignKeyOwner('anthropic', 'sk-ant-abc'), null);
+  assert.equal(foreignKeyOwner('anthropic', '  '), null);
+  assert.equal(foreignKeyOwner('compatible', 'whatever-a-local-server-wants'), null);
+});

--- a/src/lib/ai/providers/dialects.ts
+++ b/src/lib/ai/providers/dialects.ts
@@ -1,0 +1,68 @@
+/* The same schema, in each vendor's accent.
+ *
+ * `ANALYSIS_SCHEMA` is plain JSON Schema and stays that way: it is the thing
+ * `convert.ts` is written against and the thing the tests hold. What differs is
+ * what each API will accept.
+ *
+ * - **Anthropic** takes it unchanged.
+ * - **OpenAI-compatible** takes it unchanged under `strict: true`, which
+ *   demands `additionalProperties: false` on every object and every property
+ *   listed in `required`. The schema already satisfies both — not by luck: it
+ *   was written that way so "unknown" is the empty string rather than an
+ *   absent field, and `schema.test.ts` keeps it so.
+ * - **Gemini** wants an OpenAPI-flavoured Schema object: types in upper case,
+ *   no `additionalProperties`, and an explicit property order. */
+
+type Node = {
+  type?: string;
+  properties?: Record<string, Node>;
+  items?: Node;
+  required?: string[];
+  enum?: string[];
+  additionalProperties?: boolean;
+};
+
+export interface GeminiSchema {
+  type: string;
+  properties?: Record<string, GeminiSchema>;
+  items?: GeminiSchema;
+  required?: string[];
+  enum?: string[];
+  format?: string;
+  propertyOrdering?: string[];
+}
+
+export function toGeminiSchema(schema: Record<string, unknown>): GeminiSchema {
+  return convert(schema as Node);
+}
+
+function convert(node: Node): GeminiSchema {
+  const out: GeminiSchema = { type: String(node.type ?? 'string').toUpperCase() };
+
+  /* An enum is worth keeping — it is what stops the model inventing an icon —
+   * but only when every value is a real word. Gemini's enum handling pairs
+   * with `format: "enum"`, and an empty-string member of that set is asking
+   * for trouble on a surface we cannot test from here. Where the studio uses
+   * "" to mean "I don't know" (a link's kind), the constraint is dropped and
+   * `convert.ts` does the validating instead — it already has to, since a
+   * model can return a wrong-but-legal value under any schema. */
+  if (node.enum?.length && node.enum.every(v => v !== '')) {
+    out.enum = [...node.enum];
+    out.format = 'enum';
+  }
+
+  if (node.items) out.items = convert(node.items);
+
+  if (node.properties) {
+    out.properties = Object.fromEntries(
+      Object.entries(node.properties).map(([k, v]) => [k, convert(v)])
+    );
+    /* Gemini emits fields in whatever order it likes unless told; the schema's
+     * own order reads best when a human inspects the raw answer. */
+    out.propertyOrdering = Object.keys(node.properties);
+  }
+
+  if (node.required?.length) out.required = [...node.required];
+
+  return out;
+}

--- a/src/lib/ai/providers/gemini.ts
+++ b/src/lib/ai/providers/gemini.ts
@@ -1,0 +1,99 @@
+import type { Adapter, AiConfig, CompleteInput, CompleteResult, TokenCount } from './types';
+import { ProviderError, baseUrlOf, failure, request } from './types';
+import { toGeminiSchema } from './dialects';
+
+/* Google's Generative Language API.
+ *
+ * Reads PDFs as inline data, and — like Anthropic and unlike the
+ * OpenAI-compatible surface — will count the tokens of a request before it is
+ * run, so the estimate shown to the reader is the real number.
+ *
+ * The key travels as a header rather than the `?key=` query parameter the
+ * quickstarts use: a URL ends up in proxy logs and error messages, and this
+ * one would be carrying a credential. */
+
+const headers = (cfg: AiConfig): Record<string, string> => ({
+  'Content-Type': 'application/json',
+  'x-goog-api-key': cfg.apiKey
+});
+
+const parts = (input: CompleteInput) =>
+  input.parts.map(p => p.kind === 'text'
+    ? { text: p.text }
+    : { inlineData: { mimeType: 'application/pdf', data: p.base64 } });
+
+const payload = (cfg: AiConfig, input: CompleteInput) => ({
+  systemInstruction: { parts: [{ text: input.system }] },
+  contents: [{ role: 'user', parts: parts(input) }],
+  generationConfig: {
+    responseMimeType: 'application/json',
+    responseSchema: toGeminiSchema(input.schema),
+    maxOutputTokens: input.maxTokens
+  }
+});
+
+export const geminiAdapter: Adapter = {
+  async listModels(cfg) {
+    const res = await request(`${baseUrlOf(cfg)}/models?pageSize=200`, { headers: headers(cfg) }, 'list the models');
+    if (!res.ok) throw await failure(res, 'Could not list the models');
+    const json = await res.json() as {
+      models?: { name?: string; supportedGenerationMethods?: string[] }[];
+    };
+    return (json.models ?? [])
+      /* Only the ones that can answer a prompt: the list also carries
+       * embedding and token-counting models, which would fail confusingly if
+       * one were picked. Some responses omit the field — keep those rather
+       * than hide a model that would have worked. */
+      .filter(m => !m.supportedGenerationMethods || m.supportedGenerationMethods.includes('generateContent'))
+      .map(m => String(m.name ?? '').replace(/^models\//, ''))
+      .filter(Boolean)
+      .sort();
+  },
+
+  async countTokens(cfg, input): Promise<TokenCount> {
+    const res = await request(`${baseUrlOf(cfg)}/models/${encodeURIComponent(cfg.model)}:countTokens`, {
+      method: 'POST',
+      headers: headers(cfg),
+      body: JSON.stringify({ contents: payload(cfg, input).contents })
+    }, 'measure the document');
+    if (!res.ok) throw await failure(res, 'Could not measure the document');
+    const json = await res.json() as { totalTokens?: number };
+    return { tokens: json.totalTokens ?? 0, exact: true };
+  },
+
+  async complete(cfg, input): Promise<CompleteResult> {
+    const res = await request(`${baseUrlOf(cfg)}/models/${encodeURIComponent(cfg.model)}:generateContent`, {
+      method: 'POST', headers: headers(cfg), body: JSON.stringify(payload(cfg, input))
+    }, 'run the analysis');
+    if (!res.ok) throw await failure(res, 'The analysis was refused');
+
+    const json = await res.json() as {
+      candidates?: { content?: { parts?: { text?: string }[] }; finishReason?: string }[];
+      promptFeedback?: { blockReason?: string };
+      usageMetadata?: { promptTokenCount?: number; candidatesTokenCount?: number };
+    };
+
+    if (json.promptFeedback?.blockReason) {
+      throw new ProviderError(`The provider blocked this document (${json.promptFeedback.blockReason}).`);
+    }
+
+    const candidate = json.candidates?.[0];
+    if (candidate?.finishReason === 'MAX_TOKENS') {
+      throw new ProviderError(
+        'The answer was cut off before it was complete — the document describes more than one run can return.'
+      );
+    }
+    if (candidate?.finishReason && !['STOP', 'MAX_TOKENS'].includes(candidate.finishReason)) {
+      throw new ProviderError(`The provider stopped early (${candidate.finishReason}).`);
+    }
+
+    const text = (candidate?.content?.parts ?? []).map(p => p.text ?? '').join('');
+    if (!text) throw new ProviderError('The provider returned an empty answer.');
+
+    return {
+      json: JSON.parse(text),
+      inputTokens: json.usageMetadata?.promptTokenCount ?? 0,
+      outputTokens: json.usageMetadata?.candidatesTokenCount ?? 0
+    };
+  }
+};

--- a/src/lib/ai/providers/index.ts
+++ b/src/lib/ai/providers/index.ts
@@ -1,0 +1,15 @@
+import { anthropicAdapter } from './anthropic';
+import { geminiAdapter } from './gemini';
+import { openaiAdapter } from './openai';
+import { providerInfo, type Adapter, type AdapterId, type AiConfig } from './types';
+
+export * from './types';
+
+const ADAPTERS: Record<AdapterId, Adapter> = {
+  anthropic: anthropicAdapter,
+  openai: openaiAdapter,
+  gemini: geminiAdapter
+};
+
+/** The adapter that will serve this config. Five providers, three adapters. */
+export const adapterFor = (cfg: AiConfig): Adapter => ADAPTERS[providerInfo(cfg.provider).adapter];

--- a/src/lib/ai/providers/openai.ts
+++ b/src/lib/ai/providers/openai.ts
@@ -1,0 +1,137 @@
+import type { Adapter, AiConfig, CompleteInput, CompleteResult, TokenCount } from './types';
+import { ProviderError, baseUrlOf, estimateTokens, failure, providerInfo, request } from './types';
+
+/* Everything that speaks `/v1/chat/completions`.
+ *
+ * OpenAI, NVIDIA's hosted NIM endpoint, Ollama, LM Studio, vLLM, Groq,
+ * Together, OpenRouter — one wire format, one adapter. Written against REST
+ * with `fetch` rather than a vendor SDK, and deliberately: the whole point of
+ * this adapter is to work against a base URL nobody has seen yet, which is
+ * exactly what an SDK pinned to one vendor's assumptions is worst at. (Claude
+ * keeps its SDK — see anthropic.ts.)
+ *
+ * Structured output has two spellings here. OpenAI's is `response_format:
+ * json_schema` with `strict: true`; NVIDIA's NIM does not implement it and
+ * documents `nvext.guided_json` instead. The registry says which to send, and
+ * `complete` falls back from the first to the second when a server says it
+ * does not know it — which is what lets a self-hosted NIM work under
+ * "OpenAI-compatible". A server that supports neither says so in the error,
+ * which the settings dialog's Test button surfaces before a document is ever
+ * uploaded. */
+
+const headers = (cfg: AiConfig): Record<string, string> => ({
+  'Content-Type': 'application/json',
+  /* A local server usually wants no key at all; sending an empty bearer makes
+   * some of them reject a request they would otherwise have served. */
+  ...(cfg.apiKey ? { Authorization: `Bearer ${cfg.apiKey}` } : {})
+});
+
+function textOf(input: CompleteInput): string {
+  const pdf = input.parts.find(p => p.kind === 'pdf');
+  if (pdf) {
+    throw new ProviderError(
+      'This provider is set up for text documents. Send the PDF to Anthropic or Gemini, '
+      + 'or convert it to Markdown or plain text first.'
+    );
+  }
+  return input.parts.map(p => (p.kind === 'text' ? p.text : '')).join('\n\n');
+}
+
+type Structured = 'response_format' | 'guided_json';
+
+function body(cfg: AiConfig, input: CompleteInput, tokenField: string, structured: Structured) {
+  return {
+    model: cfg.model,
+    messages: [
+      { role: 'system', content: input.system },
+      { role: 'user', content: textOf(input) }
+    ],
+    [tokenField]: input.maxTokens,
+    ...(structured === 'response_format'
+      ? {
+          response_format: {
+            type: 'json_schema',
+            json_schema: { name: 'architecture_analysis', strict: true, schema: input.schema }
+          }
+        }
+      /* NVIDIA's own extension, and the only structured-output mechanism NIM
+       * implements. Sent alone: a server that understands one of these does
+       * not necessarily ignore the other quietly. */
+      : { nvext: { guided_json: input.schema } })
+  };
+}
+
+export const openaiAdapter: Adapter = {
+  async listModels(cfg) {
+    const res = await request(`${baseUrlOf(cfg)}/models`, { headers: headers(cfg) }, 'list the models');
+    if (!res.ok) throw await failure(res, 'Could not list the models');
+    const json = await res.json() as { data?: { id?: string }[] };
+    return (json.data ?? []).map(m => String(m.id)).filter(Boolean).sort();
+  },
+
+  async countTokens(cfg, input): Promise<TokenCount> {
+    /* No counting endpoint in this API. The estimate is character-based and
+     * says so wherever it is shown. */
+    return { tokens: estimateTokens(input), exact: false };
+  },
+
+  async complete(cfg, input): Promise<CompleteResult> {
+    /* "OpenAI-compatible" is a family, not a specification, and two fields in
+     * this request are spelled differently across it. Rather than ask the
+     * operator which dialect their server speaks, send the common form and
+     * adapt to what the server says it wants — each correction fires at most
+     * once, and only on the error that names the field. */
+    let tokenField = 'max_tokens';
+    let structured: Structured = providerInfo(cfg.provider).structured ?? 'response_format';
+    let res: Response;
+
+    for (let attempt = 0; ; attempt++) {
+      res = await request(`${baseUrlOf(cfg)}/chat/completions`, {
+        method: 'POST', headers: headers(cfg),
+        body: JSON.stringify(body(cfg, input, tokenField, structured))
+      }, 'run the analysis');
+
+      if (res.ok || res.status !== 400 || attempt >= 2) break;
+
+      const said = await res.clone().text().catch(() => '');
+      /* Renamed on OpenAI's newer models, kept as-is by most others. */
+      if (tokenField === 'max_tokens' && said.includes('max_completion_tokens')) {
+        tokenField = 'max_completion_tokens';
+        continue;
+      }
+      /* A NIM container behind a custom endpoint, or an older vLLM: it wants
+       * guided_json and has just said it does not know response_format. */
+      if (structured === 'response_format' && /response_format|json_schema/i.test(said)) {
+        structured = 'guided_json';
+        continue;
+      }
+      break;
+    }
+
+    if (!res.ok) throw await failure(res, 'The analysis was refused');
+
+    const json = await res.json() as {
+      choices?: { message?: { content?: string }; finish_reason?: string }[];
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
+    const choice = json.choices?.[0];
+
+    if (choice?.finish_reason === 'length') {
+      throw new ProviderError(
+        'The answer was cut off before it was complete — the document describes more than one run can return.'
+      );
+    }
+    if (choice?.finish_reason === 'content_filter') {
+      throw new ProviderError('The provider’s content filter stopped this analysis.');
+    }
+    if (!choice?.message?.content) {
+      throw new ProviderError('The provider returned an empty answer.');
+    }
+
+    return {
+      json: JSON.parse(choice.message.content),
+      inputTokens: json.usage?.prompt_tokens ?? 0,
+      outputTokens: json.usage?.completion_tokens ?? 0
+    };
+  }
+};

--- a/src/lib/ai/providers/types.ts
+++ b/src/lib/ai/providers/types.ts
@@ -1,0 +1,229 @@
+/* One shape for every provider.
+ *
+ * The studio needs exactly one thing from a model: read this document and
+ * return JSON that validates against this schema. Every provider can do it,
+ * and every provider spells it differently — a `format` here, a
+ * `response_format` there, a `responseSchema` in a third place, with a
+ * different name for the same field in each. The adapters below absorb that,
+ * and nothing above this directory knows which vendor answered.
+ *
+ * Five entries, three adapters: OpenAI, NVIDIA and "anything OpenAI-compatible"
+ * are one code path, which is also what makes Ollama, vLLM, Groq, Together and
+ * OpenRouter work without a line of their own. */
+
+export type ProviderId = 'anthropic' | 'openai' | 'gemini' | 'nvidia' | 'compatible';
+export type AdapterId = 'anthropic' | 'openai' | 'gemini';
+
+/** What the studio holds about one provider. The key never leaves the server. */
+export interface AiConfig {
+  provider: ProviderId;
+  model: string;
+  /** Required for `compatible`; defaulted from the registry otherwise. */
+  baseUrl?: string;
+  apiKey: string;
+  /** US dollars per million tokens. Optional: without them the run shows a
+   *  token count and no price, which is better than a made-up price. */
+  inputPrice?: number;
+  outputPrice?: number;
+}
+
+/** The content of one request, before any provider has been chosen. */
+export type Part =
+  | { kind: 'text'; text: string }
+  | { kind: 'pdf'; filename: string; base64: string };
+
+export interface CompleteInput {
+  system: string;
+  parts: Part[];
+  /** Plain JSON Schema. Each adapter translates it into its own dialect. */
+  schema: Record<string, unknown>;
+  maxTokens: number;
+}
+
+export interface CompleteResult {
+  json: unknown;
+  inputTokens: number;
+  outputTokens: number;
+}
+
+export interface TokenCount {
+  tokens: number;
+  /** False when the number is a character-count estimate rather than the
+   *  provider's own tokeniser — the UI says so rather than implying precision. */
+  exact: boolean;
+}
+
+export interface Adapter {
+  listModels(cfg: AiConfig): Promise<string[]>;
+  complete(cfg: AiConfig, input: CompleteInput): Promise<CompleteResult>;
+  countTokens(cfg: AiConfig, input: CompleteInput): Promise<TokenCount>;
+}
+
+/** What the settings dialog needs to render one provider's form. */
+export interface ProviderInfo {
+  id: ProviderId;
+  label: string;
+  adapter: AdapterId;
+  blurb: string;
+  /** Where to get a key, for the link under the field. */
+  keyUrl: string;
+  keyPlaceholder: string;
+  defaultBaseUrl?: string;
+  /** Only `compatible` asks the operator for one. */
+  baseUrlEditable: boolean;
+  defaultModel?: string;
+  /** Whether a PDF can be handed over as-is. Text always can. */
+  supportsPdf: boolean;
+  /** Read when no key is stored, so a container can pass one in. */
+  envKey?: string;
+  /* How this provider's keys begin. Used only to notice that a key belongs to
+   * a *different* provider — never to reject one, because a vendor is free to
+   * change the shape of its keys tomorrow and a studio that refused the new
+   * format would be broken for no reason. A warning is right here; a rule is
+   * not. */
+  keyPrefixes?: string[];
+  /* How this server wants a schema, on the OpenAI-compatible adapter.
+   *
+   * `response_format` is OpenAI's; NVIDIA's NIM does not implement it and
+   * documents its own `nvext.guided_json` instead — and recommends it, on the
+   * grounds that OpenAI's older `json_object` mode lets a model return any
+   * valid JSON at all, including `{}`. Sending the wrong one does not fail
+   * loudly: the field is ignored and the answer comes back unconstrained,
+   * which is the one outcome this whole feature is built to prevent. The
+   * adapter also falls back on its own when a server says it does not know the
+   * first form — that is what makes a self-hosted NIM work under
+   * "OpenAI-compatible". */
+  structured?: 'response_format' | 'guided_json';
+}
+
+export const PROVIDERS: ProviderInfo[] = [
+  {
+    id: 'anthropic', label: 'Anthropic', adapter: 'anthropic',
+    blurb: 'Claude. Reads PDFs directly and counts tokens exactly before a run.',
+    keyUrl: 'https://platform.claude.com/settings/keys',
+    keyPlaceholder: 'sk-ant-…',
+    keyPrefixes: ['sk-ant-'],
+    defaultModel: 'claude-opus-5',
+    baseUrlEditable: false,
+    supportsPdf: true,
+    envKey: 'ANTHROPIC_API_KEY'
+  },
+  {
+    id: 'openai', label: 'OpenAI', adapter: 'openai',
+    blurb: 'Text documents only here — hand a PDF to Anthropic or Gemini, or paste its text.',
+    keyUrl: 'https://platform.openai.com/api-keys',
+    keyPlaceholder: 'sk-…',
+    keyPrefixes: ['sk-'],
+    defaultBaseUrl: 'https://api.openai.com/v1',
+    baseUrlEditable: false,
+    supportsPdf: false,
+    envKey: 'OPENAI_API_KEY'
+  },
+  {
+    id: 'gemini', label: 'Google Gemini', adapter: 'gemini',
+    blurb: 'Reads PDFs directly and counts tokens exactly.',
+    keyUrl: 'https://aistudio.google.com/apikey',
+    keyPlaceholder: 'AIza…',
+    keyPrefixes: ['AIza'],
+    defaultBaseUrl: 'https://generativelanguage.googleapis.com/v1beta',
+    baseUrlEditable: false,
+    supportsPdf: true,
+    envKey: 'GEMINI_API_KEY'
+  },
+  {
+    id: 'nvidia', label: 'NVIDIA NIM', adapter: 'openai',
+    blurb: 'The hosted NIM endpoint. Text documents only, and the model must support guided JSON — test it before trusting it.',
+    keyUrl: 'https://build.nvidia.com',
+    keyPlaceholder: 'nvapi-…',
+    keyPrefixes: ['nvapi-'],
+    defaultBaseUrl: 'https://integrate.api.nvidia.com/v1',
+    baseUrlEditable: false,
+    supportsPdf: false,
+    envKey: 'NVIDIA_API_KEY',
+    structured: 'guided_json'
+  },
+  {
+    id: 'compatible', label: 'OpenAI-compatible', adapter: 'openai',
+    blurb: 'Anything that speaks /v1/chat/completions — Ollama, LM Studio, vLLM, Groq, Together, OpenRouter. The model must support JSON-schema output.',
+    keyUrl: '',
+    keyPlaceholder: 'left empty for a local server',
+    defaultBaseUrl: 'http://localhost:11434/v1',
+    baseUrlEditable: true,
+    supportsPdf: false
+  }
+];
+
+/** The provider a key visibly belongs to, when it is not the one selected.
+ *
+ *  Pasting one vendor's key into another's field produces an authentication
+ *  error that names neither vendor — "invalid x-api-key" — and there is
+ *  nothing in it to tell you that you are simply in the wrong row. The
+ *  prefixes are public and stable enough to say "that looks like an NVIDIA
+ *  key"; longest first, so `sk-ant-` is not read as OpenAI's `sk-`. */
+export function foreignKeyOwner(provider: ProviderId, key: string): ProviderInfo | null {
+  const trimmed = key.trim();
+  if (!trimmed) return null;
+  const match = [...PROVIDERS]
+    .filter(p => p.keyPrefixes?.length)
+    .flatMap(p => p.keyPrefixes!.map(prefix => ({ p, prefix })))
+    .sort((a, b) => b.prefix.length - a.prefix.length)
+    .find(({ prefix }) => trimmed.startsWith(prefix));
+  return match && match.p.id !== provider ? match.p : null;
+}
+
+export const providerInfo = (id: ProviderId): ProviderInfo =>
+  PROVIDERS.find(p => p.id === id) ?? PROVIDERS[0];
+
+/** The base URL a config will actually call. */
+export const baseUrlOf = (cfg: AiConfig): string =>
+  (cfg.baseUrl || providerInfo(cfg.provider).defaultBaseUrl || '').replace(/\/+$/, '');
+
+/* Roughly four characters to a token for English prose, which is the figure
+ * every provider's own documentation uses for a rule of thumb. Only reached
+ * when the provider has no counting endpoint, and always reported as an
+ * estimate. A PDF is counted on its decoded size, which is wronger still —
+ * hence `exact: false` and a UI that says "about". */
+export function estimateTokens(input: CompleteInput): number {
+  let chars = input.system.length;
+  for (const part of input.parts) {
+    chars += part.kind === 'text' ? part.text.length : (part.base64.length * 3) / 4;
+  }
+  return Math.ceil(chars / 4);
+}
+
+/** Providers answer errors in their own shapes; this is the one the studio shows. */
+export class ProviderError extends Error {
+  constructor(message: string, readonly status?: number) {
+    super(message);
+    this.name = 'ProviderError';
+  }
+}
+
+/* `fetch` throws for anything below HTTP — a wrong port, a stopped container,
+ * a hostname that does not resolve — and the message it throws is the useless
+ * "fetch failed", with the real reason one `cause` deep. An operator pointing
+ * the studio at their own server hits this far more often than they hit a 401,
+ * so it is worth naming what actually happened. */
+export async function request(url: string, init: RequestInit, what: string): Promise<Response> {
+  try {
+    return await fetch(url, init);
+  } catch (e) {
+    const cause = (e as { cause?: { code?: string; message?: string } }).cause;
+    const reason = cause?.code === 'ECONNREFUSED' ? 'nothing is listening there'
+      : cause?.code === 'ENOTFOUND' ? 'the host does not resolve'
+      : cause?.code === 'CERT_HAS_EXPIRED' ? 'its certificate has expired'
+      : cause?.message || (e as Error).message;
+    throw new ProviderError(`Could not reach ${new URL(url).origin} to ${what}: ${reason}.`);
+  }
+}
+
+/** Pulls whatever a provider put in the body of a failed response. */
+export async function failure(res: Response, fallback: string): Promise<ProviderError> {
+  const body = await res.text().catch(() => '');
+  let detail = body.slice(0, 500);
+  try {
+    const parsed = JSON.parse(body);
+    detail = parsed?.error?.message || parsed?.message || parsed?.error || detail;
+  } catch { /* not JSON — the raw body is the best we have */ }
+  return new ProviderError(`${fallback} (HTTP ${res.status})${detail ? `: ${detail}` : ''}`, res.status);
+}

--- a/src/lib/ai/schema.test.ts
+++ b/src/lib/ai/schema.test.ts
@@ -1,0 +1,95 @@
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+
+import { LINK_KINDS } from '../links';
+import { ANALYSIS_SCHEMA, COMPONENT_FIELDS, analysisSchema } from './schema';
+import type { Component } from '../types';
+
+/* The schema is sent to an API that compiles it and then holds the model to
+ * it, so a mistake here is not a type error — it is a 400 at the moment a
+ * reader presses the button, or worse, a document that validates and means
+ * something else. These tests hold it to the two things that are true of it by
+ * construction and easy to break by hand. */
+
+/** Compile-time: every field the schema declares is a field of `Component`.
+ *  If a name drifts, `tsc` fails before any test runs. */
+const _fields: readonly (keyof Component)[] = COMPONENT_FIELDS;
+void _fields;
+
+type Node = { type?: string; properties?: Record<string, Node>; items?: Node;
+              required?: string[]; additionalProperties?: boolean; enum?: string[] };
+
+function walk(node: Node, path: string, visit: (n: Node, path: string) => void): void {
+  visit(node, path);
+  if (node.properties) {
+    for (const [key, child] of Object.entries(node.properties)) walk(child, `${path}.${key}`, visit);
+  }
+  if (node.items) walk(node.items, `${path}[]`, visit);
+}
+
+test('every object closes itself and requires everything it declares', () => {
+  /* Structured outputs reject an open object, and an optional property is a
+   * bet on how the API reads optionality. Requiring all of them is the shape
+   * `convert.ts` is written against: "unknown" is "" or [], never absent. */
+  walk(ANALYSIS_SCHEMA as Node, 'root', (n, path) => {
+    if (n.type !== 'object') return;
+    assert.equal(n.additionalProperties, false, `${path} must be closed`);
+    assert.deepEqual(
+      [...(n.required ?? [])].sort(),
+      Object.keys(n.properties ?? {}).sort(),
+      `${path} must require every property it declares`
+    );
+  });
+});
+
+test('the one enum left is the studio’s own set, not a copy that can drift', () => {
+  let kinds: string[] | undefined;
+  walk(ANALYSIS_SCHEMA as Node, 'root', (n, path) => {
+    if (path.endsWith('links[].kind')) kinds = n.enum;
+  });
+  /* Plus the empty string, which is how the model declines to guess. */
+  assert.deepEqual(kinds, ['', ...LINK_KINDS]);
+});
+
+test('the schema stays small enough to compile into a grammar', () => {
+  /* A provider turns this into a grammar before it generates, and past a size
+   * none of them publishes it refuses outright. Two things drive that size:
+   * long enums, and objects nested inside arrays inside arrays. Both are
+   * bounded here, and the bound is a test rather than a comment because the
+   * failure lands on a reader mid-upload, not on us. */
+  let enumValues = 0;
+  let deepestObject = 0;
+  walk(ANALYSIS_SCHEMA as Node, 'root', (n, path) => {
+    enumValues += n.enum?.length ?? 0;
+    if (n.type === 'object') {
+      deepestObject = Math.max(deepestObject, path.split('[]').length - 1);
+    }
+  });
+
+  assert.ok(enumValues <= 16, `enum values across the schema: ${enumValues}`);
+  /* An object may live inside one array (components[], links[]), never inside
+   * two — that is what moved the annotations out of the components. */
+  assert.ok(deepestObject <= 1, `objects nested ${deepestObject} arrays deep`);
+  assert.ok(
+    JSON.stringify(ANALYSIS_SCHEMA).length < 4_000,
+    `serialised schema: ${JSON.stringify(ANALYSIS_SCHEMA).length} characters`
+  );
+});
+
+test('the lean fallback drops the deepest branches and stays valid', () => {
+  const lean = analysisSchema('lean') as Node;
+  const document = lean.properties!.document;
+  assert.equal('flows' in document.properties!, false);
+  assert.equal('technologies' in document.properties!, false);
+  /* Still a complete, closed object: what it does ask for is unchanged. */
+  assert.deepEqual(
+    [...(document.required ?? [])].sort(),
+    ['components', 'groups', 'layers', 'links', 'meta']
+  );
+  assert.ok(JSON.stringify(lean).length < JSON.stringify(ANALYSIS_SCHEMA).length);
+});
+
+test('the answer carries its own caveats', () => {
+  const root = ANALYSIS_SCHEMA as Node;
+  assert.deepEqual([...(root.required ?? [])].sort(), ['assumptions', 'document', 'questions']);
+});

--- a/src/lib/ai/schema.ts
+++ b/src/lib/ai/schema.ts
@@ -1,0 +1,158 @@
+import { LINK_KINDS } from '@/lib/links';
+
+/* The contract the model answers under.
+ *
+ * This is a JSON Schema passed to the provider, so the response is constrained
+ * at generation time: the model cannot return prose, a half document, or a
+ * field this file does not declare. That is the whole reason the feature is
+ * safe to build — the failure mode of an LLM here is a *wrong* document, never
+ * a malformed one, and a wrong document is something a human can read and
+ * reject.
+ *
+ * Three shapes here cost a little elegance and buy a lot:
+ *
+ * 1. **Every property is required, and "unknown" is the empty string or the
+ *    empty array.** Optional properties are legal JSON Schema, but they double
+ *    the state space of the compiled grammar — Anthropic's own guidance is to
+ *    make everything required — and the exact treatment of optionality is not
+ *    something this file should bet on across four vendors. It also makes the
+ *    model consider each field rather than quietly omit the ones it finds
+ *    hard. `toArchitecture` drops the empties.
+ *
+ * 2. **It is kept flat and enum-free on purpose.** A schema is compiled into a
+ *    grammar before generation, and past a size nobody publishes the provider
+ *    refuses it outright: *"the compiled grammar is too large"*. Two things
+ *    drive that — large enums, and objects nested inside arrays inside arrays.
+ *    So dependency annotations live in one flat `links` array keyed by
+ *    `from`/`to` rather than inside each component, and the icon is a plain
+ *    string rather than a 38-way alternation. Nothing is lost: `convert.ts`
+ *    validates both against the studio's own sets, which it has to do anyway —
+ *    a model can return a wrong-but-legal value under any schema.
+ *
+ * 3. **This is a wire shape, not `Architecture`.** Deliberately a subset: no
+ *    `ui`, no `theme`, no `sections`. Those are the author's decisions about
+ *    how the document is presented and argued, and a model that has read one
+ *    PDF has no basis for them.
+ *
+ * `src/lib/ai/schema.test.ts` checks this file against `types.ts` so the two
+ * cannot drift apart silently. */
+
+const str = { type: 'string' } as const;
+const strList = { type: 'array', items: { type: 'string' } } as const;
+
+const object = (props: Record<string, unknown>) => ({
+  type: 'object',
+  additionalProperties: false,
+  required: Object.keys(props),
+  properties: props
+});
+
+const list = (props: Record<string, unknown>) => ({ type: 'array', items: object(props) });
+
+export const COMPONENT_FIELDS = [
+  'id', 'name', 'group', 'layer', 'icon', 'badge', 'url', 'role',
+  'tech', 'features', 'notes', 'deps'
+] as const;
+
+/** How much of the document to ask for. `lean` drops the two deepest branches
+ *  and is the retry when a provider refuses to compile the full one. */
+export type SchemaLevel = 'full' | 'lean';
+
+export function analysisSchema(level: SchemaLevel = 'full') {
+  const document: Record<string, unknown> = {
+    meta: object({
+      /** ISO 639-1 of the source document — the export is rendered in it. */
+      lang: { type: 'string', enum: ['en', 'fr'] },
+      name: str,
+      tagline: str,
+      kicker: str,
+      intro: str,
+      principle: str
+    }),
+    groups: list({ id: str, name: str, short: str, description: str }),
+    layers: list({ id: str, name: str, desc: str }),
+    components: list({
+      id: str,
+      name: str,
+      group: str,
+      layer: str,
+      /* A key from the studio's icon set. Named in the prompt rather than
+       * enumerated here — see the note on grammar size above. */
+      icon: str,
+      badge: str,
+      url: str,
+      role: str,
+      tech: strList,
+      features: strList,
+      notes: strList,
+      deps: strList
+    }),
+    /* Flat, and outside `components`, so the component item stays a shallow
+     * object of strings and string arrays. */
+    links: list({
+      from: str,
+      to: str,
+      /* "" is how the model says it does not know how the call travels.
+       * Forcing a choice between three kinds would manufacture one. Four short
+       * literals: small enough to be worth constraining. */
+      kind: { type: 'string', enum: ['', ...LINK_KINDS] },
+      protocol: str,
+      note: str
+    })
+  };
+
+  if (level === 'full') {
+    document.technologies = list({ name: str, category: str, description: str, groups: strList });
+    document.flows = list({ id: str, name: str, sub: str, group: str, note: str });
+    /* Steps are flat too, for the same reason the links are: an object inside
+     * an array inside an array is what a grammar compiler charges most for.
+     * Each names the flow it belongs to, and their order in this list is the
+     * order of the flow. */
+    document.flowSteps = list({ flow: str, component: str, title: str, description: str });
+  }
+
+  return object({
+    document: object(document),
+    /* The two side-channels. They never reach the document — they are what the
+     * reader needs in order to judge it, and the reason this feature shows a
+     * review screen rather than writing straight to the database. */
+    assumptions: strList,
+    questions: strList
+  });
+}
+
+/** The full contract. `analysisSchema('lean')` is the fallback. */
+export const ANALYSIS_SCHEMA = analysisSchema('full');
+
+/* ------------------------------------------------------------------ types */
+/* Hand-written rather than inferred: the schema above is a plain object so
+ * that it can be sent over the wire unchanged, and inferring types from it
+ * would be a lot of machinery to restate twelve field names. */
+
+export interface WireLink { from: string; to: string; kind: string; protocol: string; note: string }
+
+export interface WireComponent {
+  id: string; name: string; group: string; layer: string;
+  icon: string; badge: string; url: string; role: string;
+  tech: string[]; features: string[]; notes: string[]; deps: string[];
+}
+
+export interface WireDocument {
+  meta: { lang: 'en' | 'fr'; name: string; tagline: string; kicker: string; intro: string; principle: string };
+  groups: { id: string; name: string; short: string; description: string }[];
+  layers: { id: string; name: string; desc: string }[];
+  components: WireComponent[];
+  links: WireLink[];
+  /** Absent on a lean run. */
+  technologies?: { name: string; category: string; description: string; groups: string[] }[];
+  /** Absent on a lean run. */
+  flows?: { id: string; name: string; sub: string; group: string; note: string }[];
+  /** Absent on a lean run. Ordered; each step names its flow. */
+  flowSteps?: { flow: string; component: string; title: string; description: string }[];
+}
+
+export interface Analysis {
+  document: WireDocument;
+  assumptions: string[];
+  questions: string[];
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,13 @@
+/** The one-line fetch wrapper the client components share: JSON in, JSON out,
+ *  and the server's own `error` string on the way back up so a failed call
+ *  reads as what went wrong rather than as "500". */
+export const api = {
+  async json<T>(url: string, init?: RequestInit): Promise<T> {
+    const res = await fetch(url, {
+      ...init,
+      headers: { 'Content-Type': 'application/json', ...(init?.headers || {}) }
+    });
+    if (!res.ok) throw new Error((await res.json().catch(() => ({}))).error || res.statusText);
+    return res.json();
+  }
+};

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -22,6 +22,13 @@ PRAGMA foreign_keys = ON;
 -- one process against this file — dev server and a build, or several workers —
 -- so the honest default is to block briefly rather than fail the request.
 PRAGMA busy_timeout = 5000;
+-- Deleted content is overwritten with zeros rather than left in a free page.
+-- The default is off because zeroing costs writes, and for folders and
+-- projects nobody would care — but this file also holds an API key, and
+-- "forget my key" has to mean the bytes are gone, not that a row stopped
+-- pointing at them. It applies to future deletions only, so settings.ts
+-- vacuums when a key changes, to scrub any copy written before this existed.
+PRAGMA secure_delete = ON;
 
 CREATE TABLE IF NOT EXISTS folders (
   id         TEXT PRIMARY KEY,
@@ -46,6 +53,16 @@ CREATE TABLE IF NOT EXISTS projects (
   updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
 );
 CREATE INDEX IF NOT EXISTS idx_projects_folder ON projects(folder_id);
+
+-- One row per settings group, holding JSON. A key-value table rather than
+-- columns because this holds operator configuration, not domain data: it grows
+-- by whatever the next feature needs to remember, and a migration per field
+-- would be a lot of ceremony for a single-user file.
+CREATE TABLE IF NOT EXISTS settings (
+  key        TEXT PRIMARY KEY,
+  value      TEXT NOT NULL,
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
 
 CREATE TABLE IF NOT EXISTS revisions (
   id         TEXT PRIMARY KEY,

--- a/src/lib/settings.residue.test.ts
+++ b/src/lib/settings.residue.test.ts
@@ -1,0 +1,52 @@
+import { strict as assert } from 'node:assert';
+import { after, before, test } from 'node:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+/* "Forget my key" has to be true on disk.
+ *
+ * Deleting a row in SQLite unlinks it; it does not erase it. Without
+ * `secure_delete` and a vacuum, a key stays legible in a free page — and in
+ * the write-ahead log — long after the studio says it is gone, and travels
+ * into every copy of the file made afterwards. This test reads the raw bytes,
+ * because that is the only place the claim can be checked. */
+
+const dbFile = path.join(os.tmpdir(), `archstudio-residue-${process.pid}.db`);
+process.env.DATABASE_PATH = dbFile;
+
+let S: typeof import('./settings');
+
+const files = () => [dbFile, `${dbFile}-wal`, `${dbFile}-shm`];
+
+/** Every byte the studio has written, across the main file and the WAL. */
+const onDisk = (): string =>
+  files().filter(f => fs.existsSync(f)).map(f => fs.readFileSync(f, 'latin1')).join('');
+
+before(async () => { S = await import('./settings'); });
+after(() => { for (const f of files()) fs.rmSync(f, { force: true }); });
+
+test('a stored key is on disk — that much is the documented trade', () => {
+  S.saveAiSettings({ provider: 'anthropic', model: 'claude-opus-5', apiKey: 'sk-ant-FIRSTKEY-aaaa' });
+  assert.ok(onDisk().includes('sk-ant-FIRSTKEY-aaaa'), 'the key is stored in clear text, as the dialog says');
+});
+
+test('replacing a key leaves no trace of the one it replaced', () => {
+  S.saveAiSettings({ apiKey: 'sk-ant-SECONDKEY-bbbb' });
+  const bytes = onDisk();
+  assert.equal(bytes.includes('sk-ant-FIRSTKEY-aaaa'), false, 'the replaced key must not survive in a free page');
+  assert.ok(bytes.includes('sk-ant-SECONDKEY-bbbb'), 'the current key is of course still there');
+});
+
+test('forgetting a key removes it from the file, not just from the row', () => {
+  S.saveAiSettings({ apiKey: null });
+  assert.equal(S.publicAiSettings().hasKey, false);
+  assert.equal(onDisk().includes('sk-ant-SECONDKEY-bbbb'), false, 'the forgotten key must be gone from the bytes');
+});
+
+test('the rest of the document survives the scrubbing', () => {
+  /* A vacuum rewrites the whole file; the point is to lose the key, not the
+   * settings around it. */
+  assert.equal(S.publicAiSettings().model, 'claude-opus-5');
+  assert.equal(S.publicAiSettings().provider, 'anthropic');
+});

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -1,0 +1,107 @@
+import { strict as assert } from 'node:assert';
+import { after, before, test } from 'node:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+/* Settings are the one place a credential is handled, so these tests are about
+ * two properties and nothing else: **the key never comes back out**, and the
+ * three states of the key field — untouched, replaced, forgotten — are told
+ * apart. Everything else about this module is a JSON blob in a row.
+ *
+ * `node --test` gives each file its own process, so pointing DATABASE_PATH at
+ * a scratch file here cannot affect another test or the developer's own data.
+ * The import is deferred because db.ts reads that variable when it loads. */
+
+const dbFile = path.join(os.tmpdir(), `archstudio-settings-${process.pid}.db`);
+process.env.DATABASE_PATH = dbFile;
+
+let S: typeof import('./settings');
+
+before(async () => { S = await import('./settings'); });
+after(() => {
+  for (const f of [dbFile, `${dbFile}-wal`, `${dbFile}-shm`]) fs.rmSync(f, { force: true });
+});
+
+test('nothing is configured until a provider, a model and a key exist', () => {
+  assert.equal(S.resolveAiConfig(), null);
+
+  S.saveAiSettings({ provider: 'anthropic', model: 'claude-opus-5' });
+  assert.equal(S.resolveAiConfig(), null, 'a model without a key cannot run');
+
+  S.saveAiSettings({ apiKey: 'sk-ant-secret-value-7f3a' });
+  assert.equal(S.resolveAiConfig()?.model, 'claude-opus-5');
+});
+
+test('the key never leaves the server — only its last four characters', () => {
+  const shown = S.publicAiSettings();
+  assert.equal(shown.hasKey, true);
+  assert.equal(shown.keyHint, '…7f3a');
+  assert.equal(JSON.stringify(shown).includes('sk-ant-secret'), false);
+});
+
+test('an absent key field leaves the stored key alone', () => {
+  /* The browser never receives the key, so it cannot send one back: an absent
+   * field has to mean "keep it". A save that changed the model must not
+   * silently log the operator out of their provider. */
+  S.saveAiSettings({ model: 'claude-opus-4-8' });
+  assert.equal(S.resolveAiConfig()?.apiKey, 'sk-ant-secret-value-7f3a');
+  assert.equal(S.resolveAiConfig()?.model, 'claude-opus-4-8');
+});
+
+test('null forgets the key, and only the key', () => {
+  S.saveAiSettings({ apiKey: null });
+  assert.equal(S.publicAiSettings().hasKey, false);
+  assert.equal(S.publicAiSettings().model, 'claude-opus-4-8');
+  assert.equal(S.resolveAiConfig(), null);
+});
+
+test('a key in the environment is used when none is stored, and says so', () => {
+  process.env.ANTHROPIC_API_KEY = 'sk-ant-from-the-environment-1234';
+  try {
+    const shown = S.publicAiSettings();
+    assert.equal(shown.hasKey, true);
+    assert.equal(shown.keyFromEnv, true);
+    assert.equal(shown.keyHint, '…1234');
+    assert.equal(S.resolveAiConfig()?.apiKey, 'sk-ant-from-the-environment-1234');
+
+    /* A key typed into the dialog takes over from the environment. */
+    S.saveAiSettings({ apiKey: 'sk-ant-typed-in-here-abcd' });
+    assert.equal(S.publicAiSettings().keyFromEnv, false);
+    assert.equal(S.resolveAiConfig()?.apiKey, 'sk-ant-typed-in-here-abcd');
+  } finally {
+    delete process.env.ANTHROPIC_API_KEY;
+  }
+});
+
+test('switching provider does not carry the previous one’s model or key across', () => {
+  S.saveAiSettings({ provider: 'gemini' });
+  const shown = S.publicAiSettings();
+  assert.equal(shown.provider, 'gemini');
+  assert.equal(shown.model, '', 'a Claude model id would be nonsense here');
+  assert.equal(shown.hasKey, false, 'and an Anthropic key would not authenticate');
+  assert.match(shown.baseUrl, /generativelanguage/);
+});
+
+test('a local OpenAI-compatible server is usable with no key at all', () => {
+  S.saveAiSettings({ provider: 'compatible', model: 'llama3.1', baseUrl: 'http://localhost:11434/v1' });
+  const cfg = S.resolveAiConfig();
+  assert.equal(cfg?.apiKey, '');
+  assert.equal(cfg?.baseUrl, 'http://localhost:11434/v1');
+});
+
+test('a candidate config falls back to the stored key so Test works without retyping it', () => {
+  S.saveAiSettings({ provider: 'openai', model: 'gpt-x', apiKey: 'sk-openai-stored-9999' });
+  const candidate = S.candidateAiConfig({ provider: 'openai', model: 'gpt-y' });
+  assert.equal(candidate?.apiKey, 'sk-openai-stored-9999');
+  assert.equal(candidate?.model, 'gpt-y', 'the form’s model wins over the stored one');
+  /* …but not across providers: that key would not authenticate there. */
+  assert.equal(S.candidateAiConfig({ provider: 'gemini', model: 'gemini-x' }), null);
+});
+
+test('prices are optional and clearable', () => {
+  S.saveAiSettings({ inputPrice: 5, outputPrice: 25 });
+  assert.equal(S.resolveAiConfig()?.inputPrice, 5);
+  S.saveAiSettings({ inputPrice: null, outputPrice: null });
+  assert.equal(S.resolveAiConfig()?.inputPrice, undefined);
+});

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1,0 +1,196 @@
+import { db, now, plain } from './db';
+import { PROVIDERS, providerInfo, type AiConfig, type ProviderId } from './ai/providers/types';
+
+/* Operator settings, kept in the database rather than the environment.
+ *
+ * The trade is explicit and worth stating where the code is, not only in the
+ * README: **the API key is stored in `data/studio.db` in clear text.** There is
+ * no master secret in a single-user, no-login application to encrypt it
+ * against, and a key derived from something on the machine would only look like
+ * encryption. So the honest arrangement is: anyone who can read the database
+ * file can read the key, backups of that file carry it, and the settings dialog
+ * says so before you paste one.
+ *
+ * Two things follow from that, both enforced here. The key is never returned to
+ * the browser — only whether one exists and its last four characters. And a key
+ * in the environment still wins when none is stored, so an install that would
+ * rather keep secrets out of its data directory can pass one in and never open
+ * this dialog. */
+
+const KEY = 'ai';
+
+export interface StoredAi {
+  provider: ProviderId;
+  model: string;
+  baseUrl?: string;
+  apiKey?: string;
+  /** US dollars per million tokens, if the operator wants a cost estimate. */
+  inputPrice?: number;
+  outputPrice?: number;
+}
+
+/** What the browser is allowed to know. No key, ever. */
+export interface PublicAiSettings {
+  /** Whether a run could actually be made with what is stored. */
+  configured: boolean;
+  provider: ProviderId;
+  model: string;
+  baseUrl: string;
+  hasKey: boolean;
+  /** "…7f3a" — enough to tell two keys apart, not enough to use one. */
+  keyHint: string;
+  /** True when the key comes from the environment rather than this dialog. */
+  keyFromEnv: boolean;
+  inputPrice?: number;
+  outputPrice?: number;
+}
+
+function readRow(): StoredAi | null {
+  const row = db.prepare('SELECT value FROM settings WHERE key = ?').get(KEY);
+  if (!row) return null;
+  try {
+    return JSON.parse(plain<{ value: string }>(row).value) as StoredAi;
+  } catch {
+    return null;
+  }
+}
+
+function writeRow(value: StoredAi): void {
+  db.prepare(
+    `INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?)
+     ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`
+  ).run(KEY, JSON.stringify(value), now());
+}
+
+const envKeyFor = (provider: ProviderId): string => {
+  const name = providerInfo(provider).envKey;
+  return name ? (process.env[name]?.trim() ?? '') : '';
+};
+
+const defaults = (provider: ProviderId): StoredAi => ({
+  provider,
+  model: providerInfo(provider).defaultModel ?? '',
+  baseUrl: providerInfo(provider).defaultBaseUrl
+});
+
+/** The config a run will use, or null when there is not enough to run one. */
+export function resolveAiConfig(): AiConfig | null {
+  const stored = readRow();
+  if (!stored?.provider || !stored.model) return null;
+
+  const info = providerInfo(stored.provider);
+  const apiKey = stored.apiKey?.trim() || envKeyFor(stored.provider);
+  const baseUrl = stored.baseUrl?.trim() || info.defaultBaseUrl || '';
+
+  /* A local OpenAI-compatible server is normally unauthenticated, so an empty
+   * key is a valid configuration there and only there. */
+  if (!apiKey && stored.provider !== 'compatible') return null;
+  if (!baseUrl && info.adapter !== 'anthropic') return null;
+
+  return {
+    provider: stored.provider,
+    model: stored.model,
+    baseUrl,
+    apiKey,
+    inputPrice: stored.inputPrice,
+    outputPrice: stored.outputPrice
+  };
+}
+
+export function publicAiSettings(): PublicAiSettings {
+  const stored = readRow() ?? defaults(PROVIDERS[0].id);
+  const info = providerInfo(stored.provider);
+  const own = stored.apiKey?.trim() ?? '';
+  const env = envKeyFor(stored.provider);
+  const key = own || env;
+
+  return {
+    configured: resolveAiConfig() !== null,
+    provider: stored.provider,
+    model: stored.model ?? '',
+    baseUrl: stored.baseUrl ?? info.defaultBaseUrl ?? '',
+    hasKey: key.length > 0,
+    keyHint: key ? `…${key.slice(-4)}` : '',
+    keyFromEnv: !own && env.length > 0,
+    inputPrice: stored.inputPrice,
+    outputPrice: stored.outputPrice
+  };
+}
+
+/** The config a form is *proposing*, for listing models and testing before it
+ *  is saved. The key falls back to the stored one, because the browser never
+ *  had it to send back — otherwise pressing Test without retyping the key
+ *  would fail for a reason that has nothing to do with what is being tested. */
+export function candidateAiConfig(patch: AiSettingsPatch): AiConfig | null {
+  const stored = readRow();
+  const provider = PROVIDERS.some(p => p.id === patch.provider)
+    ? patch.provider! : (stored?.provider ?? PROVIDERS[0].id);
+  const info = providerInfo(provider);
+  const sameProvider = stored?.provider === provider;
+
+  const apiKey = (typeof patch.apiKey === 'string' && patch.apiKey.trim())
+    || (sameProvider ? stored?.apiKey?.trim() ?? '' : '')
+    || envKeyFor(provider);
+  const baseUrl = patch.baseUrl?.trim()
+    || (sameProvider ? stored?.baseUrl?.trim() ?? '' : '')
+    || info.defaultBaseUrl || '';
+
+  if (!apiKey && provider !== 'compatible') return null;
+  if (!baseUrl && info.adapter !== 'anthropic') return null;
+
+  return {
+    provider,
+    model: patch.model?.trim() || (sameProvider ? stored?.model ?? '' : info.defaultModel ?? ''),
+    baseUrl,
+    apiKey,
+    inputPrice: stored?.inputPrice,
+    outputPrice: stored?.outputPrice
+  };
+}
+
+export interface AiSettingsPatch {
+  provider?: ProviderId;
+  model?: string;
+  baseUrl?: string;
+  /** Absent leaves the stored key alone; null clears it; a string replaces it. */
+  apiKey?: string | null;
+  inputPrice?: number | null;
+  outputPrice?: number | null;
+}
+
+export function saveAiSettings(patch: AiSettingsPatch): PublicAiSettings {
+  const known = PROVIDERS.some(p => p.id === patch.provider);
+  const previous = readRow();
+  const provider = known ? patch.provider! : (previous?.provider ?? PROVIDERS[0].id);
+
+  /* Switching provider resets the model and base URL rather than carrying the
+   * previous vendor's values across, where they would be silently wrong. */
+  const switched = previous?.provider !== undefined && previous.provider !== provider;
+  const base = switched ? defaults(provider) : (previous ?? defaults(provider));
+
+  const next: StoredAi = {
+    provider,
+    model: patch.model?.trim() ?? base.model ?? '',
+    baseUrl: patch.baseUrl?.trim() || base.baseUrl || providerInfo(provider).defaultBaseUrl,
+    apiKey: patch.apiKey === null ? undefined
+      : patch.apiKey !== undefined ? patch.apiKey.trim() || undefined
+      : (switched ? undefined : base.apiKey),
+    inputPrice: patch.inputPrice === null ? undefined : patch.inputPrice ?? base.inputPrice,
+    outputPrice: patch.outputPrice === null ? undefined : patch.outputPrice ?? base.outputPrice
+  };
+
+  writeRow(next);
+
+  /* Replacing or forgetting a key rewrites the row, and the old bytes sit in a
+   * free page — and in the write-ahead log — until something reuses them. For
+   * ordinary data nobody would mind; for a credential, "I removed it" has to
+   * be true on disk. `secure_delete` zeroes what is deleted from here on, the
+   * checkpoint folds the WAL back into the file, and the vacuum rewrites it so
+   * copies written before either of those existed do not survive. Cheap on a
+   * file this size, and only on the save that actually changed the key. */
+  if ((previous?.apiKey ?? '') !== (next.apiKey ?? '')) {
+    db.exec('PRAGMA wal_checkpoint(TRUNCATE); VACUUM;');
+  }
+
+  return publicAiSettings();
+}


### PR DESCRIPTION
- Introduced types for AI providers, including configuration and request structures.
- Implemented schema validation tests for AI settings to ensure correctness.
- Created a JSON schema for analysis documents, enforcing required fields and structure.
- Developed a unified API fetch wrapper for consistent error handling.
- Enhanced database schema to securely manage API keys and settings.
- Added tests to verify secure deletion of sensitive information from the database.
- Implemented settings management to handle AI provider configurations, ensuring keys are never exposed to the client.

## Summary by Sourcery

Add document analysis powered by configurable AI providers, with secure server-side settings and key management, plus schema-driven conversion and enrichment of architecture documents.

New Features:
- Introduce document reading and enrichment flows that generate or extend projects from PDFs or text documents via AI.
- Add a settings UI and backing API to configure AI providers, models, endpoints, pricing, and API keys without exposing keys to the client.
- Implement AI provider abstraction with support for Anthropic, OpenAI, Google Gemini, NVIDIA NIM, and generic OpenAI-compatible endpoints.
- Define a JSON schema and wire formats for AI-generated architecture documents and use them to drive analysis requests and responses.

Enhancements:
- Refine workspace and editor UI to surface Read a document and Enrich actions and provide clearer access to model settings.
- Add a shared client-side API wrapper for consistent JSON fetching and error propagation.
- Extend the database schema with a settings table and enable secure deletion to support operator configuration and key rotation.

Build:
- Update test runner to discover all test files under src and add Anthropic SDK as a dependency.

Documentation:
- Expand README with documentation for the document reading feature, provider options, pricing, data flow, and security trade-offs, and update project structure notes to cover AI and settings modules.

Tests:
- Add tests for AI schema size and alignment with core types, and for provider-specific schema translations.
- Add conversion tests to ensure AI responses are normalised into safe architecture documents with explicit repair reporting.
- Add merge tests to verify enrichment never overwrites author content and only adds permitted changes.
- Add settings tests, including residue checks, to ensure API keys are handled, persisted, and scrubbed correctly from disk.