### PR TITLE
feat: add optional Docker setup for contributors

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+.next
+out
+dist
+data
+.env.local
+.env
+.git
+.github
+screenshots
+*.log
+npm-debug.log*

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ data/*.db
 data/*.db-shm
 data/*.db-wal
 .env.local
+# docker compose reads .env, and the Docker section of the README points API
+# keys at it — it must never be committable.
+.env
 .DS_Store
 *.log
 next-env.d.ts

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# syntax=docker/dockerfile:1
+FROM node:24-alpine AS deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+
+FROM node:24-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+FROM node:24-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/next.config.mjs ./next.config.mjs
+# The export renderer reads /viewer at request time, not at build time:
+# exportHtml.ts resolves it from process.cwd(). Without it every export and
+# every preview 500s on a missing style.css.
+COPY --from=builder /app/viewer ./viewer
+
+# `node` (uid 1000) ships with the image and matches the first-user uid on
+# most Linux hosts, so the bind-mounted ./data stays writable. A system user
+# from adduser -S lands around uid 100 and cannot open the database there.
+RUN mkdir -p /app/data && chown node:node /app /app/data
+VOLUME /app/data
+USER node
+
+EXPOSE 3000
+# next directly, not `npm start`: npm as PID 1 does not forward SIGTERM, so
+# every stop would wait out the grace period and be killed mid-write.
+CMD ["node_modules/.bin/next", "start"]

--- a/README.md
+++ b/README.md
@@ -471,6 +471,19 @@ There is no authentication. Put it behind your VPN, a reverse-proxy basic-auth, 
 network — do not expose it to the open internet as is. Adding auth means one middleware and a
 session check in the API routes; the data model does not need to change.
 
+**Docker** — a `Dockerfile` and `docker-compose.yml` ship at the repo root, mainly for anyone
+whose local Node is older than the `node:sqlite` floor above.
+
+```bash
+docker compose up --build            # http://localhost:3000
+```
+
+`./data` on the host is bind-mounted to `/app/data` in the container, so `data/studio.db`
+survives rebuilds. Run `npm run reset` on the **host**, not inside the container — `data` is the
+mount point there, and a mount point cannot remove itself. To use a document-reading provider, copy
+`.env.example` to `.env` and fill in the key(s) you need; `docker compose` reads it
+automatically.
+
 ---
 
 ## Roadmap

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  archstudio:
+    build: .
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./data:/app/data
+    environment:
+      - DATABASE_PATH=/app/data/studio.db
+      # Optional — copy .env.example to .env and fill in the ones you use.
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - GEMINI_API_KEY=${GEMINI_API_KEY:-}
+      - NVIDIA_API_KEY=${NVIDIA_API_KEY:-}
+    restart: unless-stopped


### PR DESCRIPTION
## Why

I wanted to try the studio and could not start it: my machine had an older Node, and the app needs `>= 22.13`.

That floor is not arbitrary — `node:sqlite` is flagged before it, and using the core module instead of a native dependency is precisely what makes `npm install && npm run dev` the whole setup. But it is also well ahead of what most distributions ship (Debian stable is on 18, Ubuntu LTS on 20), so the first contact with the project is often "install a version manager", before having seen a single diagram.

So this adds a container as a *second* way in, not a replacement for the first one. The premise is untouched: one process, one SQLite file, no database server, no external service. `npm install && npm run dev` remains the documented path, and this changes nothing for anyone already on the right Node.

```bash
docker compose up --build     # http://localhost:3000
```

## What is in it

| File | |
|---|---|
| `Dockerfile` | Multi-stage on `node:24-alpine`, non-root |
| `docker-compose.yml` | One service, port 3000, `./data` bind-mounted |
| `.dockerignore` | Keeps the build context (and `.env`) out of the image |
| `.gitignore` | Adds `.env` — see below |
| `README.md` | Four paragraphs in *Deploying it*, where containers were already mentioned |

`./data` on the host is bind-mounted to `/app/data`, so `data/studio.db` survives rebuilds and stays a normal file you can inspect, back up or delete from the host.

## One thing worth flagging beyond Docker

`src/lib/exportHtml.ts` resolves `viewer/` and `public/fonts/` from `process.cwd()` **at request time**. My first image did not ship `viewer/`, and the result was not a build error — it was a clean boot, a working editor, and a `500` with `ENOENT: stat '/app/viewer/style.css'` on every export and every preview.

That failure mode is not specific to Docker: any deployment that does not carry the full repository tree next to the server (Next standalone output, a tarball of `.next` + `node_modules`, some PaaS builders) will start fine and break on the feature the project exists for. Might be worth a runtime check, or a line in *Deploying it*. Happy to open a separate issue or PR for that if useful — I kept it out of this one.

## Three decisions that are not obvious from the diff

- **Runs as the image's `node` user (uid 1000)**, not a system user from `adduser -S`. A system user lands around uid 100, and on a Linux host the bind-mounted `./data` belongs to uid 1000 — the app boots and then cannot open the database. macOS does not reproduce this, since virtiofs remaps ownership.
- **`next` is exec'd directly** instead of `npm start`. npm as PID 1 does not forward `SIGTERM`, so every `docker compose stop` would sit out the grace period and end in a `SIGKILL` — mid-write, on a SQLite file, with WAL files left behind. PID 1 is now `next-server` and stops are immediate.
- **`.env` added to `.gitignore`.** `docker compose` reads `.env` by default and the new documentation points API keys at it, but only `.env.local` was ignored. `.dockerignore` already excluded it; the repository did not.

`npm run reset` is documented as host-side only: inside the container `data` is the mount point, and a mount point cannot remove itself.

## Verified

Built and run end to end: boot, project creation, **export at 237 KB** (the README says 235–240 KB), data surviving a restart, `npm run reset` from the host, and an immediate stop. Nothing in `src/` is touched, so existing CI covers the rest.

Branched off `main` since it is the default branch and currently ahead of `develop` — glad to retarget if `develop` is where you would rather take this.

## Summary by Sourcery

Add optional Docker-based setup to run the app without requiring a compatible local Node installation.

New Features:
- Provide a Dockerfile and docker-compose configuration to run the application in a container with a bind-mounted data directory and configured environment variables.

Enhancements:
- Document the Docker-based deployment and clarify data persistence and reset behavior in the README.
- Ignore local .env files in git to support Docker-based configuration without committing secrets.

Build:
- Introduce a multi-stage Node 24 Alpine Docker image that builds and runs the Next.js app as a non-root user with proper volume setup for SQLite data.