### PR TITLE
Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,23 @@ is the whole reason nothing foreign can wander into it — and the reason the dr
 column per zone whether or not every row uses it. That is the visible, honest price of a
 boundary that means what it draws.
 
+**The sheet is capped, and the order is yours.** `BAND_MAX` caps one band at six columns; nothing
+capped their *sum*, so a fourth zone could push the drawing off the right of the frame — where the
+editor has no zoom to pull it back, only a scrollbar to find it with. `BAND_BUDGET` is twelve
+columns, about 2 900 px, and when the bands ask for more the widest gives up a column at a time
+until they fit. No card is lost: a narrowed band wraps inside itself and its layer grows taller,
+which is the trade a reader can scroll. It is a ceiling and not a promise — a document with more
+buckets than columns gets one each and is wider than that, because one card per band is the floor.
+
+The **Zones** panel moves a zone left or right among its own siblings. Left and right rather than
+up and down, because a zone *is* a band of columns and that is the direction it moves on the sheet;
+among siblings, because the band order comes from the zone tree, where the array position only ever
+breaks ties between zones sharing a parent — a plain array swap would usually move nothing at all.
+A nested zone slides inside its parent and never out of it, and its children travel with it.
+
+To see a wide sheet whole, use **Preview**: it renders the real exported viewer, which has zoom,
+pan and a **Fit** button. The editor canvas has none of those — it scrolls.
+
 The **EXTERNAL / INTERNAL** divide those diagrams draw as a full-height vertical line does not
 transpose. This layout is horizontal bands; a vertical axis wants columns. Modelled as a zone it
 gives you a frame around the external services, which is legible and is not the same thing.

--- a/README.md
+++ b/README.md
@@ -221,12 +221,30 @@ Five rules hold the whole thing together, and each one is written where it is en
 
 | Token | | |
 |---|---|---|
+| Layers | `--lt1..--lt6` | a band's label and the rule under it — never a chip |
 | Ink | `#0B1B2B` | text, rules, the mark |
 | Paper | `#FFFFFF` | surfaces, cards, the printed page |
 | Calque | `#EEF3F6` | the canvas ground, the app background |
 | Teal | `#0E7C8A` | the single accent — actions and selection only |
 | Cyan | `#00E5FF` | **marine ground only, never on white** |
 | Scopes | `oklch(0.62 0.11 h)` | h = 200, 250, 290, 340, 150 |
+
+**The layer ramp is the one exception to rule 1, and it is an exception about
+position rather than about colour.** A tall landscape has six or seven bands and, before it, one
+way to tell them apart: a 10 px monospace label in `--ink-3`. What makes a layer tint safe is that
+a scope colour lives on the icon chip and the technology pills, and a layer tint lives on the
+band's label and the rule under it — the two never meet on one element, so neither can be read as
+the other. The ground was not available: zones already own it at 3–9 % ink, and a second tint
+under a zone rectangle makes both unreadable. The ramp is lower in chroma than the scope palette
+and spans a wider arc, including warm hues the scope circle never reaches, so a band label never
+competes with a card for attention.
+
+It also reads *better* than what it replaced. Against paper the six measure 3.68–4.17:1 where
+`--ink-3` measured 2.67:1; on the marine ground, 6.90–7.98:1 against 5.77:1. Six, where scopes
+stop at five: that ceiling is an argument about one hue circle at fixed lightness, and this ramp
+is neither. Past the sixth band it cycles. `ui.architecture.layerTint: false` emits no custom
+property at all, and every rule falls back to the neutral it had before — the off state is the
+absence of this look, not a second one to maintain.
 
 Cyan is the one colour with a hard rule attached, and the rule is arithmetic: it sits at 1.5:1
 against white and 11.3:1 against ink. So it is the inverted mark, the app icon, and the accent the

--- a/src/app/api/projects/[id]/export/route.ts
+++ b/src/app/api/projects/[id]/export/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server';
 import { getProject } from '@/lib/store';
-import { buildStandaloneHtml, buildDataFile, safeFilename } from '@/lib/exportHtml';
+import { buildStandaloneHtml, buildDataFile, inlineFontCss, safeFilename } from '@/lib/exportHtml';
+import { buildDrawioXml } from '@/lib/export/drawio';
+import { buildDiagramSvg } from '@/lib/export/svg';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -16,29 +18,38 @@ export async function GET(req: Request, { params }: Ctx) {
   const format = url.searchParams.get('format') || 'html';
   const inline = url.searchParams.get('inline') === '1';
 
-  if (format === 'json') {
-    return new NextResponse(JSON.stringify(project.data, null, 2), {
+  /* One shape for every format: a body, a type, and the name the browser should
+   * save it under. `inline` drops the disposition — the preview iframe and the
+   * PNG builder both read these over `fetch` and neither wants a download. */
+  const send = (body: string, type: string, filename: string) =>
+    new NextResponse(body, {
       headers: {
-        'Content-Type': 'application/json; charset=utf-8',
-        'Content-Disposition': `attachment; filename="${safeFilename(project.name, 'json')}"`
+        'Content-Type': `${type}; charset=utf-8`,
+        ...(inline ? {} : { 'Content-Disposition': `attachment; filename="${filename}"` })
       }
     });
+
+  if (format === 'json') {
+    return send(JSON.stringify(project.data, null, 2), 'application/json',
+      safeFilename(project.name, 'json'));
   }
 
   if (format === 'datafile') {
-    return new NextResponse(buildDataFile(project.data), {
-      headers: {
-        'Content-Type': 'application/javascript; charset=utf-8',
-        'Content-Disposition': `attachment; filename="architecture.js"`
-      }
-    });
+    return send(buildDataFile(project.data), 'application/javascript', 'architecture.js');
   }
 
-  const html = buildStandaloneHtml(project.data);
-  return new NextResponse(html, {
-    headers: {
-      'Content-Type': 'text/html; charset=utf-8',
-      ...(inline ? {} : { 'Content-Disposition': `attachment; filename="${safeFilename(project.name, 'html')}"` })
-    }
-  });
+  if (format === 'drawio') {
+    return send(buildDrawioXml(project.data), 'application/xml',
+      safeFilename(project.name, 'drawio'));
+  }
+
+  if (format === 'svg') {
+    /* The faces travel with the drawing. Without them an SVG opened anywhere
+     * else falls back to the reader's Helvetica, and the PNG built from it in an
+     * `<img>` cannot request a font at all. */
+    return send(buildDiagramSvg(project.data, { fontCss: inlineFontCss() }), 'image/svg+xml',
+      safeFilename(project.name, 'svg'));
+  }
+
+  return send(buildStandaloneHtml(project.data), 'text/html', safeFilename(project.name, 'html'));
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -344,6 +344,32 @@ input.input[type="color"] { height: 34px; padding: 3px; cursor: pointer; }
 .saveflag.error { color: var(--danger); }
 .saveflag.error i { background: var(--danger); }
 
+/* Undo and redo sit against the save flag, boxed as one control: they are two
+   directions of the same thing, and the box is what says the pair is a unit
+   rather than two more buttons in a bar that already has several. */
+.undogroup {
+  display: inline-flex; border: 1px solid var(--line-2); background: var(--panel);
+}
+.undogroup .iconbtn { width: 28px; height: 28px; border: 0; }
+.undogroup .iconbtn + .iconbtn { border-left: 1px solid var(--line); }
+.undogroup .iconbtn:disabled { opacity: .3; cursor: default; background: transparent; }
+
+/* What just happened, bottom left, over the canvas and clear of the inspector.
+   Ink on paper like everything else; the way back is the one word set in teal,
+   because rule 2 says teal is what you can act on. */
+.noticebar {
+  position: fixed; left: 18px; bottom: 18px; z-index: 140;
+  display: flex; align-items: center; gap: 14px; max-width: min(520px, calc(100vw - 36px));
+  padding: 10px 10px 10px 14px; border: 1px solid var(--ink); background: var(--panel);
+  box-shadow: var(--shadow-lg); font-size: 12.5px; color: var(--ink);
+}
+.noticebar > span { flex: 1; min-width: 0; }
+.noticebar .iconbtn { width: 24px; height: 24px; flex: none; }
+@media (prefers-reduced-motion: no-preference) {
+  .noticebar { animation: notice-in .14s ease-out; }
+}
+@keyframes notice-in { from { opacity: 0; transform: translateY(6px); } }
+
 .segmented {
   display: flex; border: 1px solid color-mix(in srgb, var(--ink) 16%, transparent);
   border-radius: 0; padding: 0;
@@ -360,7 +386,83 @@ input.input[type="color"] { height: 34px; padding: 3px; cursor: pointer; }
   width: 246px; flex: none; border-right: 1px solid var(--line); background: var(--panel-2);
   overflow-y: auto; overflow-x: hidden; padding: 12px 10px 30px;
 }
-.canvas-wrap { flex: 1; overflow: auto; padding: 20px 22px 80px; position: relative; background: var(--bg); }
+/* The sheet's own frame: a toolbar that stays put and a pane that scrolls under
+   it. The padding moved off the wrapper and onto the pane, so the controls do
+   not scroll away from the drawing they act on. */
+.canvas-wrap { flex: 1; display: flex; flex-direction: column; overflow: hidden; background: var(--bg); }
+.canvas-frame { flex: 1; overflow: auto; padding: 20px 22px 60px; position: relative; }
+.canvas-frame.panning { cursor: grabbing; user-select: none; }
+
+/* Mirrors the viewer's filter row — same chips, same zoom bar, same class names,
+   because it is the same control over the same sheet. See viewer/style.css. */
+.canvas-tools {
+  flex: none; display: flex; gap: 10px; align-items: center; flex-wrap: wrap;
+  padding: 9px 22px; border-bottom: 1px solid var(--line); background: var(--panel);
+}
+.canvas-tools .filters { display: flex; gap: 7px; flex-wrap: wrap; align-items: center; }
+.canvas-tools .toolside {
+  margin-left: auto; display: flex; align-items: center; gap: 12px; flex-wrap: wrap;
+  justify-content: flex-end;
+}
+.canvas-tools .tools { display: flex; align-items: center; gap: 8px; }
+.canvas-tools .hintline { font-family: var(--mono); font-size: 10.5px; color: var(--ink-3); }
+/* Below the width where the hint would push the controls onto a line of their
+   own, the hint is the half that goes: the shortcut it describes still works. */
+@media (max-width: 1420px) { .canvas-tools .hintline { display: none; } }
+.chip {
+  border: 1px solid color-mix(in srgb, var(--ink) 16%, transparent); background: var(--panel);
+  color: var(--ink-2); padding: 5px 11px; border-radius: 0; font: inherit; font-size: 12px;
+  font-weight: 600; cursor: pointer; display: inline-flex; align-items: center; gap: 7px;
+  transition: .12s;
+}
+.chip:hover { border-color: var(--ink); }
+.chip i { width: 9px; height: 9px; border-radius: 0; display: inline-block; flex: none; }
+.chip[aria-pressed="true"] { background: var(--ink); color: var(--panel); border-color: var(--ink); }
+/* Rule 1: a filtered scope fills, it does not outline. */
+.chip.pole[aria-pressed="true"] {
+  background: color-mix(in srgb, var(--c) 16%, transparent); border-color: var(--ink-3); color: var(--ink);
+}
+.zoombar {
+  display: flex; align-items: center; background: var(--panel);
+  border: 1px solid color-mix(in srgb, var(--ink) 16%, transparent);
+}
+.zb {
+  border: 0; background: none; color: var(--ink-2); font: inherit; font-size: 12px; font-weight: 600;
+  padding: 0 8px; height: 26px; display: grid; place-items: center; cursor: pointer; transition: .12s;
+}
+.zb:hover { background: var(--panel-3); color: var(--ink); }
+.zb.zfit { border-left: 1px solid var(--line-2); padding: 0 10px; }
+.zval {
+  font-family: var(--mono); font-size: 10.5px; color: var(--ink-3); min-width: 38px;
+  text-align: center; font-variant-numeric: tabular-nums;
+}
+
+/* Compact: the cards drop to their icon and name, so twice as many fit on a row.
+   The same treatment the viewer's Compact gives, and for the same reason. */
+.canvas.compact .ccard { width: 168px; padding: 9px 11px; }
+.canvas.compact .ccard.selected, .canvas.compact .ccard.linktarget { padding: 8px 10px; }
+.canvas.compact .ccard .tech { display: none; }
+.canvas.compact .ccard .depcount { display: none; }
+
+/* A filtered scope fades rather than leaves, because in the editor you are still
+   working on what you narrowed away — a card that vanished is one you cannot
+   drop anything onto. */
+.ccard.faded { opacity: .22; }
+.ccard.faded:hover { opacity: .6; }
+
+/* Hovering a card quietens everything it does not touch, so one dependency reads
+   at a glance. The same move the exported file already made; it had no business
+   being absent from the surface the drawing is made on.
+
+   Lighter than the scope filter on purpose — this is a glance, not a decision,
+   and it has to be reversible by moving the pointer. The transition is on the
+   quietening rather than on the card, so the sheet settles instead of flashing
+   while the pointer crosses it. */
+.ccard.away { opacity: .3; }
+.ccard.away .tech span { opacity: .7; }
+@media (prefers-reduced-motion: no-preference) {
+  .ccard { transition: border-color .12s, opacity .12s; }
+}
 .inspector {
   width: var(--inspector); flex: none; border-left: 1px solid var(--line); background: var(--panel-2);
   overflow-y: auto; padding: 16px 16px 60px;
@@ -381,6 +483,18 @@ input.input[type="color"] { height: 34px; padding: 3px; cursor: pointer; }
   background-size: 24px 24px; opacity: .05;
 }
 .canvas-edges { position: absolute; inset: 0; width: 100%; height: 100%; pointer-events: none; z-index: 1; overflow: visible; }
+/* The lines are the only thing on the sheet you could not click. The drawn
+   stroke stays 1.2 px and an invisible one 14 px wide underneath takes the
+   pointer — `stroke`, not `all`, so the empty inside of a curve is still the
+   paper and still deselects. The cards sit above this layer, so a line running
+   under one is the card's to click, which is the right answer. */
+.canvas-edges .hit { pointer-events: stroke; cursor: pointer; }
+.canvas.linking .canvas-edges .hit { pointer-events: none; }
+/* Rule 2: what you have selected is teal. The open circle keeps its paper fill
+   from the inline style, which is the whole point of an open circle. */
+.canvas-edges g[data-sel="1"] path { stroke: var(--brand); }
+.canvas-edges g[data-sel="1"] circle { stroke: var(--brand); }
+.canvas-edges g[data-sel="1"] circle:first-of-type { fill: var(--brand); }
 
 /* A zone's cards in one layer. Present only on a document that has zones, and it
    mirrors `.layer-drop` exactly so a single run lays out like a bare row. Its job
@@ -404,7 +518,41 @@ input.input[type="color"] { height: 34px; padding: 3px; cursor: pointer; }
 /* A run fills its band rather than shrinking to its cards, so the measured
    rectangle is band-shaped on every layer instead of jumping in and out with the
    card count. */
-.layer-drop.banded .zrun { min-width: 0; justify-self: stretch; }
+.layer-drop.banded .zrun { min-width: 0; justify-self: stretch; position: relative; z-index: 1; }
+
+/* ------------------------------------------------------- dropping into a zone
+   A second grid laid over the row, on the same tracks, holding one target per
+   reserved band. Behind the cards and inert until something is being dragged —
+   a band that swallowed clicks would take them from the paper underneath, which
+   is what deselects.
+
+   It cannot be the run itself: a run is measured to draw its zone rectangle and
+   has to stay a tight box around its own cards, while a target has to cover the
+   whole band including the empty part — which on a given row is exactly where
+   the first card to join that zone has to land. */
+.layer-drop.banded { position: relative; }
+.banddrops {
+  position: absolute; inset: 0; display: grid; pointer-events: none;
+  grid-template-columns: repeat(var(--cols), var(--card-w));
+  column-gap: 24px; justify-content: start;
+}
+.banddrop { border-radius: 0; transition: background .12s, box-shadow .12s; }
+.banddrop.live { pointer-events: auto; }
+/* Only the band under the pointer answers, and it answers in teal — rule 2: the
+   thing you are about to act on. */
+.banddrop.over {
+  background: color-mix(in srgb, var(--brand) 9%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--brand) 45%, transparent);
+}
+
+/* Where the release would put the card: in front of this one. A rule on the
+   leading edge rather than a gap opening up — the sheet is a grid of reserved
+   columns and reflowing it under the pointer would move the very target being
+   aimed at. */
+.ccard.insert::before {
+  content: ""; position: absolute; left: -7px; top: -2px; bottom: -2px;
+  width: 3px; background: var(--brand);
+}
 
 /* ------------------------------------------------------------------- zones
    Measured after layout and drawn into the edge SVG, behind every card. Two
@@ -422,8 +570,17 @@ input.input[type="color"] { height: 34px; padding: 3px; cursor: pointer; }
   fill: var(--ink-3);
 }
 
-/* The zone rows in the palette rail: name and count, then kind and nesting. */
-.zonerow { margin-bottom: 8px; }
+/* The zone rows in the palette rail: name and count, then kind and nesting.
+   They are also drop targets — the only way into a zone that holds nothing yet,
+   since an empty zone reserves no band and so has no target on the sheet. The
+   dashed outline appears only while a component is in the air, so the rail is
+   as quiet as it was the rest of the time. */
+.zonerow { margin-bottom: 8px; padding: 2px; border: 1px dashed transparent; }
+.zonerow.droppable { border-color: var(--line-2); }
+.zonerow.over {
+  border-color: var(--brand); border-style: solid;
+  background: color-mix(in srgb, var(--brand) 8%, transparent);
+}
 .zonerow .frow { display: flex; gap: 6px; margin-top: 4px; }
 .zonerow .select.sm { font-size: 10.5px; padding: 3px 6px; min-width: 0; flex: 1; }
 .zonerow .count {
@@ -455,8 +612,48 @@ input.input[type="color"] { height: 34px; padding: 3px; cursor: pointer; }
   color: var(--lc, var(--ink-3)); font-weight: 400;
 }
 .layer-head em { font-style: normal; font-family: var(--mono); font-size: 10px; color: var(--ink-3); opacity: .8; }
-.layer-head .layer-tools { margin-left: auto; display: none; gap: 2px; }
-.layer:hover .layer-head .layer-tools { display: flex; }
+.layer-head b { cursor: text; }
+/* The label, editable in place — same type, same size, so the row does not jump
+   when it turns into a field. */
+.layer-rename {
+  font-family: var(--mono); font-size: 10px; letter-spacing: .06em; color: var(--ink);
+  background: var(--panel); border: 1px solid var(--brand); border-radius: 0;
+  padding: 2px 6px; width: 190px; outline: none;
+}
+/* Add is always there; rename and delete are not. The three used to appear
+   together on hover, which made the one you need constantly as hard to reach as
+   the two you need twice a year — and made all three unreachable by keyboard.
+   `:focus-within` is what fixes the second half. */
+.layer-head .layer-add {
+  margin-left: auto; display: inline-flex; align-items: center; gap: 5px;
+  border: 1px solid var(--line-2); background: var(--panel); color: var(--ink-2);
+  font: inherit; font-family: var(--mono); font-size: 10px; letter-spacing: .04em;
+  padding: 3px 8px; border-radius: 0; cursor: pointer; transition: .12s;
+}
+.layer-head .layer-add:hover { border-color: var(--ink); color: var(--ink); }
+.layer-head .layer-add svg { fill: none; stroke: currentColor; stroke-width: 2; }
+.layer-head .layer-tools { display: none; gap: 2px; }
+.layer:hover .layer-head .layer-tools,
+.layer:focus-within .layer-head .layer-tools { display: flex; }
+
+/* The empty row is the invitation, so it takes the click as well as the drop. */
+.emptyadd {
+  border: 0; background: transparent; font: inherit; font-size: 12px; color: var(--ink-3);
+  cursor: pointer; padding: 6px 10px; width: 100%; text-align: center;
+}
+.emptyadd:hover { color: var(--ink); }
+
+/* The rail's folds. The twist takes the whole label so the target is a line and
+   not an 11 px glyph; the section's own Add stays outside it, or opening a
+   section and adding to it would be the same click. */
+.sect-label.railhead { display: flex; align-items: center; gap: 0; }
+.railtwist {
+  display: inline-flex; align-items: center; gap: 6px; border: 0; background: none;
+  font: inherit; color: inherit; letter-spacing: inherit; text-transform: inherit;
+  padding: 0; cursor: pointer;
+}
+.railtwist:hover { color: var(--ink); }
+.railtwist svg { fill: none; stroke: currentColor; stroke-width: 2.2; transition: transform .12s; }
 .layer-drop {
   display: flex; flex-wrap: wrap; gap: 12px; min-height: 62px; align-content: flex-start;
   border-radius: 0; padding: 2px;
@@ -476,9 +673,27 @@ input.input[type="color"] { height: 34px; padding: 3px; cursor: pointer; }
   user-select: none;
 }
 .ccard:hover { border-color: var(--ink-3); }
+/* The cards were already tab stops — dnd-kit puts a role and a tabindex on every
+   draggable — but nothing drew the focus, so tabbing through the sheet moved an
+   invisible cursor. Offset outward: a 2 px ring inside the border would be read
+   as the teal selection frame. */
+.ccard:focus-visible { outline: 2px solid var(--brand); outline-offset: 2px; }
 .ccard.selected { border: 2px solid var(--brand); padding: 11px 12px; }
 .ccard.dragging { opacity: .35; cursor: grabbing; }
 .ccard.linktarget { border: 2px solid var(--brand); padding: 11px 12px; }
+/* A card the line being drawn already reaches. Said during the drag, in ink and
+   not in teal: teal is what you can act on, and dropping here does nothing new.
+   The check is what carries the meaning — the border alone would read as another
+   flavour of target. */
+.canvas.linking .ccard.linkdone { border: 1px dashed var(--ink-3); opacity: .55; }
+.canvas.linking .ccard.linkdone.linktarget {
+  border: 2px solid var(--ink); padding: 11px 12px; opacity: 1;
+}
+.canvas.linking .ccard.linkdone.linktarget::after {
+  content: "already linked"; position: absolute; bottom: -9px; right: 6px;
+  font-family: var(--mono); font-size: 9px; letter-spacing: .04em;
+  padding: 1px 5px; background: var(--ink); color: var(--panel);
+}
 .ccard .nh { display: flex; align-items: center; gap: 9px; }
 .ccard .ic { width: 20px; height: 20px; border-radius: 0; flex: none; display: grid; place-items: center; background: var(--c); }
 .ccard .ic svg { width: 12px; height: 12px; stroke: var(--on-fill); fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
@@ -663,6 +878,10 @@ input.input[type="color"] { height: 34px; padding: 3px; cursor: pointer; }
 
 .elist { border: 1px solid var(--line-2); border-radius: 0; background: var(--panel-2); }
 .elist.open { border-color: var(--ink-3); background: var(--panel); box-shadow: var(--shadow); }
+/* The row that answers the line you clicked on the canvas. Teal on the leading
+   edge only — the same selection colour as the edge itself, so the two read as
+   one thing seen from two places. */
+.elist.revealed { border-left: 2px solid var(--brand); }
 .elist-head { display: flex; align-items: center; gap: 4px; padding: 5px 6px 5px 4px; }
 .elist-name {
   flex: 1; min-width: 0; text-align: left; border: 0; background: transparent; font: inherit;
@@ -772,6 +991,52 @@ input.input[type="color"] { height: 34px; padding: 3px; cursor: pointer; }
 .modal-actions { display: flex; gap: 8px; justify-content: flex-end; margin-top: 18px; }
 .err { color: var(--danger); font-size: 12.5px; margin-top: 8px; }
 .dependency-sheet { width: min(620px, 100%); }
+
+/* A question, not a panel: narrower than the working dialogs so it reads as an
+   interruption to be answered and dismissed. Above them in the stack too — it is
+   always asked *from* one, and a history panel painting over its own confirm
+   would be a dead end. */
+.askmodal { width: min(440px, 100%); padding: 22px 24px; }
+.askmodal h2 { font-size: 18px; }
+.askmodal p.lede { margin: 0 0 4px; }
+.askmodal .field { margin-top: 14px; }
+.modal-scrim:has(> .askmodal) { z-index: 210; }
+/* Elsewhere `.btn.danger` only reddens on hover, which is right for a delete
+   sitting among other controls. Here it is one of two answers and the whole
+   point is to say which one is which, so it carries the colour at rest and
+   fills on the way to being pressed. */
+.askmodal .btn.danger { border-color: var(--danger); color: var(--danger); }
+.askmodal .btn.danger:hover, .askmodal .btn.danger:focus-visible {
+  background: var(--danger); border-color: var(--danger); color: var(--panel);
+}
+
+/* ---------- The finder (⌘K) ----------
+   Near the top rather than centred: the list grows downwards and a dialog that
+   re-centres itself on every keystroke is unreadable. */
+.finder-scrim { align-items: start; padding-top: 12vh; }
+.finder { width: min(560px, 100%); padding: 0; overflow: hidden; }
+.finder-input {
+  width: 100%; border: 0; border-bottom: 1px solid var(--line); background: transparent;
+  padding: 16px 18px; font: inherit; font-size: 15px; color: var(--ink); outline: none;
+}
+.finder-input::placeholder { color: var(--ink-3); }
+.finder-list { max-height: 46vh; overflow-y: auto; padding: 5px; }
+.finder-list button {
+  display: flex; align-items: center; gap: 10px; width: 100%; text-align: left; border: 0;
+  background: transparent; padding: 8px 11px; border-radius: 0; font: inherit; font-size: 13px;
+  color: var(--ink); cursor: pointer;
+}
+.finder-list button svg { flex: none; fill: none; stroke: currentColor; stroke-width: 1.9; }
+/* Teal marks the row you are about to act on — the same rule the canvas
+   selection follows. */
+.finder-list button[aria-selected="true"] { background: var(--brand); color: var(--on-fill); }
+.finder-name { font-weight: 600; flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.finder-where { font-family: var(--mono); font-size: 10px; color: var(--ink-3); flex: none; }
+.finder-list button[aria-selected="true"] .finder-where { color: var(--on-fill); opacity: .8; }
+.finder-foot {
+  border-top: 1px solid var(--line); padding: 8px 14px;
+  font-family: var(--mono); font-size: 10px; color: var(--ink-3); background: var(--panel-2);
+}
 .dependency-suggestion {
   display: flex; align-items: center; justify-content: space-between; gap: 16px;
   padding: 14px 0; border-top: 1px solid var(--line-2);
@@ -961,11 +1226,28 @@ input.input[type="color"] { height: 34px; padding: 3px; cursor: pointer; }
   position: absolute; top: 30px; right: 6px; background: var(--panel); border: 1px solid var(--ink);
   border-radius: 0; box-shadow: var(--shadow-lg); padding: 4px; z-index: 40; min-width: 168px;
 }
-.menu-pop button {
+.menu-pop button, .menu-pop a {
   display: flex; align-items: center; gap: 8px; width: 100%; text-align: left; border: 0;
   background: transparent; padding: 7px 10px; border-radius: 0; font-size: 12.5px; cursor: pointer; color: var(--ink);
 }
-.menu-pop button:hover { background: var(--panel-3); }
+.menu-pop a { text-decoration: none; }
+.menu-pop button:hover, .menu-pop a:hover { background: var(--panel-3); }
+/* Hung under the control that opened it rather than under a card's corner. */
+.menu-pop.under { top: calc(100% + 4px); right: 0; }
+/* Room for a line of explanation per entry: "HTML" and "JSON" side by side ask
+   the reader to already know which file they want. */
+.menu-pop.wide { min-width: 268px; }
+.menu-pop.wide svg { flex: none; align-self: flex-start; margin-top: 2px; }
+/* The PNG row is a button and every other row is an anchor, because a PNG is the
+   one export this app cannot hand over as a URL — it is assembled in the browser.
+   The two have to be indistinguishable in the list, so they share the rule. */
+.menu-pop.wide a, .menu-pop.wide button { align-items: flex-start; padding: 9px 11px; }
+.menu-pop button:disabled { cursor: default; color: var(--ink-3); }
+.menu-pop button:disabled:hover { background: transparent; }
+.menu-pop.wide em {
+  display: block; font-style: normal; font-size: 11px; color: var(--ink-3); margin-top: 2px;
+  line-height: 1.35;
+}
 .menu-pop button.danger { color: var(--danger); }
 .menu-pop svg { width: 14px; height: 14px; fill: none; stroke: currentColor; stroke-width: 1.9; stroke-linecap: round; }
 .menu-pop hr { border: 0; border-top: 1px solid var(--line); margin: 4px 0; }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -103,6 +103,13 @@
   --line-2: #DCE5EB;
   --line-3: #D3DEE5;         /* card edge on the calque ground */
 
+  /* The layer ramp — a separate palette from the scopes, and separate on
+     purpose: lower chroma, a wider arc including warm hues the scope circle
+     never reaches, and it appears only on a band's label and the rule under it,
+     never on a chip or a pill. Position is what keeps the two readings apart. */
+  --lt1: #5B7FA6; --lt2: #5E9070; --lt3: #9A8149;
+  --lt4: #A5735F; --lt5: #8474A8; --lt6: #4E8C93;
+
   --danger: #B3261E;
   --ok: #2E7D4F;
 
@@ -142,6 +149,10 @@ html[data-theme="dark"] {
   --line: #1C3549;
   --line-2: #274459;
   --line-3: #2F4E64;
+
+  /* The same six hues lifted onto the marine ground. */
+  --lt1: #8FB3D9; --lt2: #8FC7A2; --lt3: #CFB57E;
+  --lt4: #D6A492; --lt5: #B5A6D6; --lt6: #85C0C7;
 
   --danger: #FF8A80;
   --ok: #6FD39B;
@@ -430,7 +441,10 @@ input.input[type="color"] { height: 34px; padding: 3px; cursor: pointer; }
 }
 
 .layer {
-  position: relative; z-index: 2; padding: 14px 0 8px; border-bottom: 1px dashed var(--line-3);
+  position: relative; z-index: 2; padding: 14px 0 8px;
+  /* `--lc` is the band's tint, set by the renderer; the fallback is what the
+     rule was before, so turning tints off is the absence of this look. */
+  border-bottom: 1px dashed color-mix(in srgb, var(--lc, var(--line-3)) 42%, var(--line-3));
   border-radius: 0; transition: background .12s;
 }
 .layer:last-child { border-bottom: 0; }
@@ -438,7 +452,7 @@ input.input[type="color"] { height: 34px; padding: 3px; cursor: pointer; }
 .layer-head { display: flex; align-items: center; gap: 9px; margin-bottom: 10px; }
 .layer-head b {
   font-family: var(--mono); font-size: 10px; letter-spacing: .06em; text-transform: capitalize;
-  color: var(--ink-3); font-weight: 400;
+  color: var(--lc, var(--ink-3)); font-weight: 400;
 }
 .layer-head em { font-style: normal; font-family: var(--mono); font-size: 10px; color: var(--ink-3); opacity: .8; }
 .layer-head .layer-tools { margin-left: auto; display: none; gap: 2px; }

--- a/src/app/projects/[id]/document/PaperDocument.tsx
+++ b/src/app/projects/[id]/document/PaperDocument.tsx
@@ -19,7 +19,7 @@ import Link from 'next/link';
 import { Icon } from '@/components/Icon';
 import { Mark, Wordmark } from '@/components/Brand';
 import { PALETTE } from '@/lib/defaults';
-import { displayLayerLabel } from '@/lib/layers';
+import { displayLayerLabel, layerTintEnabled, layerTintVar } from '@/lib/layers';
 import {
   dashFor, describeLink, edgeLabelSvg, edgePlateText, kindsInUse, LINK_DASH, LINK_KIND_LABELS,
   linkOf, protocolConvention, protocolNote
@@ -400,8 +400,12 @@ function PaperDiagram({ doc, lang }: { doc: Architecture; lang: 'en' | 'fr' }) {
       <div ref={stage} className="paper-stage">
         <svg className="paper-edges" viewBox={`0 0 ${STAGE_W} ${height || 1}`}
           width={STAGE_W} height={height} dangerouslySetInnerHTML={{ __html: edges }} />
-        {doc.layers.map(layer => (
-          <div className="paper-layer" key={layer.id}>
+        {doc.layers.map((layer, i) => (
+          /* Only the index travels: the six values live in `document.css`, which
+             is what makes the printed band agree with the screen one. */
+          <div className="paper-layer" key={layer.id}
+            style={layerTintEnabled(doc.ui.architecture)
+              ? { ['--lc' as string]: layerTintVar(i) } : undefined}>
             <div className="paper-layer-head">
               <b>{displayLayerLabel(layer.name)}</b>{layer.desc && <em>{layer.desc}</em>}
             </div>

--- a/src/app/projects/[id]/document/document.css
+++ b/src/app/projects/[id]/document/document.css
@@ -90,6 +90,11 @@ a.paper-btn { border-bottom-width: 1px; }
   --ink: #0B1B2B;
   --ink-2: #3D566B;
   --ink-3: #8CA1B2;
+
+  /* The layer ramp, transposed from the screen unchanged — a label and a
+     hairline are exactly the two things a print can still carry. */
+  --lt1: #5B7FA6; --lt2: #5E9070; --lt3: #9A8149;
+  --lt4: #A5735F; --lt5: #8474A8; --lt6: #4E8C93;
   --line: #E7EEF2;
   --line-2: #DCE5EB;
   --line-3: #D3DEE5;
@@ -275,12 +280,15 @@ a.paper-btn { border-bottom-width: 1px; }
 .paper-edges { position: absolute; inset: 0; pointer-events: none; }
 
 /* `.layer` / `.layer-head` / `.nodes` */
-.paper-layer { position: static; padding: 16px 0 6px; border-bottom: 1px dashed var(--line-3); }
+.paper-layer {
+  position: static; padding: 16px 0 6px;
+  border-bottom: 1px dashed color-mix(in srgb, var(--lc, var(--line-3)) 42%, var(--line-3));
+}
 .paper-layer:last-child { border-bottom: 0; }
 .paper-layer-head { display: flex; align-items: center; gap: 10px; margin-bottom: 12px; }
 .paper-layer-head b {
   font-family: var(--mono); font-size: 10px; letter-spacing: .06em; text-transform: capitalize;
-  color: var(--ink-3); font-weight: 400;
+  color: var(--lc, var(--ink-3)); font-weight: 400;
 }
 .paper-layer-head em { font-style: normal; font-family: var(--mono); font-size: 10px; color: var(--ink-3); opacity: .8; }
 .paper-layer-row { display: flex; flex-wrap: wrap; gap: 12px; }

--- a/src/components/Ask.tsx
+++ b/src/components/Ask.tsx
@@ -1,0 +1,209 @@
+'use client';
+
+/* The two questions the browser answers badly.
+ *
+ * `confirm()` and `prompt()` are not merely ugly. They block the page, they
+ * cannot be styled or read in the document's own voice, they truncate anything
+ * longer than a sentence, they are suppressible by the browser after a few
+ * uses, and `prompt()` returns exactly one unvalidated string — which is why
+ * every creation in this app used to arrive half-built and need a second visit
+ * to a rail to finish. They also cannot say *which* answer is the dangerous one.
+ *
+ * This is the same two questions, asked in the studio's own frame. The hook
+ * hands back a promise so a call site stays one line and keeps the shape it had:
+ *
+ *   if (!await ask.confirm({ title: 'Delete "Payments"?' })) return;
+ *   const name = await ask.text({ title: 'New folder', label: 'Name' });
+ *
+ * A promise rather than a callback because that is what `confirm()` was: the
+ * next statement is the "yes" branch. Nothing else about the surrounding code
+ * has to move.
+ *
+ * When to reach for it: an action that leaves the document — deleting a project,
+ * a folder, a version, a shared pattern. Anything that only edits the document
+ * should not ask at all. The editor keeps an undo stack and a notice bar, and a
+ * confirm there taxes every deliberate edit to insure against the rare mistaken
+ * one. See `NoticeBar` in Editor.tsx. */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+export interface ConfirmRequest {
+  title: string;
+  /** What the reader needs before answering. Prose, not a repeat of the title. */
+  body?: React.ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  /** Draws the confirming button as a deletion. Say so when it is one. */
+  danger?: boolean;
+}
+
+export interface TextRequest {
+  title: string;
+  body?: React.ReactNode;
+  label: string;
+  value?: string;
+  placeholder?: string;
+  confirmLabel?: string;
+  /** An empty answer is a real answer — clearing a version's name is how it
+   *  becomes an ordinary snapshot again. Off by default: everywhere else an
+   *  empty name is a cancel, not a thing called "". */
+  allowEmpty?: boolean;
+}
+
+type Pending =
+  | { kind: 'confirm'; req: ConfirmRequest }
+  | { kind: 'text'; req: TextRequest };
+
+export interface Ask {
+  /** Render this anywhere inside the component that owns the hook — it portals
+   *  itself to the body, so where it sits in the markup does not matter. */
+  dialog: React.ReactNode;
+  confirm: (req: ConfirmRequest) => Promise<boolean>;
+  /** The answer, or null when cancelled — the same distinction `prompt()` made
+   *  between "" and null, and the reason `allowEmpty` exists. */
+  text: (req: TextRequest) => Promise<string | null>;
+}
+
+export function useAsk(): Ask {
+  const [pending, setPending] = useState<Pending | null>(null);
+  /* The resolver lives in a ref rather than beside the request in state: calling
+   * it from inside a state updater would fire twice under StrictMode's double
+   * invoke, and a settled promise swallowing the second call is luck, not
+   * design. */
+  const resolver = useRef<((value: never) => void) | null>(null);
+
+  const open = useCallback(<T,>(next: Pending) => new Promise<T>(resolve => {
+    /* A question still on screen is answered "cancelled" rather than left
+     * hanging: an unresolved promise is a click that never finishes. */
+    resolver.current?.(null as never);
+    resolver.current = resolve as (value: never) => void;
+    setPending(next);
+  }), []);
+
+  const settle = useCallback((value: boolean | string | null) => {
+    const resolve = resolver.current;
+    resolver.current = null;
+    setPending(null);
+    resolve?.(value as never);
+  }, []);
+
+  const confirm = useCallback(
+    (req: ConfirmRequest) => open<boolean>({ kind: 'confirm', req }), [open]);
+  const text = useCallback(
+    (req: TextRequest) => open<string | null>({ kind: 'text', req }), [open]);
+
+  /* Portalled to the body, and not as a nicety.
+   *
+   * A dialog is `position: fixed`, which sounds like it escapes its ancestors —
+   * it does not. An ancestor with `opacity` below 1, a `transform`, or a `filter`
+   * becomes the containing block *and* the compositing group for everything
+   * inside it. The project card's ⋯ menu is `opacity: 0` until the card is
+   * hovered, so a confirm rendered under it was painted at zero opacity the
+   * moment the pointer left the card to reach the dialog: still there, still
+   * clickable, completely invisible. The body has no such ancestor, and putting
+   * every dialog there means no call site has to know which of its parents is
+   * animated.
+   *
+   * `pending` is null on the first render, so there is no portal during SSR and
+   * nothing to mismatch at hydration. */
+  let dialog: React.ReactNode = null;
+  if (pending && typeof document !== 'undefined') {
+    dialog = createPortal(
+      pending.kind === 'confirm'
+        ? <ConfirmDialog req={pending.req} onSettle={settle} />
+        : <TextDialog req={pending.req} onSettle={settle} />,
+      document.body
+    );
+  }
+
+  return { dialog, confirm, text };
+}
+
+/* ------------------------------------------------------------------- shells */
+
+/** Escape and the scrim both cancel, on both dialogs — the two ways out anyone
+ *  tries, and the two `confirm()` already had. */
+function useDismiss(onCancel: () => void) {
+  useEffect(() => {
+    const esc = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      e.stopPropagation();
+      onCancel();
+    };
+    document.addEventListener('keydown', esc);
+    return () => document.removeEventListener('keydown', esc);
+  }, [onCancel]);
+}
+
+function ConfirmDialog({ req, onSettle }: {
+  req: ConfirmRequest; onSettle: (v: boolean) => void;
+}) {
+  const go = useRef<HTMLButtonElement>(null);
+  useDismiss(useCallback(() => onSettle(false), [onSettle]));
+  /* Focus lands on the confirming button because that is the answer the reader
+   * came for; Escape and the scrim are the other one, and both are one key or
+   * one click away. */
+  useEffect(() => { go.current?.focus(); }, []);
+
+  return (
+    /* Stopped rather than merely handled: a React portal still bubbles its
+       events through the React tree, so without this a click on this scrim
+       would also reach the panel that asked the question and close it. */
+    <div className="modal-scrim" onPointerDown={e => e.stopPropagation()}
+      onClick={e => { e.stopPropagation(); onSettle(false); }}>
+      <div className="modal askmodal" role="alertdialog" aria-label={req.title}
+        onClick={e => e.stopPropagation()}>
+        <h2>{req.title}</h2>
+        {req.body && <p className="lede">{req.body}</p>}
+        <div className="modal-actions">
+          <button type="button" className="btn ghost" onClick={() => onSettle(false)}>
+            {req.cancelLabel ?? 'Cancel'}
+          </button>
+          <button type="button" ref={go}
+            className={`btn ${req.danger ? 'danger' : 'primary'}`}
+            onClick={() => onSettle(true)}>
+            {req.confirmLabel ?? (req.danger ? 'Delete' : 'Continue')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TextDialog({ req, onSettle }: {
+  req: TextRequest; onSettle: (v: string | null) => void;
+}) {
+  const [value, setValue] = useState(req.value ?? '');
+  const field = useRef<HTMLInputElement>(null);
+  useDismiss(useCallback(() => onSettle(null), [onSettle]));
+  useEffect(() => { field.current?.select(); }, []);
+
+  const ok = req.allowEmpty || !!value.trim();
+  const submit = () => {
+    if (!ok) { field.current?.focus(); return; }
+    onSettle(value.trim());
+  };
+
+  return (
+    <div className="modal-scrim" onPointerDown={e => e.stopPropagation()}
+      onClick={e => { e.stopPropagation(); onSettle(null); }}>
+      <div className="modal askmodal" role="dialog" aria-label={req.title}
+        onClick={e => e.stopPropagation()}>
+        <h2>{req.title}</h2>
+        {req.body && <p className="lede">{req.body}</p>}
+        <label className="field"><span>{req.label}</span>
+          <input className="input" ref={field} value={value} placeholder={req.placeholder}
+            onChange={e => setValue(e.target.value)}
+            onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); submit(); } }} />
+        </label>
+        <div className="modal-actions">
+          <button type="button" className="btn ghost" onClick={() => onSettle(null)}>Cancel</button>
+          <button type="button" className="btn primary" onClick={submit} disabled={!ok}>
+            {req.confirmLabel ?? 'Save'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ContentEditor.tsx
+++ b/src/components/ContentEditor.tsx
@@ -13,6 +13,7 @@ import StackEditor from './editors/StackEditor';
 import SectionsEditor from './editors/SectionsEditor';
 import { tabRows } from '@/lib/tabs';
 import type { LegoCatalogSnapshot } from '@/lib/lego/types';
+import type { Notify } from '@/lib/undo';
 import type { Architecture } from '@/lib/types';
 
 type Patch = (fn: (d: Architecture) => Architecture) => void;
@@ -26,7 +27,9 @@ const PANELS: { id: PanelId; label: string; icon: string; count?: (d: Architectu
   { id: 'sections', label: 'Sections', icon: 'folder', count: d => d.sections.length }
 ];
 
-export default function ContentEditor({ doc, patch, catalog }: { doc: Architecture; patch: Patch; catalog: LegoCatalogSnapshot | null }) {
+export default function ContentEditor({ doc, patch, catalog, notify }: {
+  doc: Architecture; patch: Patch; catalog: LegoCatalogSnapshot | null; notify: Notify;
+}) {
   const [panel, setPanel] = useState<PanelId>('document');
 
   return (
@@ -54,7 +57,7 @@ export default function ContentEditor({ doc, patch, catalog }: { doc: Architectu
         {panel === 'tabs' && <TabsEditor doc={doc} patch={patch} />}
         {panel === 'flows' && <FlowsEditor doc={doc} patch={patch} catalog={catalog} />}
         {panel === 'stack' && <StackEditor doc={doc} patch={patch} />}
-        {panel === 'sections' && <SectionsEditor doc={doc} patch={patch} />}
+        {panel === 'sections' && <SectionsEditor doc={doc} patch={patch} notify={notify} />}
       </div>
     </div>
   );

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -13,7 +13,7 @@ import History from './History';
 import PlacementWizard from './editors/PlacementWizard';
 import { EnrichDialog, useAiStatus } from './Analyse';
 import { PALETTE, PALETTE_DARK, slugify } from '@/lib/defaults';
-import { displayLayerLabel } from '@/lib/layers';
+import { displayLayerLabel, layerTintEnabled, layerTintVar } from '@/lib/layers';
 import { ensurePlacementScaffold, componentBrick } from '@/lib/lego/place';
 import { syncTechnologies } from '@/lib/lego/stack';
 import { loadLegoCatalog } from '@/lib/lego/client';
@@ -632,22 +632,25 @@ function Canvas({ doc, selected, setSelected, hoverTarget, linking, onStartLink,
           No layers yet — add a layer in the palette, or place a brick (it creates the layer it needs).
         </div>
       )}
-      {doc.layers.map(layer => (
+      {doc.layers.map((layer, i) => (
         <LayerRow key={layer.id} layer={layer} doc={doc} patch={patch}
           selected={selected} setSelected={setSelected} hoverTarget={hoverTarget}
-          onStartLink={onStartLink} groupColor={groupColor} plan={plan} />
+          onStartLink={onStartLink} groupColor={groupColor} plan={plan} index={i} />
       ))}
     </div>
   );
 }
 
-function LayerRow({ layer, doc, patch, selected, setSelected, hoverTarget, onStartLink, groupColor, plan }: {
+function LayerRow({
+  layer, doc, patch, selected, setSelected, hoverTarget, onStartLink, groupColor, plan, index
+}: {
   layer: { id: string; name: string; desc?: string };
   doc: Architecture; patch: (fn: (d: Architecture) => Architecture) => void;
   selected: string | null; setSelected: (id: string | null) => void; hoverTarget: string | null;
   onStartLink: (id: string, x: number, y: number) => void;
   groupColor: (id: string) => { light: string; dark: string };
   plan: BandPlan | null;
+  index: number;
 }) {
   const { setNodeRef, isOver } = useDroppable({ id: `layer:${layer.id}` });
   const items = doc.components.filter(c => c.layer === layer.id);
@@ -658,8 +661,15 @@ function LayerRow({ layer, doc, patch, selected, setSelected, hoverTarget, onSta
       onSelect={() => setSelected(c.id)} onStartLink={onStartLink} />
   );
 
+  /* Only the index travels: the six values live in the stylesheet, which is what
+   * makes them follow the theme without a second table in here. Off emits no
+   * property and every rule falls back to the neutral it had before. */
+  const tint = layerTintEnabled(doc.ui.architecture)
+    ? { ['--lc' as string]: layerTintVar(index) }
+    : undefined;
+
   return (
-    <div className={`layer${isOver ? ' over' : ''}`}>
+    <div className={`layer${isOver ? ' over' : ''}`} style={tint}>
       <div className="layer-head">
         <b>{displayLayerLabel(layer.name)}</b>
         {layer.desc && <em>{layer.desc}</em>}

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -3,8 +3,9 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import {
-  DndContext, DragOverlay, PointerSensor, useSensor, useSensors,
-  useDraggable, useDroppable, type DragEndEvent, type DragStartEvent
+  DndContext, DragOverlay, PointerSensor, pointerWithin, rectIntersection,
+  useDndContext, useDraggable, useDroppable, useSensor, useSensors,
+  type CollisionDetection, type DragEndEvent, type DragStartEvent
 } from '@dnd-kit/core';
 import { Icon } from './Icon';
 import Inspector from './Inspector';
@@ -12,7 +13,8 @@ import ContentEditor from './ContentEditor';
 import History from './History';
 import PlacementWizard from './editors/PlacementWizard';
 import { EnrichDialog, useAiStatus } from './Analyse';
-import { PALETTE, PALETTE_DARK, slugify } from '@/lib/defaults';
+import { deleteComponent, PALETTE, PALETTE_DARK, slugify } from '@/lib/defaults';
+import { withDrawioXml } from '@/lib/export/png';
 import { displayLayerLabel, layerTintEnabled, layerTintVar } from '@/lib/layers';
 import { ensurePlacementScaffold, componentBrick } from '@/lib/lego/place';
 import { syncTechnologies } from '@/lib/lego/stack';
@@ -33,20 +35,74 @@ import {
   type BandPlan, type Box, type ZoneKind
 } from '@/lib/zones';
 import { protocolLabel, suggestedLinkForBrick } from '@/lib/lego/protocols';
-import type { Architecture, Component, ProjectWithData } from '@/lib/types';
+import {
+  canRedo, canUndo, initUndo, record, redo as redoStep, typingInField, undo as undoStep,
+  type Notify
+} from '@/lib/undo';
+import {
+  anchoredScroll, clampZoom, fitLadder, zoomStyle, ZOOM_MIN, ZOOM_STEP, type ZoomStyle
+} from '@/lib/viewport';
+import { isArrowKey, searchComponents, stepSelection } from '@/lib/navigate';
+import {
+  bandDropId, DEPTH, dropChangesAnything, layerDropId, PALETTE_NEW, railZoneDropId, resolveDrop
+} from '@/lib/dnd';
+import type { Architecture, Component, ProjectWithData, Zone } from '@/lib/types';
+
+/* Which of the boxes under the pointer is meant.
+ *
+ * A card is inside a band and a band is inside a row, so a release always has
+ * two or three true answers. dnd-kit's default ranks them by how much of the
+ * dragged rectangle each one overlaps, and the row — being the largest — wins
+ * nearly every time; that is why dropping a card *onto another card* to place
+ * it worked at all only by accident, and why the row never lit up while you
+ * dragged over it.
+ *
+ * `pointerWithin` narrows to what is actually under the pointer, and `DEPTH`
+ * settles the nesting explicitly rather than by geometry. The rect fallback is
+ * for the pointer being outside every target — dragging above the first layer,
+ * say — where some answer is better than none. */
+const preferInnermost: CollisionDetection = args => {
+  const hits = pointerWithin(args);
+  const pool = hits.length ? hits : rectIntersection(args);
+  if (!pool.length) return pool;
+  const depthOf = (c: (typeof pool)[number]) =>
+    Number(c.data?.droppableContainer?.data?.current?.depth ?? DEPTH.component);
+  const best = Math.max(...pool.map(depthOf));
+  return pool.filter(c => depthOf(c) === best);
+};
 
 type SaveState = 'saved' | 'dirty' | 'saving' | 'error';
 type Mode = 'edit' | 'content' | 'preview';
+/** One dependency, named by its two ends — `deps` is the single source of truth
+ *  for whether it exists, so there is no id to point at. */
+type EdgeRef = { from: string; to: string };
 
 export default function Editor({ project }: { project: ProjectWithData }) {
   const router = useRouter();
-  const [doc, setDoc] = useState<Architecture>(project.data);
+  /* The document lives inside its undo stack rather than beside it: there is no
+   * Save button here, so `doc` and "the state you can come back to" have to be
+   * the same object or they drift the first time an edit lands from a dialog. */
+  const [stack, setStack] = useState(() => initUndo(project.data));
+  const doc = stack.present;
+  const [notice, setNotice] = useState<Notice | null>(null);
   const [name, setName] = useState(project.name);
   const [save, setSave] = useState<SaveState>('saved');
   const [selected, setSelected] = useState<string | null>(null);
   const [mode, setMode] = useState<Mode>('edit');
   const [dragId, setDragId] = useState<string | null>(null);
   const [link, setLink] = useState<{ from: string; x: number; y: number } | null>(null);
+  /* A dependency is selected apart from its endpoints: clicking the line has to
+   * mean the line, not "the caller, again". The caller is selected alongside it,
+   * because that is where the fields live. */
+  const [selectedEdge, setSelectedEdge] = useState<EdgeRef | null>(null);
+  const [finder, setFinder] = useState(false);
+  /* When the last dependency drag ended. See `clearSelection`. */
+  const linkEndedAt = useRef(0);
+  /* The sheet's scale, mirrored up out of the stage for one reason: the drag
+   * overlay is rendered at the context level, outside the element the zoom is
+   * applied to, so at 40 % you would be dragging a card two and a half times the
+   * size of the ones you are aiming between. */
+  const [sheetZoom, setSheetZoom] = useState(1);
   const [hoverTarget, setHoverTarget] = useState<string | null>(null);
   const [history, setHistory] = useState(false);
   const [enrich, setEnrich] = useState(false);
@@ -98,15 +154,178 @@ export default function Editor({ project }: { project: ProjectWithData }) {
   }, [save]);
 
   const patch = useCallback((fn: (d: Architecture) => Architecture) => {
-    setDoc(d => fn(structuredClone(d)));
+    setStack(s => record(s, fn(structuredClone(s.present)), Date.now()));
+  }, []);
+
+  /* A restore or an enrichment arrives whole, and it is always its own step —
+   * the cleared stamp is what says so, rather than trusting that the dialog took
+   * longer than the coalescing window to fill in. */
+  const adopt = useCallback((next: Architecture) => {
+    setStack(s => record({ ...s, stamp: -Infinity }, next, Date.now()));
+  }, []);
+
+  /* ------------------------------------------------------------ undo, redo */
+  const undo = useCallback(() => { setStack(undoStep); setNotice(null); }, []);
+  const redo = useCallback(() => { setStack(redoStep); setNotice(null); }, []);
+
+  /* One place says what just happened and offers the way back, so a delete does
+   * not need its own confirm to be safe — the step is already on the stack. */
+  const notify = useCallback<Notify>(
+    (text, undoable = true) => setNotice({ text, id: Date.now(), undoable }), []);
+
+  useEffect(() => {
+    const h = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey)) return;
+      const key = e.key.toLowerCase();
+      if (key !== 'z' && key !== 'y') return;
+      /* A text field has its own history and the browser's restores the caret,
+       * which ours cannot. Inside one, stand back. */
+      if (typingInField(e.target)) return;
+      e.preventDefault();
+      if (key === 'y' || e.shiftKey) redo(); else undo();
+    };
+    window.addEventListener('keydown', h);
+    return () => window.removeEventListener('keydown', h);
+  }, [undo, redo]);
+
+  /* Stepping back over the creation of a component — or over anything that
+   * removed one — leaves the inspector pointed at an id that is gone. */
+  useEffect(() => {
+    setSelected(s => (s && !doc.components.some(c => c.id === s) ? null : s));
+    setSelectedEdge(e =>
+      (e && doc.components.find(c => c.id === e.from)?.deps?.includes(e.to) ? e : null));
+  }, [doc.components]);
+
+  /* Selecting another card drops the line: the two are one selection with two
+   * shapes, and leaving a highlighted edge behind an unrelated card reads as a
+   * bug rather than as memory. */
+  useEffect(() => {
+    setSelectedEdge(e => (e && e.from === selected ? e : null));
+  }, [selected]);
+
+  const selectEdge = useCallback((from: string, to: string) => {
+    setSelected(from);
+    setSelectedEdge({ from, to });
+  }, []);
+
+  /* Clicking the paper clears the selection — except in the instant after a
+   * dependency drag.
+   *
+   * A press on one card and a release on another dispatches its click on the two
+   * cards' nearest common ancestor, and for cards in different layers that is the
+   * sheet itself. The gesture therefore ended by selecting the edge it had just
+   * drawn and then immediately deselecting it, with nothing on screen to say why.
+   * Suppressing by time rather than by swallowing the next click: a drag that
+   * ends over nothing produces no click at all, and a one-shot listener left
+   * armed would eat an unrelated one later. */
+  const clearSelection = useCallback(() => {
+    if (Date.now() - linkEndedAt.current < 300) return;
+    setSelected(null);
+    setSelectedEdge(null);
+  }, []);
+
+  const dropEdge = useCallback((edge: EdgeRef) => {
+    const names = (id: string) => doc.components.find(c => c.id === id)?.name ?? id;
+    patch(d => {
+      const caller = d.components.find(c => c.id === edge.from);
+      if (caller) {
+        caller.deps = (caller.deps || []).filter(x => x !== edge.to);
+        caller.links = (caller.links || []).filter(l => l.to !== edge.to);
+      }
+      return d;
+    });
+    notify(`${names(edge.from)} → ${names(edge.to)} removed`);
+    setSelectedEdge(null);
+  }, [doc.components, patch, notify]);
+
+  const dropComponent = useCallback((id: string) => {
+    const gone = doc.components.find(c => c.id === id);
+    if (!gone) return;
+    patch(d => { deleteComponent(d, id); return d; });
+    notify(`"${gone.name}" deleted — dependencies pointing at it went with it`);
+  }, [doc.components, patch, notify]);
+
+  /* The canvas keyboard, in one handler.
+   *
+   * Delete and Escape are global — they need a selection, not a focused element,
+   * because the thing you just clicked is the thing you mean, wherever the focus
+   * drifted to. The arrows are not: they only move when a card actually holds
+   * focus, or they would take the arrow keys away from scrolling the sheet.
+   *
+   * `linkFrom`/dialogs are deliberately not consulted here. A modal traps its own
+   * Escape and a drag ends on pointerup; adding either as a condition would be a
+   * second source of truth for what is going on.
+   *
+   * The mode is consulted, though. A selection survives a switch to the Content
+   * tab, and Delete there — with the canvas nowhere on screen — would remove a
+   * component the author cannot see. Undo would have it back, but only once they
+   * noticed. */
+  useEffect(() => {
+    if (mode !== 'edit') return;
+    const h = (e: KeyboardEvent) => {
+      if (typingInField(e.target)) return;
+
+      if (e.key === 'Escape') {
+        if (selectedEdge) { setSelectedEdge(null); return; }
+        if (selected) { setSelected(null); return; }
+        return;
+      }
+
+      if (e.key === 'Delete' || e.key === 'Backspace') {
+        if (selectedEdge) { e.preventDefault(); dropEdge(selectedEdge); return; }
+        if (selected) { e.preventDefault(); dropComponent(selected); }
+        return;
+      }
+
+      if (isArrowKey(e.key)) {
+        const card = (e.target as HTMLElement | null)?.closest?.('[data-comp]') as HTMLElement | null;
+        if (!card?.dataset.comp) return;
+        const next = stepSelection(doc, card.dataset.comp, e.key);
+        if (!next) return;
+        e.preventDefault();
+        setSelected(next);
+        /* Focus follows the selection, or the next arrow would start over from
+         * the card that has been left behind. */
+        const node = document.querySelector<HTMLElement>(`[data-comp="${CSS.escape(next)}"]`);
+        node?.focus();
+        node?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+      }
+    };
+    window.addEventListener('keydown', h);
+    return () => window.removeEventListener('keydown', h);
+  }, [mode, doc, selected, selectedEdge, dropEdge, dropComponent]);
+
+  /* ⌘K opens the finder. Bound apart from the handler above because this one has
+   * to fire while a text field has focus — that is most of when you want it. It
+   * picks a card on the sheet, so it belongs to the tab that has one. */
+  useEffect(() => {
+    if (mode !== 'edit') return;
+    const h = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey) || e.key.toLowerCase() !== 'k') return;
+      e.preventDefault();
+      setFinder(true);
+    };
+    window.addEventListener('keydown', h);
+    return () => window.removeEventListener('keydown', h);
+  }, [mode]);
+
+  const revealComponent = useCallback((id: string) => {
+    setSelected(id);
+    setFinder(false);
+    /* After the render that may have had to un-fade or re-lay-out the card. */
+    requestAnimationFrame(() => {
+      const node = document.querySelector<HTMLElement>(`[data-comp="${CSS.escape(id)}"]`);
+      node?.scrollIntoView({ block: 'center', inline: 'center' });
+      node?.focus();
+    });
   }, []);
 
   /* ------------------------------------------------------------ mutations */
-  const addComponent = useCallback((layerId: string, index?: number) => {
+  const addComponent = useCallback((layerId: string, index?: number, zone?: string) => {
     const id = slugify('component', doc.components.map(c => c.id));
     const groupId = doc.groups[0]?.id || 'product';
     const comp: Component = {
-      id, name: 'New component', group: groupId, layer: layerId,
+      id, name: 'New component', group: groupId, layer: layerId, zone,
       icon: 'box', tech: [], features: [], notes: [], deps: []
     };
     patch(d => {
@@ -165,37 +384,53 @@ export default function Editor({ project }: { project: ProjectWithData }) {
     setPlacementRequest(null);
   }, [acceptSuggestedLink, catalog, doc.meta.lang, placeBrick, placementRequest]);
 
-  const moveComponent = useCallback((id: string, layerId: string, beforeId?: string) => {
-    patch(d => {
-      const i = d.components.findIndex(c => c.id === id);
-      if (i < 0) return d;
-      const [comp] = d.components.splice(i, 1);
-      comp.layer = layerId;
-      const at = beforeId ? d.components.findIndex(c => c.id === beforeId) : -1;
-      if (at >= 0) d.components.splice(at, 0, comp);
-      else d.components.push(comp);
-      return d;
-    });
-  }, [patch]);
+  /* The zone travels with the layer. It has to: a card is drawn inside whatever
+   * rectangle its band belongs to, so a move that changed the row and left the
+   * zone behind would put the drawing and the document at odds. `undefined` is
+   * a real value here — it is how a card leaves a zone. */
+  const moveComponent = useCallback(
+    (id: string, layerId: string, zone: string | undefined, beforeId?: string) => {
+      patch(d => {
+        const i = d.components.findIndex(c => c.id === id);
+        if (i < 0) return d;
+        const [comp] = d.components.splice(i, 1);
+        comp.layer = layerId;
+        comp.zone = zone;
+        const at = beforeId ? d.components.findIndex(c => c.id === beforeId) : -1;
+        if (at >= 0) d.components.splice(at, 0, comp);
+        else d.components.push(comp);
+        return d;
+      });
+    }, [patch]);
 
+  /* Dropping the handle on a card that is already the target used to *remove* the
+   * dependency. It reads as a toggle in the code and as a data loss at the desk:
+   * the gesture people make when they think the first drag missed is the same
+   * gesture, and it silently undid the link they were trying to draw. A line that
+   * exists is now selected rather than destroyed — the delete is the trash on its
+   * row, or Delete once it is selected, both of which say what they do. */
   const addDep = useCallback((from: string, to: string) => {
     if (from === to) return;
+    const caller = doc.components.find(x => x.id === from);
+    if (!caller) return;
+    const nameOf = (id: string) => doc.components.find(c => c.id === id)?.name ?? id;
+
+    if ((caller.deps || []).includes(to)) {
+      selectEdge(from, to);
+      notify(`${caller.name} already depends on ${nameOf(to)} — its line is selected on the right`, false);
+      return;
+    }
     patch(d => {
       const c = d.components.find(x => x.id === from);
       const callee = d.components.find(x => x.id === to);
       if (!c) return d;
-      c.deps = c.deps || [];
-      if (c.deps.includes(to)) {
-        c.deps = c.deps.filter(x => x !== to);
-        c.links = (c.links || []).filter(link => link.to !== to);
-      } else {
-        c.deps.push(to);
-        const suggestion = suggestedLinkForBrick(componentBrick(callee || {}));
-        c.links = [...(c.links || []).filter(link => link.to !== to), { to, ...suggestion }];
-      }
+      c.deps = [...(c.deps || []), to];
+      const suggestion = suggestedLinkForBrick(componentBrick(callee || {}));
+      c.links = [...(c.links || []).filter(link => link.to !== to), { to, ...suggestion }];
       return d;
     });
-  }, [patch]);
+    selectEdge(from, to);
+  }, [doc.components, patch, notify, selectEdge]);
 
   /* -------------------------------------------------------------- linking */
   useEffect(() => {
@@ -211,6 +446,7 @@ export default function Editor({ project }: { project: ProjectWithData }) {
       const el = document.elementFromPoint(e.clientX, e.clientY) as HTMLElement | null;
       const card = el?.closest('[data-comp]') as HTMLElement | null;
       if (card?.dataset.comp) addDep(link.from, card.dataset.comp);
+      linkEndedAt.current = Date.now();
       setLink(null); setHoverTarget(null);
     };
     window.addEventListener('pointermove', move);
@@ -221,22 +457,29 @@ export default function Editor({ project }: { project: ProjectWithData }) {
   /* ----------------------------------------------------------------- dnd */
   function onDragEnd(e: DragEndEvent) {
     setDragId(null);
-    const active = String(e.active.id);
-    const over = e.over ? String(e.over.id) : null;
-    if (!over) return;
+    const drop = resolveDrop(doc, String(e.active.id), e.over ? String(e.over.id) : null);
+    /* A release that would leave the document exactly as it is stops here rather
+     * than writing a step you would have to undo to get back to where you
+     * already were. */
+    if (!drop || !dropChangesAnything(doc, drop)) return;
 
-    const targetLayer = over.startsWith('layer:')
-      ? over.slice(6)
-      : doc.components.find(c => c.id === over)?.layer;
-    if (!targetLayer) return;
-    const beforeId = over.startsWith('layer:') ? undefined : over;
-
-    if (active === 'palette:new') {
-      const idx = beforeId ? doc.components.findIndex(c => c.id === beforeId) : undefined;
-      addComponent(targetLayer, idx);
+    if (!drop.componentId) {
+      const at = drop.before ? doc.components.findIndex(c => c.id === drop.before) : undefined;
+      addComponent(drop.layer, at, drop.zone);
       return;
     }
-    if (active !== beforeId) moveComponent(active, targetLayer, beforeId);
+    moveComponent(drop.componentId, drop.layer, drop.zone, drop.before);
+
+    /* Only a change of zone is announced. Moving between rows is visible the
+     * instant it happens; a zone is a rectangle in the background, and a card
+     * that quietly joined or left one is exactly the edit worth a sentence. */
+    const was = doc.components.find(c => c.id === drop.componentId);
+    if (was && (was.zone ?? undefined) !== drop.zone) {
+      const nameOf = (id: string) => doc.zones.find(z => z.id === id)?.name ?? id;
+      notify(drop.zone
+        ? `"${was.name}" moved into ${nameOf(drop.zone)}`
+        : `"${was.name}" left ${was.zone ? nameOf(was.zone) : 'its zone'}`);
+    }
   }
 
   const selectedComp = doc.components.find(c => c.id === selected) || null;
@@ -247,7 +490,7 @@ export default function Editor({ project }: { project: ProjectWithData }) {
   }, [doc.groups]);
 
   return (
-    <DndContext sensors={sensors}
+    <DndContext sensors={sensors} collisionDetection={preferInnermost}
       onDragStart={(e: DragStartEvent) => setDragId(String(e.active.id))}
       onDragEnd={onDragEnd} onDragCancel={() => setDragId(null)}>
       <div className="shell">
@@ -259,6 +502,15 @@ export default function Editor({ project }: { project: ProjectWithData }) {
             <input className="name" value={name} onChange={e => setName(e.target.value)}
               aria-label="Project name" />
             <SaveFlag state={save} />
+
+            {/* Next to the save flag rather than out with the exports: these two
+                are the other half of "nothing here has a Save button". */}
+            <span className="undogroup">
+              <button className="iconbtn" onClick={undo} disabled={!canUndo(stack)}
+                title="Undo (⌘Z)" aria-label="Undo"><Icon name="undo" size={15} /></button>
+              <button className="iconbtn" onClick={redo} disabled={!canRedo(stack)}
+                title="Redo (⌘⇧Z)" aria-label="Redo"><Icon name="redo" size={15} /></button>
+            </span>
 
             <div style={{ flex: 1 }} />
 
@@ -280,37 +532,31 @@ export default function Editor({ project }: { project: ProjectWithData }) {
               <Icon name="clock" size={15} />History
             </button>
 
-            <a className="btn" href={`/projects/${project.id}/document`} target="_blank" rel="noreferrer"
-              title="The same document, linear and numbered — print it to PDF from there">
-              <Icon name="file" size={15} />Document
-            </a>
-            <a className="btn" href={`/api/projects/${project.id}/export?format=html`}>
-              <Icon name="download" size={15} />HTML
-            </a>
-            <a className="btn" href={`/api/projects/${project.id}/export?format=json`}>
-              <Icon name="download" size={15} />JSON
-            </a>
+            <ExportMenu projectId={project.id} name={project.name} notify={notify} />
           </div>
 
           {mode === 'preview' ? (
             <PreviewPane projectId={project.id} version={doc} saveState={save} />
           ) : mode === 'content' ? (
-            <ContentEditor doc={doc} patch={patch} catalog={catalog} />
+            <ContentEditor doc={doc} patch={patch} catalog={catalog} notify={notify} />
           ) : (
             <div className="editor-body">
-              <Palette doc={doc} patch={patch} catalog={catalog} onOpenPlacement={() => setPlacementRequest({})} />
+              <Palette doc={doc} patch={patch} catalog={catalog} notify={notify}
+                onOpenPlacement={() => setPlacementRequest({})} />
 
-              <div className="canvas-wrap">
-                <Canvas
-                  doc={doc} selected={selected} setSelected={setSelected}
-                  hoverTarget={hoverTarget} linking={!!link}
-                  onStartLink={(id, x, y) => setLink({ from: id, x, y })}
-                  groupColor={groupColor} patch={patch}
-                />
-              </div>
+              <CanvasStage
+                doc={doc} selected={selected} setSelected={setSelected}
+                hoverTarget={hoverTarget} linkFrom={link?.from ?? null}
+                onStartLink={(id, x, y) => setLink({ from: id, x, y })}
+                groupColor={groupColor} patch={patch} notify={notify}
+                onClearSelection={clearSelection} onZoomChange={setSheetZoom}
+                selectedEdge={selectedEdge} onSelectEdge={selectEdge}
+                onAddComponent={layerId => addComponent(layerId)}
+              />
 
               <Inspector
-                doc={doc} patch={patch} component={selectedComp}
+                doc={doc} patch={patch} component={selectedComp} notify={notify}
+                openLink={selectedEdge?.from === selected ? selectedEdge.to : null}
                 onClose={() => setSelected(null)} onSelect={setSelected}
               />
             </div>
@@ -318,18 +564,31 @@ export default function Editor({ project }: { project: ProjectWithData }) {
         </div>
       </div>
 
+      {finder && mode === 'edit' && (
+        <Finder doc={doc} onClose={() => setFinder(false)} onPick={revealComponent} />
+      )}
+
+      <NoticeBar notice={notice} canUndo={canUndo(stack)}
+        onUndo={undo} onDismiss={() => setNotice(null)} />
+
       <DragOverlay dropAnimation={null}>
-        {dragId && dragId !== 'palette:new' && (() => {
+        {dragId && dragId !== PALETTE_NEW && (() => {
           const c = doc.components.find(x => x.id === dragId);
           if (!c) return null;
           return (
-            <div className="ccard" style={{ ['--c' as string]: groupColor(c.group).light, cursor: 'grabbing', boxShadow: 'var(--shadow-lg)' }}>
+            <div className="ccard" style={{
+              ['--c' as string]: groupColor(c.group).light, cursor: 'grabbing',
+              boxShadow: 'var(--shadow-lg)',
+              /* Anchored at the corner the pointer picked the card up by. */
+              transform: sheetZoom === 1 ? undefined : `scale(${sheetZoom})`,
+              transformOrigin: 'top left'
+            }}>
               <div className="nh"><span className="ic"><Icon name={c.icon || 'box'} size={13} /></span>
                 <span className="nm">{c.name}</span></div>
             </div>
           );
         })()}
-        {dragId === 'palette:new' && (
+        {dragId === PALETTE_NEW && (
           <div className="palette-item" style={{ background: 'var(--panel)', cursor: 'grabbing' }}>
             <Icon name="plus" size={14} />New component
           </div>
@@ -379,9 +638,10 @@ export default function Editor({ project }: { project: ProjectWithData }) {
           onRestore={data => {
             /* The restore already wrote the document server-side. Adopting it
              * here keeps the canvas, the inspector and the preview in step —
-             * the autosave that follows is a no-op against what is on disk. */
-            setDoc(data);
-            setSelected(s => (data.components.some(c => c.id === s) ? s : null));
+             * the autosave that follows is a no-op against what is on disk — and
+             * puts the pre-restore document on the undo stack as well. */
+            adopt(data);
+            notify('Version restored');
           }} />
       )}
 
@@ -392,8 +652,9 @@ export default function Editor({ project }: { project: ProjectWithData }) {
             /* Adopted like a restore: the dialog has already checkpointed the
              * document, and the autosave that follows this state change is the
              * one and only write. */
-            setDoc(merged);
+            adopt(merged);
             setEnrich(false);
+            notify('Enrichment applied');
           }} />
       )}
     </DndContext>
@@ -401,6 +662,447 @@ export default function Editor({ project }: { project: ProjectWithData }) {
 }
 
 /* ------------------------------------------------------------------ pieces */
+
+/* `id` is a timestamp and not a counter: two deletions of the same thing must
+ * produce two different notices, or the second one never restarts the timer. */
+type Notice = { text: string; id: number; undoable: boolean };
+
+/* What just happened, and the way back from it.
+ *
+ * This is what lets a delete stop asking. A confirm interrupts every deletion to
+ * insure against the rare one that was a mistake; a notice with an Undo costs
+ * the mistake one click and the other ninety-nine nothing at all. */
+function NoticeBar({ notice, canUndo, onUndo, onDismiss }: {
+  notice: Notice | null; canUndo: boolean; onUndo: () => void; onDismiss: () => void;
+}) {
+  useEffect(() => {
+    if (!notice) return;
+    const t = setTimeout(onDismiss, 8000);
+    return () => clearTimeout(t);
+  }, [notice, onDismiss]);
+
+  if (!notice) return null;
+  return (
+    <div className="noticebar" role="status">
+      <span>{notice.text}</span>
+      {notice.undoable && canUndo && (
+        <button type="button" className="linkbtn" onClick={onUndo}>Undo</button>
+      )}
+      <button type="button" className="iconbtn" onClick={onDismiss} aria-label="Dismiss">
+        <Icon name="plus" size={13} style={{ transform: 'rotate(45deg)' }} />
+      </button>
+    </div>
+  );
+}
+
+/* The rail's sections, foldable.
+ *
+ * Five stacked lists that all grow with the document — scopes, layers, zones and
+ * two or three legends — inside 246 px that does not. On a document with four
+ * layers and three zones the Add block was off the top of the rail before you
+ * had scrolled to it.
+ *
+ * The state is remembered, because a fold you have to redo every time you open a
+ * project is worse than no fold. Read after mount rather than during the first
+ * render: the server has no localStorage, and a section that renders open and
+ * then closes is a hydration mismatch. */
+const RAIL_FOLD_KEY = 'archstudio.rail.folded';
+
+interface RailFolds { isOpen: (id: string) => boolean; toggle: (id: string) => void }
+
+function useRailFolds(): RailFolds {
+  const [folded, setFolded] = useState<Record<string, boolean>>({});
+  const loaded = useRef(false);
+
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem(RAIL_FOLD_KEY);
+      if (raw) setFolded(JSON.parse(raw) as Record<string, boolean>);
+    } catch { /* a rail that will not fold is not worth an error */ }
+    loaded.current = true;
+  }, []);
+
+  useEffect(() => {
+    if (!loaded.current) return;
+    try { window.localStorage.setItem(RAIL_FOLD_KEY, JSON.stringify(folded)); } catch { /* ignore */ }
+  }, [folded]);
+
+  return {
+    isOpen: (id: string) => !folded[id],
+    toggle: (id: string) => setFolded(f => ({ ...f, [id]: !f[id] }))
+  };
+}
+
+/** The label the rail already drew, with a twist in front of it and whatever the
+ *  section's own control was — Add — still on the right. */
+function RailSection({ id, label, open, onToggle, action, children }: {
+  id: string; label: string; open: boolean; onToggle: () => void;
+  action?: React.ReactNode; children: React.ReactNode;
+}) {
+  return (
+    <>
+      <div className="sect-label railhead">
+        <button type="button" className="railtwist" onClick={onToggle}
+          aria-expanded={open} aria-controls={`rail-${id}`}>
+          <Icon name="chevron" size={11} style={{ transform: open ? 'rotate(90deg)' : 'none' }} />
+          {label}
+        </button>
+        <span className="spacer" />
+        {action}
+      </div>
+      {open && <div id={`rail-${id}`}>{children}</div>}
+    </>
+  );
+}
+
+/* ⌘K — the one control that scales with the document.
+ *
+ * Every other way to reach a component gets harder as the sheet grows: the eye
+ * scans further, the scroll gets longer, the scope filter narrows a category
+ * rather than finding a thing. Typing four letters does not. It searches the
+ * name, the id, the technologies and the role, because "which box is the one
+ * running Postgres" is the question people actually arrive with.
+ *
+ * Arrows move the highlight and Enter takes it — never a click-only list. This
+ * is the keyboard's own control; making it need the mouse would be a joke. */
+function Finder({ doc, onClose, onPick }: {
+  doc: Architecture; onClose: () => void; onPick: (id: string) => void;
+}) {
+  const [query, setQuery] = useState('');
+  const [at, setAt] = useState(0);
+  const hits = useMemo(() => searchComponents(doc, query), [doc, query]);
+  const list = useRef<HTMLDivElement>(null);
+
+  /* A new query starts at the top; keeping the old index would land Enter on
+   * whatever happened to be third in a list the reader has not looked at. */
+  useEffect(() => { setAt(0); }, [query]);
+  useEffect(() => {
+    list.current?.querySelector('[aria-selected="true"]')?.scrollIntoView({ block: 'nearest' });
+  }, [at]);
+
+  const move = (d: number) => setAt(i => {
+    if (!hits.length) return 0;
+    return (i + d + hits.length) % hits.length;
+  });
+
+  return (
+    <div className="modal-scrim finder-scrim" onClick={onClose}>
+      <div className="modal finder" role="dialog" aria-label="Find a component"
+        onClick={e => e.stopPropagation()}>
+        <input className="finder-input" autoFocus value={query} placeholder="Find a component…"
+          aria-label="Find a component"
+          onChange={e => setQuery(e.target.value)}
+          onKeyDown={e => {
+            if (e.key === 'Escape') { e.preventDefault(); onClose(); }
+            if (e.key === 'ArrowDown') { e.preventDefault(); move(1); }
+            if (e.key === 'ArrowUp') { e.preventDefault(); move(-1); }
+            if (e.key === 'Enter' && hits[at]) { e.preventDefault(); onPick(hits[at].component.id); }
+          }} />
+
+        <div className="finder-list" ref={list} role="listbox">
+          {hits.map((hit, i) => (
+            <button key={hit.component.id} type="button" role="option" aria-selected={i === at}
+              onMouseEnter={() => setAt(i)} onClick={() => onPick(hit.component.id)}>
+              <Icon name={hit.component.icon || 'box'} size={14} />
+              <span className="finder-name">{hit.component.name}</span>
+              <span className="finder-where">{hit.layerName} · {hit.groupName}</span>
+            </button>
+          ))}
+          {!hits.length && <p className="hint" style={{ padding: '12px 14px' }}>Nothing matches.</p>}
+        </div>
+
+        <div className="finder-foot">↑↓ to move · ↵ to select · esc to close</div>
+      </div>
+    </div>
+  );
+}
+
+/* Creating a layer, a scope or a zone.
+ *
+ * All three were `prompt()`. Beyond looking like 1997, the cost was structural:
+ * a prompt returns one string, so a zone was created bare and its kind and its
+ * parent had to be found again on the row afterwards — two selects at 246 px,
+ * for two answers you already had in mind when you clicked Add. A dialog can
+ * take all of it in one gesture, and it can refuse an empty name instead of
+ * quietly creating nothing.
+ *
+ * One component for the three because the frame is the same and only the middle
+ * differs; splitting it would mean three copies of the focus, the Escape and the
+ * Enter handling, which is the part that has to be identical. */
+type RailKind = 'layer' | 'scope' | 'zone';
+
+const RAIL_COPY: Record<RailKind, { title: string; blurb: string; placeholder: string }> = {
+  layer: {
+    title: 'New layer',
+    blurb: 'A row of the sheet. Layers are the vertical order of the architecture — edge, services, data.',
+    placeholder: 'Services'
+  },
+  scope: {
+    title: 'New scope',
+    blurb: 'A colour across the layers. Scopes say which part of the organisation or the product a component belongs to.',
+    placeholder: 'Platform'
+  },
+  zone: {
+    title: 'New zone',
+    blurb: 'A boundary that crosses the layers — a platform, a network zone, the perimeter of a migration.',
+    placeholder: 'OpenShift'
+  }
+};
+
+function RailDialog({ kind, doc, onClose, onCreate }: {
+  kind: RailKind;
+  doc: Architecture;
+  onClose: () => void;
+  onCreate: (v: { name: string; colour: string; zoneKind?: ZoneKind; parent?: string }) => void;
+}) {
+  const copy = RAIL_COPY[kind];
+  const [name, setName] = useState('');
+  const [zoneKind, setZoneKind] = useState<ZoneKind | ''>('');
+  const [parent, setParent] = useState('');
+  const nextColour = PALETTE[doc.groups.length % PALETTE.length];
+  const [colour, setColour] = useState(nextColour);
+  const field = useRef<HTMLInputElement>(null);
+
+  useEffect(() => { field.current?.focus(); }, []);
+  useEffect(() => {
+    const esc = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    document.addEventListener('keydown', esc);
+    return () => document.removeEventListener('keydown', esc);
+  }, [onClose]);
+
+  const submit = () => {
+    if (!name.trim()) { field.current?.focus(); return; }
+    onCreate({
+      name: name.trim(), colour,
+      zoneKind: zoneKind || undefined,
+      parent: parent || undefined
+    });
+  };
+
+  return (
+    <div className="modal-scrim" onClick={onClose}>
+      <div className="modal railmodal" role="dialog" aria-label={copy.title}
+        onClick={e => e.stopPropagation()}>
+        <div className="modal-head">
+          <div><h2>{copy.title}</h2><p className="lede">{copy.blurb}</p></div>
+        </div>
+
+        <label className="field"><span>Name</span>
+          <input className="input" ref={field} value={name} placeholder={copy.placeholder}
+            onChange={e => setName(e.target.value)}
+            onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); submit(); } }} />
+        </label>
+
+        {kind === 'scope' && (
+          <label className="field"><span>Colour</span>
+            <input type="color" className="input" value={colour}
+              onChange={e => setColour(e.target.value)} />
+            <div className="hint">
+              Five hues, one per scope. This is the next one in the palette; change it if
+              the document already means something else by it.
+            </div>
+          </label>
+        )}
+
+        {kind === 'zone' && (
+          <>
+            <label className="field"><span>Kind</span>
+              <select className="select" value={zoneKind}
+                onChange={e => setZoneKind(e.target.value as ZoneKind | '')}>
+                <option value="">Untyped — drawn dashed</option>
+                {ZONE_KINDS.map(k => (
+                  <option key={k} value={k}>{ZONE_KIND_LABELS[k].en}</option>
+                ))}
+              </select>
+              <div className="hint">
+                {zoneKind ? ZONE_KIND_BLURBS[zoneKind]
+                  : 'A boundary that exists in a document rather than in a room.'}
+              </div>
+            </label>
+            {!!doc.zones.length && (
+              <label className="field"><span>Inside</span>
+                <select className="select" value={parent} onChange={e => setParent(e.target.value)}>
+                  <option value="">Nothing — a zone of its own</option>
+                  {doc.zones.map(z => <option key={z.id} value={z.id}>in {z.name}</option>)}
+                </select>
+              </label>
+            )}
+          </>
+        )}
+
+        <div className="modal-actions">
+          <button type="button" className="btn ghost" onClick={onClose}>Cancel</button>
+          <button type="button" className="btn primary" onClick={submit} disabled={!name.trim()}>
+            Create
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* The ways out of the document, behind one word.
+ *
+ * They were four buttons in the bar, two of them carrying the same download
+ * glyph and distinguished only by "HTML" and "JSON" — which asks the reader to
+ * know what those files are before knowing which one they want. A menu can say
+ * it in a line each, and the bar goes back to being about the three tabs.
+ *
+ * Real anchors, not click handlers: an export is a download, and a download you
+ * cannot open in a new tab or copy the address of is a worse download. The PNG
+ * is the one exception and it is not a preference — see `downloadPng`, which has
+ * to assemble the file in this browser because there is no rasteriser on the
+ * other end of the wire. It is the only row that is a button. */
+function ExportMenu({ projectId, name, notify }: {
+  projectId: string; name: string; notify: Notify;
+}) {
+  const [open, setOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const box = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const away = (e: MouseEvent) => {
+      if (!box.current?.contains(e.target as Node)) setOpen(false);
+    };
+    const esc = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false); };
+    document.addEventListener('mousedown', away);
+    document.addEventListener('keydown', esc);
+    return () => {
+      document.removeEventListener('mousedown', away);
+      document.removeEventListener('keydown', esc);
+    };
+  }, [open]);
+
+  const png = async () => {
+    setBusy(true);
+    try {
+      await downloadPng(projectId, `${slugify(name || 'architecture')}.png`);
+      setOpen(false);
+    } catch (e) {
+      notify(e instanceof Error ? `PNG export failed — ${e.message}` : 'PNG export failed', false);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const api = `/api/projects/${projectId}/export`;
+  return (
+    <div className="menu" ref={box} style={{ position: 'relative' }}>
+      <button className="btn" aria-haspopup="menu" aria-expanded={open}
+        onClick={() => setOpen(o => !o)}>
+        <Icon name="download" size={15} />Export
+        <Icon name="chevron" size={12} style={{ transform: 'rotate(90deg)', opacity: .6 }} />
+      </button>
+      {open && (
+        /* The PNG row keeps the menu open while it works: it is the one item
+         * that takes a moment, and a menu that vanished with nothing downloaded
+         * yet reads as a click that missed. */
+        <div className="menu-pop under wide" role="menu"
+          onClick={e => { if (!(e.target as HTMLElement).closest('[data-busy]')) setOpen(false); }}>
+          <a href={`/projects/${projectId}/document`} target="_blank" rel="noreferrer">
+            <Icon name="file" size={14} />
+            <span>Design document<em>Numbered and linear — print it to PDF from there</em></span>
+          </a>
+          <hr />
+          <a href={`${api}?format=html`}>
+            <Icon name="download" size={14} />
+            <span>Self-contained HTML<em>One file, no external requests — email it</em></span>
+          </a>
+          <a href={`${api}?format=datafile`}>
+            <Icon name="download" size={14} />
+            <span>Viewer data file<em>architecture.js, for the standalone viewer</em></span>
+          </a>
+          <a href={`${api}?format=json`}>
+            <Icon name="download" size={14} />
+            <span>JSON<em>The document itself — re-importable</em></span>
+          </a>
+          <hr />
+          <a href={`${api}?format=drawio`}>
+            <Icon name="download" size={14} />
+            <span>draw.io<em>The diagram, editable — boxes, zones and lines you can move</em></span>
+          </a>
+          <button type="button" data-busy={busy ? '1' : '0'} disabled={busy} onClick={png}>
+            <Icon name={busy ? 'clock' : 'download'} size={14} />
+            <span>PNG{busy ? ' — building…' : ''}
+              <em>An image anywhere, and still a diagram in draw.io</em></span>
+          </button>
+          <a href={`${api}?format=svg`}>
+            <Icon name="download" size={14} />
+            <span>SVG<em>Vector — scales without going soft, for slides and print</em></span>
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* The PNG, assembled here rather than on the server.
+ *
+ * Nothing in this codebase can rasterise: the server has no headless browser and
+ * this repo has no image library, which is a deliberate line — the dependency
+ * list is `next`, `react` and `@dnd-kit`, and a PNG is not worth Puppeteer. But
+ * every reader already has a rasteriser, and it is the one displaying this menu.
+ *
+ * So the server sends the drawing as SVG with its typefaces inlined, an `<img>`
+ * decodes it, a canvas paints it at 2× and hands back PNG bytes — and then the
+ * draw.io XML for the same document goes into the file as a text chunk. The
+ * result is an ordinary image that draw.io can reopen as an editable diagram,
+ * which is the whole reason to prefer it to a screenshot.
+ *
+ * 2× rather than the device's own ratio: an export is not looked at on the
+ * machine that made it, and a diagram that is crisp on a retina laptop and soft
+ * on the projector in the room has optimised for the wrong screen. */
+const PNG_SCALE = 2;
+
+async function downloadPng(projectId: string, filename: string) {
+  const api = `/api/projects/${projectId}/export`;
+  const fetchText = async (format: string) => {
+    const r = await fetch(`${api}?format=${format}&inline=1`);
+    if (!r.ok) throw new Error(`could not read the ${format} export`);
+    return r.text();
+  };
+  const [svg, xml] = await Promise.all([fetchText('svg'), fetchText('drawio')]);
+  const blob = new Blob([withDrawioXml(await rasterise(svg), xml)], { type: 'image/png' });
+
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  /* Revoked on the next frame rather than immediately: the click is synchronous
+   * but the fetch the browser makes for it is not. */
+  requestAnimationFrame(() => URL.revokeObjectURL(url));
+}
+
+function rasterise(svg: string): Promise<Uint8Array> {
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(new Blob([svg], { type: 'image/svg+xml' }));
+    const img = new Image();
+    const done = (fn: () => void) => { URL.revokeObjectURL(url); fn(); };
+
+    img.onerror = () => done(() => reject(new Error('the diagram could not be decoded')));
+    img.onload = () => {
+      const canvas = document.createElement('canvas');
+      canvas.width = Math.round(img.naturalWidth * PNG_SCALE);
+      canvas.height = Math.round(img.naturalHeight * PNG_SCALE);
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return done(() => reject(new Error('this browser has no 2D canvas')));
+      /* The SVG already paints its own ground, but a transparent PNG pasted into
+       * a dark slide deck is a diagram in invisible ink. Paint it here too. */
+      ctx.fillStyle = '#FFFFFF';
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+      canvas.toBlob(blob => {
+        if (!blob) return done(() => reject(new Error('the image could not be encoded')));
+        blob.arrayBuffer()
+          .then(buf => done(() => resolve(new Uint8Array(buf))))
+          .catch(err => done(() => reject(err)));
+      }, 'image/png');
+    };
+    img.src = url;
+  });
+}
 
 function SaveFlag({ state }: { state: SaveState }) {
   const label = { saved: 'Saved', dirty: 'Editing…', saving: 'Saving…', error: 'Not saved' }[state];
@@ -499,16 +1201,27 @@ function LinkLine({ link }: { link: { from: string; x: number; y: number } }) {
  * document renderer — three surfaces, one grammar, one table in lib/links.ts. */
 function edgeGlyph(
   x1: number, y1: number, k1: number, x2: number, y2: number, k2: number,
-  colour: string, opacity: number, width: number, dash = ''
+  colour: string, opacity: number, width: number, dash = '',
+  from = '', to = '', chosen = false
 ) {
-  return `<g opacity="${opacity}">`
-    + `<path d="M${x1},${y1} C${x1},${y1 + k1} ${x2},${y2 + k2} ${x2},${y2}" fill="none" `
+  const d = `M${x1},${y1} C${x1},${y1 + k1} ${x2},${y2 + k2} ${x2},${y2}`;
+  return `<g opacity="${opacity}" data-o="${opacity}"`
+    + ` data-from="${attr(from)}" data-to="${attr(to)}"${chosen ? ' data-sel="1"' : ''}>`
+    /* The line is 1.2 px and a pointer is not. This is the same curve at a
+     * thickness you can actually hit, painted in nothing — without it the only
+     * way to reach a dependency is to select its caller and hunt for the row. */
+    + `<path class="hit" d="${d}" fill="none" stroke="transparent" stroke-width="14"/>`
+    + `<path d="${d}" fill="none" `
     + `stroke="${colour}" stroke-width="${width}" stroke-linecap="round"`
     + `${dash ? ` stroke-dasharray="${dash}"` : ''}/>`
     + `<circle cx="${x1}" cy="${y1}" r="3.5" fill="${colour}"/>`
     + `<circle cx="${x2}" cy="${y2}" r="3" style="fill:var(--panel)" stroke="${colour}" stroke-width="1.5"/>`
     + `</g>`;
 }
+
+/** Component ids are slugs, but nothing downstream should have to know that:
+ *  this is a raw string going into an attribute in an SVG built by hand. */
+const attr = (v: string) => v.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;');
 
 /* The zone rectangles, measured after layout and drawn behind everything else.
  *
@@ -519,7 +1232,7 @@ function edgeGlyph(
  *
  * Kept in step with `zoneLayer` in viewer/engine.js and `PaperDiagram` in the
  * document renderer — three surfaces, one geometry, one table in lib/zones.ts. */
-function zoneLayer(host: HTMLElement, box: DOMRect, doc: Architecture): string {
+function zoneLayer(host: HTMLElement, box: DOMRect, doc: Architecture, scale = 1): string {
   const live = zonesInUse(doc.zones, doc.components);
   if (!live.length) return '';
 
@@ -530,7 +1243,10 @@ function zoneLayer(host: HTMLElement, box: DOMRect, doc: Architecture): string {
       host.querySelectorAll<HTMLElement>(`.zrun[data-zone="${CSS.escape(id)}"]`).forEach(run => {
         const r = run.getBoundingClientRect();
         if (!r.width && !r.height) return;
-        boxes.push({ x: r.left - box.left, y: r.top - box.top, w: r.width, h: r.height });
+        boxes.push({
+          x: (r.left - box.left) / scale, y: (r.top - box.top) / scale,
+          w: r.width / scale, h: r.height / scale
+        });
       });
     });
     const rect = inflatedUnion(boxes, zonePad(zone.id, doc.zones));
@@ -539,17 +1255,250 @@ function zoneLayer(host: HTMLElement, box: DOMRect, doc: Architecture): string {
   }).join('');
 }
 
-/* -------------------------------------------------------------------- canvas */
+/* --------------------------------------------------------------------- stage */
 
-function Canvas({ doc, selected, setSelected, hoverTarget, linking, onStartLink, groupColor, patch }: {
+interface StageProps {
   doc: Architecture; selected: string | null; setSelected: (id: string | null) => void;
-  hoverTarget: string | null; linking: boolean;
+  hoverTarget: string | null;
+  /** The card the dependency handle was pulled from, or null when nothing is
+   *  being drawn. The cards need the id and not just the fact — a target that is
+   *  already linked has to say so before the drop, not after. */
+  linkFrom: string | null;
   onStartLink: (id: string, x: number, y: number) => void;
   groupColor: (id: string) => { light: string; dark: string };
   patch: (fn: (d: Architecture) => Architecture) => void;
+  notify: Notify;
+  selectedEdge: EdgeRef | null;
+  onSelectEdge: (from: string, to: string) => void;
+  /** A click on the paper. Not `setSelected(null)` — see `clearSelection`. */
+  onClearSelection: () => void;
+  /** Reported upwards so the drag overlay can match the sheet's scale. */
+  onZoomChange: (zoom: number) => void;
+  /** Add a component to this layer. On the row itself, because the rail that
+   *  used to be the only way in is hidden below 1180 px — on a 13-inch laptop
+   *  the editor had no way at all to add a component. */
+  onAddComponent: (layerId: string) => void;
+}
+
+/* The frame around the sheet, and the controls that make a large one workable.
+ *
+ * All of this existed in the viewer and none of it here, which is the wrong way
+ * round: the reader of an exported file got Fit and a scope filter, and the
+ * person drawing the thing got a scrollbar. Same chips, same range, same two
+ * zoom mechanisms — see lib/viewport.ts, which the tests hold against
+ * viewer/engine.js so the two surfaces cannot drift.
+ *
+ * One deliberate difference. The viewer's filter takes the emptied columns out
+ * of the sheet; here it only fades them. You are still editing the components
+ * you filtered out — a card that vanished is one you cannot drop anything onto,
+ * and a layer that lost its cards is a row you would delete by mistake. */
+function CanvasStage(props: StageProps) {
+  const frameRef = useRef<HTMLDivElement>(null);
+  const hostRef = useRef<HTMLDivElement>(null);
+  const zoomRef = useRef(1);
+  const [zoom, setZoomState] = useState(1);
+  const [compact, setCompact] = useState(false);
+  const [filter, setFilter] = useState<string | null>(null);
+
+  /* Firefox only learned `zoom` in 126. Assumed present on the server, where
+   * there is no CSS object to ask — the factor is 1 there and neither mechanism
+   * emits a style, so the two renders agree. */
+  const [hasZoomProp] = useState(() =>
+    typeof CSS === 'undefined' || typeof CSS.supports !== 'function'
+      ? true : CSS.supports('zoom', '0.5'));
+
+  const { doc, groupColor, onZoomChange } = props;
+  useEffect(() => { onZoomChange(zoom); }, [zoom, onZoomChange]);
+  const scopes = useMemo(
+    () => doc.groups.filter(g => doc.components.some(c => c.group === g.id)),
+    [doc.groups, doc.components]
+  );
+  /* A scope that no longer holds anything cannot stay the active filter, or the
+   * sheet fades to nothing with no chip pressed to explain why. */
+  useEffect(() => {
+    setFilter(f => (f && scopes.some(g => g.id === f) ? f : null));
+  }, [scopes]);
+
+  const setZoom = useCallback((next: number, anchor?: { x: number; y: number }) => {
+    const from = zoomRef.current;
+    const to = clampZoom(next);
+    if (to === from) return;
+    zoomRef.current = to;
+    setZoomState(to);
+
+    const frame = frameRef.current;
+    if (!frame) return;
+    const box = frame.getBoundingClientRect();
+    const at = anchor ?? { x: box.width / 2, y: box.height / 2 };
+    const scroll = anchoredScroll(
+      from, to, { left: frame.scrollLeft, top: frame.scrollTop }, at);
+    /* After the paint that resizes the sheet: setting scrollLeft against the old
+     * layout would be clamped to the old maximum and land somewhere else. */
+    requestAnimationFrame(() => {
+      frame.scrollLeft = scroll.left;
+      frame.scrollTop = scroll.top;
+    });
+  }, []);
+
+  /* The largest factor at or below 100 % whose whole sheet fits the frame.
+   *
+   * Scaling reflows, so the height at a given factor cannot be calculated — it
+   * has to be tried, and the probe writes straight to the node rather than
+   * through state so the whole ladder costs one paint. Both properties are
+   * cleared afterwards: React only removes the style properties it set itself,
+   * and it never saw these. */
+  const fit = useCallback(() => {
+    const frame = frameRef.current, host = hostRef.current;
+    if (!frame || !host) return;
+    if (!(frame.clientHeight > 0)) return;
+
+    /* Asked of the frame, not of the sheet, and in both directions.
+     *
+     * The sheet cannot answer either question honestly. Its border box is a
+     * block clamped to the frame's width, so a banded grid running two screens
+     * to the right still measures as "fits"; and its own `scrollWidth` is
+     * reported in its local pixels, which do not shrink under `zoom`. The frame
+     * is never scaled, so its scroll extents are the painted size of whatever
+     * the sheet is currently doing — one measurement that is true for both
+     * mechanisms and both axes.
+     *
+     * Width matters only because of zones. An unzoned sheet is flex-wrap and
+     * reflows into whatever frame it is given; a zoned one is a grid of fixed
+     * columns reserving a band per zone whether or not a row uses it, and that
+     * does not reflow — it is only painted smaller. Measuring height alone left
+     * Fit answering 100 % on a sheet half of which was off the right edge. */
+    let found = ZOOM_MIN;
+    for (const z of fitLadder()) {
+      const style = zoomStyle(z, hasZoomProp);
+      host.style.zoom = style.zoom ?? '';
+      host.style.transform = style.transform ?? '';
+      host.style.transformOrigin = style.transform ? 'top left' : '';
+      if (frame.scrollWidth <= frame.clientWidth + 1
+        && frame.scrollHeight <= frame.clientHeight + 1) { found = z; break; }
+    }
+    host.style.zoom = '';
+    host.style.transform = '';
+    host.style.transformOrigin = '';
+
+    zoomRef.current = found;
+    setZoomState(found);
+    requestAnimationFrame(() => { frame.scrollLeft = 0; frame.scrollTop = 0; });
+  }, [hasZoomProp]);
+
+  /* Plain wheel stays a scroll; ctrl or ⌘ — which is also what a trackpad pinch
+   * sends — scales the sheet. Bound by hand because React's onWheel is passive
+   * and cannot preventDefault the browser's own page zoom. */
+  useEffect(() => {
+    const frame = frameRef.current;
+    if (!frame) return;
+    const onWheel = (e: WheelEvent) => {
+      if (!e.ctrlKey && !e.metaKey) return;
+      e.preventDefault();
+      const r = frame.getBoundingClientRect();
+      setZoom(zoomRef.current - Math.sign(e.deltaY) * ZOOM_STEP,
+        { x: e.clientX - r.left, y: e.clientY - r.top });
+    };
+    frame.addEventListener('wheel', onWheel, { passive: false });
+    return () => frame.removeEventListener('wheel', onWheel);
+  }, [setZoom]);
+
+  /* Drag the paper to pan it. Only from the ground — a card belongs to dnd-kit,
+   * and the layer heads own their own buttons — and only once the pointer has
+   * actually travelled, so a click on the sheet is still the click that
+   * deselects. */
+  const pan = useRef<{ id: number; x: number; y: number; left: number; top: number; live: boolean } | null>(null);
+  const onPanDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    const frame = frameRef.current;
+    if (!frame || e.button !== 0) return;
+    if ((e.target as HTMLElement).closest('.ccard, button, input, select, textarea, a')) return;
+    pan.current = {
+      id: e.pointerId, x: e.clientX, y: e.clientY,
+      left: frame.scrollLeft, top: frame.scrollTop, live: false
+    };
+  };
+  const onPanMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    const frame = frameRef.current, p = pan.current;
+    if (!frame || !p || p.id !== e.pointerId) return;
+    const dx = e.clientX - p.x, dy = e.clientY - p.y;
+    if (!p.live) {
+      if (Math.abs(dx) + Math.abs(dy) < 5) return;
+      p.live = true;
+      frame.setPointerCapture(e.pointerId);
+      frame.classList.add('panning');
+    }
+    frame.scrollLeft = p.left - dx;
+    frame.scrollTop = p.top - dy;
+  };
+  const endPan = (e: React.PointerEvent<HTMLDivElement>) => {
+    const frame = frameRef.current, p = pan.current;
+    pan.current = null;
+    if (!frame || !p) return;
+    if (p.live) {
+      frame.classList.remove('panning');
+      if (frame.hasPointerCapture(e.pointerId)) frame.releasePointerCapture(e.pointerId);
+    }
+  };
+
+  return (
+    <div className="canvas-wrap">
+      <div className="canvas-tools">
+        <div className="filters">
+          <button className="chip" aria-pressed={!filter} onClick={() => setFilter(null)}>
+            All scopes
+          </button>
+          {scopes.map(g => (
+            <button key={g.id} className="chip pole" aria-pressed={filter === g.id}
+              style={{ ['--c' as string]: groupColor(g.id).light }}
+              onClick={() => setFilter(f => (f === g.id ? null : g.id))}>
+              <i style={{ background: groupColor(g.id).light }} />{g.name}
+            </button>
+          ))}
+        </div>
+        {/* Hint and controls are one right-hand group, so a bar narrow enough to
+            wrap keeps them together instead of dropping the zoom bar to the far
+            left of the second line. */}
+        <div className="toolside">
+        <span className="hintline">⌘ + wheel = zoom · drag = pan</span>
+        <div className="tools">
+          <button className="chip" aria-pressed={compact} onClick={() => setCompact(c => !c)}
+            title="Strip the cards to their icon and name">Compact</button>
+          <div className="zoombar">
+            <button className="zb" onClick={() => setZoom(zoomRef.current - ZOOM_STEP)}
+              aria-label="Zoom out" title="Zoom out"><Icon name="minus" size={14} /></button>
+            <span className="zval">{Math.round(zoom * 100)}%</span>
+            <button className="zb" onClick={() => setZoom(zoomRef.current + ZOOM_STEP)}
+              aria-label="Zoom in" title="Zoom in"><Icon name="plus" size={14} /></button>
+            <button className="zb zfit" onClick={fit}
+              title="The largest scale that puts the whole sheet on screen">Fit</button>
+          </div>
+        </div>
+        </div>
+      </div>
+
+      <div className="canvas-frame" ref={frameRef}
+        onPointerDown={onPanDown} onPointerMove={onPanMove}
+        onPointerUp={endPan} onPointerCancel={endPan}>
+        <Canvas {...props} hostRef={hostRef} zoom={zoom} compact={compact} filter={filter}
+          zoomStyleValue={zoomStyle(zoom, hasZoomProp)} />
+      </div>
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------- canvas */
+
+function Canvas({
+  doc, selected, setSelected, hoverTarget, linkFrom, onStartLink, groupColor, patch, notify,
+  onAddComponent, selectedEdge, onSelectEdge, onClearSelection,
+  hostRef, zoom, compact, filter, zoomStyleValue
+}: Omit<StageProps, 'onZoomChange'> & {
+  hostRef: React.RefObject<HTMLDivElement | null>;
+  zoom: number; compact: boolean; filter: string | null; zoomStyleValue: ZoomStyle;
 }) {
-  const ref = useRef<HTMLDivElement>(null);
+  const ref = hostRef;
   const [edges, setEdges] = useState<string>('');
+  const [hover, setHover] = useState<string | null>(null);
+  const linking = !!linkFrom;
 
   /* Computed once for the sheet, not once per layer: a band is the same range of
    * columns on every row, which is the whole reason a zone's rectangle can only
@@ -563,6 +1512,10 @@ function Canvas({ doc, selected, setSelected, hoverTarget, linking, onStartLink,
     const host = ref.current;
     if (!host) return;
     const box = host.getBoundingClientRect();
+    /* Both zoom mechanisms scale what a rect reports, and the SVG is a child of
+     * the scaled element — so one division puts every measurement back into the
+     * sheet's own coordinates, which is what the edge geometry is written in. */
+    const sc = zoom || 1;
     const index = Object.fromEntries(doc.layers.map((l, i) => [l.id, i]));
     const byId = Object.fromEntries(doc.components.map(c => [c.id, c]));
     const conv = protocolConvention(doc.ui.architecture);
@@ -575,42 +1528,54 @@ function Canvas({ doc, selected, setSelected, hoverTarget, linking, onStartLink,
       const b = host.querySelector(`[data-comp="${CSS.escape(dep)}"]`);
       if (!a || !b || !byId[dep]) return;
       const ra = a.getBoundingClientRect(), rb = b.getBoundingClientRect();
-      const x1 = ra.left - box.left + ra.width / 2;
-      const x2 = rb.left - box.left + rb.width / 2;
+      const x1 = (ra.left - box.left + ra.width / 2) / sc;
+      const x2 = (rb.left - box.left + rb.width / 2) / sc;
       const la = index[c.layer], lb = index[byId[dep].layer];
       let y1: number, y2: number, k1: number, k2: number;
       if (la === lb) {
-        y1 = ra.bottom - box.top; y2 = rb.bottom - box.top; k1 = 30; k2 = 30;
+        y1 = (ra.bottom - box.top) / sc; y2 = (rb.bottom - box.top) / sc; k1 = 30; k2 = 30;
       } else {
         const up = la > lb;
-        y1 = (up ? ra.top : ra.bottom) - box.top;
-        y2 = (up ? rb.bottom : rb.top) - box.top;
+        y1 = ((up ? ra.top : ra.bottom) - box.top) / sc;
+        y2 = ((up ? rb.bottom : rb.top) - box.top) / sc;
         const k = (up ? -1 : 1) * Math.max(24, Math.abs(y2 - y1) * .5);
         k1 = k; k2 = -k;
       }
-      const active = selected === c.id || selected === dep;
+      const chosen = !!selectedEdge && selectedEdge.from === c.id && selectedEdge.to === dep;
+      const active = chosen || selected === c.id || selected === dep;
       const colour = groupColor(c.group).light;
       const link = linkOf(c, dep);
+      /* An edge belongs to its caller's scope, so it fades with it. Both ends
+       * are checked: a line arriving from a faded card would otherwise be the
+       * loudest thing left on a narrowed sheet. */
+      const faded = !!filter && c.group !== filter && byId[dep].group !== filter;
       /* The transition takes the two channels colour never claimed: a departure
        * from the existing state is drawn heavier, and a removal is a ghost of an
        * ordinary edge. Selection still wins over both — the canvas is where you
        * work, and what you have clicked has to stay the loudest thing on it. */
-      const opacity = active ? 1 : edgeOpacity(link?.state, .34);
-      const width = active ? 2 : edgeStroke(link?.state, 1.2);
-      out += edgeGlyph(x1, y1, k1, x2, y2, k2, colour, opacity, width, dashFor(link?.kind));
+      const opacity = (active ? 1 : edgeOpacity(link?.state, .34)) * (faded ? .18 : 1);
+      const width = chosen ? 2.6 : active ? 2 : edgeStroke(link?.state, 1.2);
+      out += edgeGlyph(x1, y1, k1, x2, y2, k2, colour, opacity, width, dashFor(link?.kind),
+        c.id, dep, chosen);
       /* Full strength even on an unselected edge: this is the surface where the
        * protocol and the mark are authored, so they have to be legible before
        * you have clicked the thing they belong to. */
       const label = edgePlateText(link, conv);
-      if (label) labels += edgeLabelSvg(x1, y1, k1, x2, y2, k2, label);
+      if (label && !faded) {
+        /* Wrapped rather than given its own attributes inside `edgeLabelSvg`:
+         * that helper draws the same plate on three surfaces, and only this one
+         * has anything to focus. */
+        labels += `<g data-from="${attr(c.id)}" data-to="${attr(dep)}">`
+          + edgeLabelSvg(x1, y1, k1, x2, y2, k2, label) + '</g>';
+      }
     }));
     /* Zones are measured from the runs, not from the cards: a run is already a
      * tight box around a zone's members in one row, so the union is a handful of
      * rects instead of one per component. Emitted first, so every line and every
      * card paints over the region rather than under it. */
-    setEdges(zoneLayer(host, box, doc) + out
+    setEdges(zoneLayer(host, box, doc, sc) + out
       + (labels ? `<g class="edgelbl">${labels}</g>` : ''));
-  }, [doc, selected, groupColor]);
+  }, [doc, selected, selectedEdge, groupColor, zoom, filter]);
 
   useLayoutEffect(() => { draw(); }, [draw]);
   useEffect(() => {
@@ -622,9 +1587,57 @@ function Canvas({ doc, selected, setSelected, hoverTarget, linking, onStartLink,
     return () => { ro.disconnect(); window.removeEventListener('resize', draw); };
   }, [draw]);
 
+  /* Everything a hovered card does not touch gets out of the way — the one thing
+   * the exported file did that the surface you draw on did not.
+   *
+   * Written straight onto the nodes instead of through `draw`: focus changes on
+   * every pointer move across the sheet, and re-measuring every card to answer
+   * "which edges touch this one" would make a large diagram stutter. Nothing
+   * here reads layout, so the sweep costs one style recalculation.
+   *
+   * Lit edges are raised from their resting opacity rather than set to 1, so a
+   * removed edge stays the ghost the transition grammar drew it as. */
+  const focus = linking ? null : hover;
+  useEffect(() => {
+    const host = ref.current;
+    if (!host) return;
+    host.querySelectorAll<SVGGElement>('.canvas-edges g[data-from]').forEach(g => {
+      const base = Number(g.dataset.o ?? '1');
+      if (!focus) { g.setAttribute('opacity', String(base)); return; }
+      const lit = g.dataset.from === focus || g.dataset.to === focus;
+      g.setAttribute('opacity', String(lit ? Math.min(1, base * 2.9) : base * .12));
+    });
+  }, [focus, edges]);
+
+  /* The hovered card, what it calls, and what calls it. */
+  const near = useMemo(() => {
+    if (!focus) return null;
+    const set = new Set<string>([focus]);
+    doc.components.forEach(c => {
+      if (c.id === focus) (c.deps || []).forEach(d => set.add(d));
+      else if ((c.deps || []).includes(focus)) set.add(c.id);
+    });
+    return set;
+  }, [focus, doc.components]);
+
   return (
-    <div className={`canvas${linking ? ' linking' : ''}`} ref={ref}
-      onClick={e => { if (e.target === e.currentTarget) setSelected(null); }}>
+    <div
+      className={`canvas${linking ? ' linking' : ''}${compact ? ' compact' : ''}${filter ? ' filtered' : ''}`}
+      ref={ref} style={zoomStyleValue as React.CSSProperties}
+      onClick={e => {
+        const edge = (e.target as Element).closest('g[data-from]') as SVGGElement | null;
+        if (edge?.dataset.from && edge.dataset.to) {
+          e.stopPropagation();
+          onSelectEdge(edge.dataset.from, edge.dataset.to);
+          return;
+        }
+        if (e.target === e.currentTarget) onClearSelection();
+      }}
+      onPointerOver={e => {
+        const card = (e.target as HTMLElement).closest('[data-comp]') as HTMLElement | null;
+        setHover(card?.dataset.comp ?? null);
+      }}
+      onPointerLeave={() => setHover(null)}>
       <svg className="canvas-edges" dangerouslySetInnerHTML={{ __html: edges }} />
       {doc.layers.length === 0 && (
         <div className="warnbox" style={{ margin: 16 }}>
@@ -633,31 +1646,63 @@ function Canvas({ doc, selected, setSelected, hoverTarget, linking, onStartLink,
         </div>
       )}
       {doc.layers.map((layer, i) => (
-        <LayerRow key={layer.id} layer={layer} doc={doc} patch={patch}
+        <LayerRow key={layer.id} layer={layer} doc={doc} patch={patch} notify={notify}
           selected={selected} setSelected={setSelected} hoverTarget={hoverTarget}
-          onStartLink={onStartLink} groupColor={groupColor} plan={plan} index={i} />
+          onStartLink={onStartLink} groupColor={groupColor} plan={plan} index={i}
+          filter={filter} near={near} linkFrom={linkFrom} onAdd={onAddComponent} />
       ))}
     </div>
   );
 }
 
 function LayerRow({
-  layer, doc, patch, selected, setSelected, hoverTarget, onStartLink, groupColor, plan, index
+  layer, doc, patch, notify, selected, setSelected, hoverTarget, onStartLink, groupColor, plan,
+  index, filter, near, linkFrom, onAdd
 }: {
   layer: { id: string; name: string; desc?: string };
   doc: Architecture; patch: (fn: (d: Architecture) => Architecture) => void;
+  notify: Notify;
   selected: string | null; setSelected: (id: string | null) => void; hoverTarget: string | null;
   onStartLink: (id: string, x: number, y: number) => void;
   groupColor: (id: string) => { light: string; dark: string };
   plan: BandPlan | null;
   index: number;
+  filter: string | null;
+  /** The hovered card and its two neighbourhoods, or null when nothing is. */
+  near: ReadonlySet<string> | null;
+  linkFrom: string | null;
+  onAdd: (layerId: string) => void;
 }) {
-  const { setNodeRef, isOver } = useDroppable({ id: `layer:${layer.id}` });
+  const { setNodeRef, isOver } = useDroppable({
+    id: layerDropId(layer.id), data: { depth: DEPTH.layer }
+  });
   const items = doc.components.filter(c => c.layer === layer.id);
+  const [renaming, setRenaming] = useState(false);
+  /* Computed once for the row rather than per card: the answer is the same list
+   * every time, and a drag re-renders every layer on the sheet. */
+  const alreadyLinked = linkFrom
+    ? new Set(doc.components.find(c => c.id === linkFrom)?.deps || [])
+    : null;
+
+  /* An empty name is a cancel, not a layer called "". Escape sets `renaming`
+   * false before the blur can fire, so it never reaches here. */
+  const commitRename = (value: string) => {
+    setRenaming(false);
+    const name = value.trim();
+    if (!name || name === layer.name) return;
+    patch(d => {
+      const l = d.layers.find(x => x.id === layer.id);
+      if (l) l.name = name;
+      return d;
+    });
+  };
 
   const card = (c: Component) => (
     <ComponentCard key={c.id} comp={c} colour={groupColor(c.group).light}
       selected={selected === c.id} isLinkTarget={hoverTarget === c.id}
+      faded={!!filter && c.group !== filter}
+      away={!!near && !near.has(c.id)}
+      linked={!!alreadyLinked?.has(c.id)}
       onSelect={() => setSelected(c.id)} onStartLink={onStartLink} />
   );
 
@@ -671,24 +1716,43 @@ function LayerRow({
   return (
     <div className={`layer${isOver ? ' over' : ''}`} style={tint}>
       <div className="layer-head">
-        <b>{displayLayerLabel(layer.name)}</b>
-        {layer.desc && <em>{layer.desc}</em>}
+        {/* Renamed where it is written rather than in a prompt that shows the
+            name out of context. Double-click works too, which is what anyone
+            tries first on a label sitting above its own row. */}
+        {renaming ? (
+          <input className="layer-rename" defaultValue={layer.name} autoFocus
+            aria-label="Layer name"
+            onBlur={e => commitRename(e.currentTarget.value)}
+            onKeyDown={e => {
+              if (e.key === 'Enter') { e.preventDefault(); e.currentTarget.blur(); }
+              if (e.key === 'Escape') { e.preventDefault(); setRenaming(false); }
+            }} />
+        ) : (
+          <b onDoubleClick={() => setRenaming(true)}>{displayLayerLabel(layer.name)}</b>
+        )}
+        {layer.desc && !renaming && <em>{layer.desc}</em>}
+        {/* Always drawn, unlike the two beside it: adding a component is the
+            thing this row is for, and it was reachable only from a rail that
+            disappears on a narrow window. */}
+        <button className="layer-add" onClick={() => onAdd(layer.id)}
+          title={`Add a component to ${displayLayerLabel(layer.name)}`}>
+          <Icon name="plus" size={12} />Add
+        </button>
         <span className="layer-tools">
           <button className="iconbtn" style={{ width: 24, height: 24 }} title="Rename layer"
-            onClick={() => {
-              const name = prompt('Layer name', layer.name);
-              if (name?.trim()) patch(d => {
-                const l = d.layers.find(x => x.id === layer.id); if (l) l.name = name.trim(); return d;
-              });
-            }}><Icon name="cog" size={13} /></button>
+            onClick={() => setRenaming(true)}><Icon name="cog" size={13} /></button>
           <button className="iconbtn" style={{ width: 24, height: 24 }} title="Delete layer"
             onClick={() => {
               if (items.length && doc.layers.length <= 1) {
-                alert('Keep at least one layer while components still use it.');
+                notify('Keep at least one layer while components still use it.', false);
                 return;
               }
-              if (items.length && !confirm(`Delete "${layer.name}"? Its ${items.length} component(s) move to "${doc.layers.find(l => l.id !== layer.id)!.name}".`)) return;
-              if (!items.length && !confirm(`Delete empty layer "${layer.name}"?`)) return;
+              /* No confirm — the notice below says where the cards went and the
+                 undo stack has the row that held them. */
+              const fallbackName = doc.layers.find(l => l.id !== layer.id)?.name;
+              notify(items.length
+                ? `Layer "${layer.name}" deleted — its ${items.length} component(s) moved to "${fallbackName}"`
+                : `Empty layer "${layer.name}" deleted`);
               patch(d => {
                 if (items.length) {
                   const fallback = d.layers.find(l => l.id !== layer.id)!.id;
@@ -703,44 +1767,116 @@ function LayerRow({
       <div ref={setNodeRef}
         className={`layer-drop${items.length ? '' : ' empty-hint'}${plan ? ' banded' : ''}`}
         style={plan ? { ['--cols' as string]: plan.total } : undefined}>
-        {items.length === 0 && 'Drop a component here'}
+        {items.length === 0 && (
+          <button type="button" className="emptyadd" onClick={() => onAdd(layer.id)}>
+            Drop a component here, or click to add one
+          </button>
+        )}
         {/* One run per zone, so a zone's cards stay contiguous even when the row
             wraps — that contiguity is what keeps the measured rectangle from
             enclosing a card it does not hold.
             The wrapper appears only on a document that has zones. A row of cards
             and a row of one-run-of-cards lay out the same in theory; not adding
             the element at all is how that stops being a thing to verify. */}
-        {plan
-          ? layerRuns(items, doc.zones).map(run => {
-              const band = plan.band(run.zone);
-              return (
-                <div className="zrun" key={run.zone || ''} data-zone={run.zone || undefined}
-                  style={band
-                    ? { gridColumn: `${band.start} / span ${band.span}` }
-                    : undefined}>
-                  {run.items.map(card)}
-                </div>
-              );
-            })
-          : items.map(card)}
+        {plan ? (() => {
+          const held = new Map(layerRuns(items, doc.zones).map(run => [run.zone ?? '', run.items]));
+          return (
+            <>
+              {/* The drop targets, one per reserved band, full height and behind
+                  everything. A separate layer rather than making the runs
+                  droppable: a run is measured to draw its zone rectangle and has
+                  to stay a tight box around its own cards, while a target has to
+                  cover the whole band — including the part of it that is empty,
+                  which on this row is the only place a first card can land. */}
+              <div className="banddrops" style={{ ['--cols' as string]: plan.total }}>
+                {plan.bands.map(band => (
+                  <BandDrop key={band.zone ?? ''} layerId={layer.id} zone={band.zone} band={band} />
+                ))}
+              </div>
+              {plan.bands.map(band => {
+                const items = held.get(band.zone ?? '') ?? [];
+                if (!items.length) return null;
+                return (
+                  <div className="zrun" key={band.zone ?? ''} data-zone={band.zone || undefined}
+                    style={{ gridColumn: `${band.start} / span ${band.span}` }}>
+                    {items.map(card)}
+                  </div>
+                );
+              })}
+            </>
+          );
+        })() : items.map(card)}
       </div>
     </div>
   );
 }
 
-function ComponentCard({ comp, colour, selected, isLinkTarget, onSelect, onStartLink }: {
-  comp: Component; colour: string; selected: boolean; isLinkTarget: boolean;
+/* One reserved band on one row, as a place to drop into.
+ *
+ * This is what makes a zone something you can put a component *in* rather than
+ * something you assign it to from a form. It is drawn for every band the plan
+ * reserves, not only the ones holding a card here — otherwise the first card to
+ * join a zone on a given row would have nowhere to land. */
+function BandDrop({ layerId, zone, band }: {
+  layerId: string; zone: string | undefined; band: { start: number; span: number };
+}) {
+  const { setNodeRef, isOver } = useDroppable({
+    id: bandDropId(layerId, zone), data: { depth: DEPTH.band }
+  });
+  const { active } = useDndContext();
+
+  return (
+    /* `data-band-zone`, not `data-zone`: the latter is the renderer's mark on a
+       measured run, and two attributes with one name on two elements that mean
+       different things is the kind of thing a future selector gets wrong. */
+    <div ref={setNodeRef} aria-hidden data-band-zone={zone ?? ''}
+      className={`banddrop${active ? ' live' : ''}${isOver && active ? ' over' : ''}`}
+      style={{ gridColumn: `${band.start} / span ${band.span}` }} />
+  );
+}
+
+function ComponentCard({
+  comp, colour, selected, isLinkTarget, faded, away, linked, onSelect, onStartLink
+}: {
+  comp: Component; colour: string; selected: boolean; isLinkTarget: boolean; faded: boolean;
+  away: boolean;
+  /** A dependency being drawn already ends here. Said before the drop, so the
+   *  gesture can be abandoned rather than explained afterwards. */
+  linked: boolean;
   onSelect: () => void; onStartLink: (id: string, x: number, y: number) => void;
 }) {
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({ id: comp.id });
-  const { setNodeRef: dropRef } = useDroppable({ id: comp.id });
+  const { setNodeRef: dropRef, isOver } = useDroppable({
+    id: comp.id, data: { depth: DEPTH.component }
+  });
+  /* Read from the context rather than threaded down: every card needs to know
+   * whether *something* is being dragged, and passing that through two layers of
+   * props would re-render the whole sheet on a value it already has. */
+  const { active } = useDndContext();
+  /* Where the card would land. Dropping onto a card inserts in front of it, so
+   * the mark belongs on the leading edge — and never when the thing being
+   * dragged is this card, which would say a move to where it already is. */
+  const insertBefore = isOver && !!active && String(active.id) !== comp.id;
 
   return (
     <div
       ref={node => { setNodeRef(node); dropRef(node); }}
       {...listeners} {...attributes}
+      /* dnd-kit already puts role="button" and a tab stop on the card. What it
+         cannot know is what the button does here: Enter and Space select, which
+         is what a role="button" promises and what nothing was honouring.
+         `aria-current` rather than `aria-selected` — the latter is not allowed
+         on a button, and a wrong ARIA attribute is worse than none. */
+      aria-label={comp.name}
+      aria-current={selected || undefined}
+      onKeyDown={e => {
+        if (e.key !== 'Enter' && e.key !== ' ') return;
+        e.preventDefault();
+        e.stopPropagation();
+        onSelect();
+      }}
       data-comp={comp.id}
-      className={`ccard${selected ? ' selected' : ''}${isDragging ? ' dragging' : ''}${isLinkTarget ? ' linktarget' : ''}${comp.state ? ` st-${comp.state}` : ''}`}
+      className={`ccard${selected ? ' selected' : ''}${isDragging ? ' dragging' : ''}${isLinkTarget ? ' linktarget' : ''}${linked ? ' linkdone' : ''}${insertBefore ? ' insert' : ''}${faded ? ' faded' : ''}${away ? ' away' : ''}${comp.state ? ` st-${comp.state}` : ''}`}
       style={{ ['--c' as string]: colour }}
       onClick={e => { e.stopPropagation(); onSelect(); }}
     >
@@ -782,12 +1918,43 @@ function ComponentCard({ comp, colour, selected, isLinkTarget, onSelect, onStart
 
 /* ------------------------------------------------------------------ palette */
 
-function Palette({ doc, patch, catalog, onOpenPlacement }: {
+function Palette({ doc, patch, catalog, notify, onOpenPlacement }: {
   doc: Architecture; patch: (fn: (d: Architecture) => Architecture) => void;
   catalog: LegoCatalogSnapshot | null;
+  notify: Notify;
   onOpenPlacement: () => void;
 }) {
   const { attributes, listeners, setNodeRef } = useDraggable({ id: 'palette:new' });
+  /* One dialog for the three rails — see RailDialog. Null is closed. */
+  const [creating, setCreating] = useState<RailKind | null>(null);
+  const fold = useRailFolds();
+
+  const create = (v: { name: string; colour: string; zoneKind?: ZoneKind; parent?: string }) => {
+    if (creating === 'layer') {
+      patch(d => {
+        d.layers.push({ id: slugify(v.name, d.layers.map(l => l.id)), name: v.name });
+        return d;
+      });
+    } else if (creating === 'scope') {
+      patch(d => {
+        const i = d.groups.length;
+        d.groups.push({
+          id: slugify(v.name, d.groups.map(g => g.id)), name: v.name, short: v.name,
+          color: v.colour, colorDark: PALETTE_DARK[i % PALETTE_DARK.length]
+        });
+        return d;
+      });
+    } else if (creating === 'zone') {
+      patch(d => {
+        d.zones.push({
+          id: slugify(v.name, d.zones.map(z => z.id)), name: v.name,
+          kind: v.zoneKind, parent: v.parent
+        });
+        return d;
+      });
+    }
+    setCreating(null);
+  };
 
   return (
     <aside className="palette">
@@ -800,30 +1967,22 @@ function Palette({ doc, patch, catalog, onOpenPlacement }: {
         Add brick
       </button>
 
-      <div className="sect-label">
-        Scopes<span className="spacer" />
-        <button className="iconbtn" style={{ width: 20, height: 20 }} title="Add scope"
-          onClick={() => {
-            /* Derived from the palette, not typed as a literal: there are five
-             * hues, and a sixth scope would be handed `PALETTE[0]` again —
-             * two scopes with one colour, which is the thing the palette is
-             * built to prevent. */
-            if (doc.groups.length >= PALETTE.length) {
-              alert(`${PALETTE.length} scopes is the maximum — a sixth would reuse the first colour.`);
-              return;
-            }
-            const name = prompt('Scope name');
-            if (!name?.trim()) return;
-            patch(d => {
-              const i = d.groups.length;
-              d.groups.push({
-                id: slugify(name, d.groups.map(g => g.id)), name: name.trim(), short: name.trim(),
-                color: PALETTE[i % PALETTE.length], colorDark: PALETTE_DARK[i % PALETTE_DARK.length]
-              });
-              return d;
-            });
-          }}><Icon name="plus" size={13} /></button>
-      </div>
+      <RailSection id="scopes" label={`Scopes (${doc.groups.length})`}
+        open={fold.isOpen('scopes')} onToggle={() => fold.toggle('scopes')}
+        action={
+          <button className="iconbtn" style={{ width: 20, height: 20 }} title="Add scope"
+            onClick={() => {
+              /* Derived from the palette, not typed as a literal: there are five
+               * hues, and a sixth scope would be handed `PALETTE[0]` again —
+               * two scopes with one colour, which is the thing the palette is
+               * built to prevent. */
+              if (doc.groups.length >= PALETTE.length) {
+                notify(`${PALETTE.length} scopes is the maximum — a sixth would reuse the first colour.`, false);
+                return;
+              }
+              setCreating('scope');
+            }}><Icon name="plus" size={13} /></button>
+        }>
       {doc.groups.map((g, i) => (
         <div className="grouprow" key={g.id}>
           <input type="color" className="swatch" value={g.color || PALETTE[i % PALETTE.length]}
@@ -836,10 +1995,13 @@ function Palette({ doc, patch, catalog, onOpenPlacement }: {
               onClick={() => {
                 const used = doc.components.filter(c => c.group === g.id).length;
                 if (used && doc.groups.length <= 1) {
-                  alert('Keep at least one scope while components still use it.');
+                  notify('Keep at least one scope while components still use it.', false);
                   return;
                 }
-                if (used && !confirm(`${used} component(s) use this scope. They will move to "${doc.groups.find(x => x.id !== g.id)!.name}".`)) return;
+                const fallbackName = doc.groups.find(x => x.id !== g.id)?.name;
+                notify(used
+                  ? `Scope "${g.name}" deleted — its ${used} component(s) moved to "${fallbackName}"`
+                  : `Scope "${g.name}" deleted`);
                 patch(d => {
                   if (used) {
                     const fallback = d.groups.find(x => x.id !== g.id)!.id;
@@ -852,19 +2014,14 @@ function Palette({ doc, patch, catalog, onOpenPlacement }: {
           ) : null}
         </div>
       ))}
+      </RailSection>
 
-      <div className="sect-label">
-        Layers<span className="spacer" />
-        <button className="iconbtn" style={{ width: 20, height: 20 }} title="Add layer"
-          onClick={() => {
-            const name = prompt('Layer name');
-            if (!name?.trim()) return;
-            patch(d => {
-              d.layers.push({ id: slugify(name, d.layers.map(l => l.id)), name: name.trim() });
-              return d;
-            });
-          }}><Icon name="plus" size={13} /></button>
-      </div>
+      <RailSection id="layers" label={`Layers (${doc.layers.length})`}
+        open={fold.isOpen('layers')} onToggle={() => fold.toggle('layers')}
+        action={
+          <button className="iconbtn" style={{ width: 20, height: 20 }} title="Add layer"
+            onClick={() => setCreating('layer')}><Icon name="plus" size={13} /></button>
+        }>
       {doc.layers.map((l, i) => (
         <div className="grouprow" key={l.id}>
           <input value={l.name}
@@ -879,10 +2036,16 @@ function Palette({ doc, patch, catalog, onOpenPlacement }: {
             })}><Icon name="chevron" size={12} style={{ transform: 'rotate(90deg)' }} /></button>
         </div>
       ))}
+      </RailSection>
 
-      <ZonesPanel doc={doc} patch={patch} />
+      <ZonesPanel doc={doc} patch={patch} notify={notify} fold={fold}
+        onAdd={() => setCreating('zone')} />
 
-      <EdgeLegend doc={doc} />
+      <EdgeLegend doc={doc} fold={fold} />
+
+      {creating && (
+        <RailDialog kind={creating} doc={doc} onClose={() => setCreating(null)} onCreate={create} />
+      )}
     </aside>
   );
 }
@@ -895,8 +2058,11 @@ function Palette({ doc, patch, catalog, onOpenPlacement }: {
  * `parent` is a select over the other zones. It cannot offer a descendant —
  * `normalizeZones` would cut the cycle back out on the next save, and an edit
  * that silently undoes itself is worse than an option that was never there. */
-function ZonesPanel({ doc, patch }: {
+function ZonesPanel({ doc, patch, notify, fold, onAdd }: {
   doc: Architecture; patch: (fn: (d: Architecture) => Architecture) => void;
+  notify: Notify;
+  fold: RailFolds;
+  onAdd: () => void;
 }) {
   const counts = new Map(doc.zones.map(z => [
     z.id,
@@ -905,18 +2071,12 @@ function ZonesPanel({ doc, patch }: {
 
   return (
     <>
-      <div className="sect-label">
-        Zones<span className="spacer" />
-        <button className="iconbtn" style={{ width: 20, height: 20 }} title="Add zone"
-          onClick={() => {
-            const name = prompt('Zone name — OpenShift, API gateway, DMZ…');
-            if (!name?.trim()) return;
-            patch(d => {
-              d.zones.push({ id: slugify(name, d.zones.map(z => z.id)), name: name.trim() });
-              return d;
-            });
-          }}><Icon name="plus" size={13} /></button>
-      </div>
+      <RailSection id="zones" label={`Zones (${doc.zones.length})`}
+        open={fold.isOpen('zones')} onToggle={() => fold.toggle('zones')}
+        action={
+          <button className="iconbtn" style={{ width: 20, height: 20 }} title="Add zone"
+            onClick={onAdd}><Icon name="plus" size={13} /></button>
+        }>
       {!doc.zones.length && (
         <div className="hint" style={{ padding: '2px 6px' }}>
           A boundary that crosses the layers — a platform, a network zone, the
@@ -924,7 +2084,7 @@ function ZonesPanel({ doc, patch }: {
         </div>
       )}
       {doc.zones.map(z => (
-        <div className="zonerow" key={z.id}>
+        <ZoneRailRow key={z.id} zone={z}>
           <div className="grouprow">
             <input value={z.name}
               onChange={e => patch(d => {
@@ -950,7 +2110,9 @@ function ZonesPanel({ doc, patch }: {
             <button className="iconbtn" style={{ width: 22, height: 22 }} title="Delete zone"
               onClick={() => {
                 const held = counts.get(z.id) ?? 0;
-                if (held && !confirm(`Delete "${z.name}"? Its ${held} component(s) become unzoned.`)) return;
+                notify(held
+                  ? `Zone "${z.name}" deleted — its ${held} component(s) are now unzoned`
+                  : `Zone "${z.name}" deleted`);
                 patch(d => {
                   d.zones = d.zones.filter(y => y.id !== z.id)
                     .map(y => (y.parent === z.id ? { ...y, parent: z.parent } : y));
@@ -984,16 +2146,40 @@ function ZonesPanel({ doc, patch }: {
                 .map(y => <option key={y.id} value={y.id}>in {y.name}</option>)}
             </select>
           </div>
-        </div>
+        </ZoneRailRow>
       ))}
+      </RailSection>
     </>
+  );
+}
+
+/* A zone in the rail, doubling as somewhere to drop a card.
+ *
+ * The bands on the sheet cover every zone that holds something *somewhere*, but
+ * a zone nobody has filled reserves no band — deliberately, since an empty
+ * perimeter should not widen the drawing. That leaves it with no target on the
+ * canvas at all, and its own row in the rail is the obvious place to put one:
+ * it is already labelled with the zone's name and it is already on screen. */
+function ZoneRailRow({ zone, children }: { zone: Zone; children: React.ReactNode }) {
+  const { setNodeRef, isOver } = useDroppable({
+    id: railZoneDropId(zone.id), data: { depth: DEPTH.railzone }
+  });
+  const { active } = useDndContext();
+  /* The palette's new-component draggable says nothing about which layer it
+     would land in, so the rail cannot accept it — see `resolveDrop`. */
+  const live = !!active && String(active.id) !== PALETTE_NEW;
+
+  return (
+    <div ref={setNodeRef} className={`zonerow${live ? ' droppable' : ''}${isOver && live ? ' over' : ''}`}>
+      {children}
+    </div>
   );
 }
 
 /* Only drawn once the document actually annotates an edge. A legend explaining
  * three line styles on a diagram that uses one is furniture — and the same
  * goes for the protocol convention, which appears only once one is declared. */
-function EdgeLegend({ doc }: { doc: Architecture }) {
+function EdgeLegend({ doc, fold }: { doc: Architecture; fold: RailFolds }) {
   const kinds = kindsInUse(doc.components);
   const states = statesInUse(doc.components);
   const marks = marksInUse(doc.components);
@@ -1003,8 +2189,8 @@ function EdgeLegend({ doc }: { doc: Architecture }) {
   return (
     <>
       {!!marks.length && (
-        <>
-          <div className="sect-label">Security</div>
+        <RailSection id="key-marks" label="Security"
+          open={fold.isOpen('key-marks')} onToggle={() => fold.toggle('key-marks')}>
           <div className="markkey">
             {marks.map(m => (
               <span key={m} title={MARK_BLURBS[m]}>
@@ -1012,11 +2198,11 @@ function EdgeLegend({ doc }: { doc: Architecture }) {
               </span>
             ))}
           </div>
-        </>
+        </RailSection>
       )}
       {!!states.length && (
-        <>
-          <div className="sect-label">Transition</div>
+        <RailSection id="key-states" label="Transition"
+          open={fold.isOpen('key-states')} onToggle={() => fold.toggle('key-states')}>
           <div className="statekey">
             {states.map(s => (
               <span key={s}>
@@ -1024,23 +2210,41 @@ function EdgeLegend({ doc }: { doc: Architecture }) {
               </span>
             ))}
           </div>
-        </>
+        </RailSection>
       )}
-      <div className="sect-label">Dependencies</div>
-      {!!kinds.length && (
+      <RailSection id="key-edges" label="Dependencies"
+        open={fold.isOpen('key-edges')} onToggle={() => fold.toggle('key-edges')}>
+        {/* The one thing the sheet never explained. A filled disc is the caller
+            and an open circle is the one that answers — it is the whole grammar
+            of an edge, it is the product's own mark, and until now you had to be
+            told. The line styles below only ever described the second question. */}
         <div className="edgekey">
-          {kinds.map(k => (
-            <span key={k}>
-              <svg viewBox="0 0 34 8" aria-hidden="true">
-                <path d="M1 4h32" fill="none" stroke="currentColor" strokeWidth="1.6"
-                  strokeLinecap="round" strokeDasharray={LINK_DASH[k] || undefined} />
-              </svg>
-              {LINK_KIND_LABELS[k].en}
-            </span>
-          ))}
+          <span>
+            <svg viewBox="0 0 34 8" aria-hidden="true">
+              <path d="M4 4h26" fill="none" stroke="currentColor" strokeWidth="1.6"
+                strokeLinecap="round" />
+              <circle cx="3.5" cy="4" r="3" fill="currentColor" />
+              <circle cx="30" cy="4" r="2.6" fill="var(--panel-2)"
+                stroke="currentColor" strokeWidth="1.4" />
+            </svg>
+            calls → answers
+          </span>
         </div>
-      )}
-      {note && <div className="protonote">{note}</div>}
+        {!!kinds.length && (
+          <div className="edgekey">
+            {kinds.map(k => (
+              <span key={k}>
+                <svg viewBox="0 0 34 8" aria-hidden="true">
+                  <path d="M1 4h32" fill="none" stroke="currentColor" strokeWidth="1.6"
+                    strokeLinecap="round" strokeDasharray={LINK_DASH[k] || undefined} />
+                </svg>
+                {LINK_KIND_LABELS[k].en}
+              </span>
+            ))}
+          </div>
+        )}
+        {note && <div className="protonote">{note}</div>}
+      </RailSection>
     </>
   );
 }

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -28,8 +28,8 @@ import {
 } from '@/lib/lifecycle';
 import { MARK_BLURBS, MARK_ICON, MARK_LABELS, marksInUse } from '@/lib/marks';
 import {
-  bandPlan, describeZone, inflatedUnion, layerRuns, withDescendants, zoneDepth, zonePad, zoneSvg,
-  zonesInUse, ZONE_KINDS, ZONE_KIND_BLURBS, ZONE_KIND_LABELS,
+  bandPlan, canMoveZone, describeZone, inflatedUnion, layerRuns, moveZone, withDescendants,
+  zoneDepth, zonePad, zoneSvg, zonesInUse, ZONE_KINDS, ZONE_KIND_BLURBS, ZONE_KIND_LABELS,
   type BandPlan, type Box, type ZoneKind
 } from '@/lib/zones';
 import { protocolLabel, suggestedLinkForBrick } from '@/lib/lego/protocols';
@@ -923,6 +923,20 @@ function ZonesPanel({ doc, patch }: {
                 return d;
               })} />
             <span className="count">{counts.get(z.id) ?? 0}</span>
+            {/* Left and right, not up and down: a zone is a band of columns, so
+                this is the direction it actually moves on the sheet. Among its
+                own siblings — a nested zone slides inside its parent, never out
+                of it, because the drawing could not show that anyway. */}
+            <button className="iconbtn" style={{ width: 22, height: 22 }} title="Move left"
+              disabled={!canMoveZone(doc.zones, z.id, -1)}
+              onClick={() => patch(d => { d.zones = moveZone(d.zones, z.id, -1); return d; })}>
+              <Icon name="chevron" size={12} style={{ transform: 'rotate(180deg)' }} />
+            </button>
+            <button className="iconbtn" style={{ width: 22, height: 22 }} title="Move right"
+              disabled={!canMoveZone(doc.zones, z.id, 1)}
+              onClick={() => patch(d => { d.zones = moveZone(d.zones, z.id, 1); return d; })}>
+              <Icon name="chevron" size={12} />
+            </button>
             <button className="iconbtn" style={{ width: 22, height: 22 }} title="Delete zone"
               onClick={() => {
                 const held = counts.get(z.id) ?? 0;

--- a/src/components/History.tsx
+++ b/src/components/History.tsx
@@ -14,6 +14,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Icon } from './Icon';
+import { useAsk } from './Ask';
 import { byArea, diffArchitecture, summarise, type ChangeKind } from '@/lib/diff';
 import type { Architecture, RevisionRecord } from '@/lib/types';
 
@@ -52,6 +53,7 @@ export default function History({ projectId, doc, dirty, onClose, onRestore }: {
   const [picked, setPicked] = useState<string | null>(null);
   const [past, setPast] = useState<Architecture | null>(null);
   const [busy, setBusy] = useState(false);
+  const ask = useAsk();
   const [error, setError] = useState('');
 
   const load = useCallback(async (select?: string) => {
@@ -81,7 +83,11 @@ export default function History({ projectId, doc, dirty, onClose, onRestore }: {
   const current = list?.find(r => r.id === picked) ?? null;
 
   async function checkpoint() {
-    const label = prompt('Name this checkpoint', 'Sent to the client');
+    const label = await ask.text({
+      title: 'Save a checkpoint',
+      body: 'A named version is never pruned — the thirty-snapshot cap only ever removes automatic ones.',
+      label: 'Name', value: 'Sent to the client', confirmLabel: 'Save'
+    });
     if (label === null) return;
     setBusy(true); setError('');
     try {
@@ -95,8 +101,12 @@ export default function History({ projectId, doc, dirty, onClose, onRestore }: {
   }
 
   async function rename(rev: RevisionRecord) {
-    const label = prompt('Name this version — an empty name makes it an ordinary snapshot again',
-      rev.label ?? '');
+    const label = await ask.text({
+      title: 'Name this version',
+      body: 'A named version is kept for good. Clearing the name makes it an ordinary snapshot again, and it can then be pruned.',
+      label: 'Name', value: rev.label ?? '', placeholder: 'Sent to the client',
+      allowEmpty: true
+    });
     if (label === null) return;
     setBusy(true);
     await fetch(`/api/projects/${projectId}/revisions`, {
@@ -108,7 +118,12 @@ export default function History({ projectId, doc, dirty, onClose, onRestore }: {
   }
 
   async function remove(rev: RevisionRecord) {
-    if (!confirm(`Delete the version from ${stamp(rev.createdAt)}? The document itself is untouched.`)) return;
+    const ok = await ask.confirm({
+      title: `Delete the version from ${stamp(rev.createdAt)}?`,
+      body: 'The document itself is untouched — only this snapshot of it goes, and it cannot be brought back.',
+      danger: true
+    });
+    if (!ok) return;
     setBusy(true);
     await fetch(`/api/projects/${projectId}/revisions?revisionId=${encodeURIComponent(rev.id)}`,
       { method: 'DELETE' }).catch(() => setError('Could not delete it.'));
@@ -119,11 +134,15 @@ export default function History({ projectId, doc, dirty, onClose, onRestore }: {
 
   async function restore(rev: RevisionRecord) {
     const n = diff?.total ?? 0;
-    if (!confirm(
-      `Restore the version from ${stamp(rev.createdAt)}?\n\n`
-      + `${n} change${n === 1 ? '' : 's'} made since then will be undone. `
-      + 'The current version is kept in the history as "Before restore", so this is reversible.'
-    )) return;
+    const ok = await ask.confirm({
+      title: `Restore the version from ${stamp(rev.createdAt)}?`,
+      body: <>
+        {n} change{n === 1 ? '' : 's'} made since then will be undone. The current version is kept
+        in the history as <b>Before restore</b>, so this is reversible.
+      </>,
+      confirmLabel: 'Restore'
+    });
+    if (!ok) return;
 
     setBusy(true); setError('');
     try {
@@ -139,6 +158,7 @@ export default function History({ projectId, doc, dirty, onClose, onRestore }: {
   }
 
   return (
+    <>
     <div className="modal-scrim" onClick={onClose}>
       <div className="modal wide" onClick={e => e.stopPropagation()}>
         <div className="modal-head">
@@ -237,5 +257,7 @@ export default function History({ projectId, doc, dirty, onClose, onRestore }: {
         </div>
       </div>
     </div>
+    {ask.dialog}
+    </>
   );
 }

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -42,8 +42,13 @@ export const ICONS: Record<string, string> = {
   terminal: '<rect x="2.5" y="4" width="19" height="16" rx="2"/><path d="m7 9 3 3-3 3M13 15h4"/>',
   ai: '<path d="M12 3v3M12 18v3M3 12h3M18 12h3"/><rect x="7" y="7" width="10" height="10" rx="3"/><path d="M11 11h2v2h-2z"/>',
 
-  /* studio-only glyphs */
+  /* studio-only glyphs — not in the viewer's map, because nothing exported ever
+     draws them: they belong to the editor's chrome rather than to a card. */
   plus: '<path d="M12 5v14M5 12h14"/>',
+  minus: '<path d="M5 12h14"/>',
+  undo: '<path d="M9 14 4 9l5-5"/><path d="M4 9h10a6 6 0 0 1 0 12h-2.5"/>',
+  redo: '<path d="m15 14 5-5-5-5"/><path d="M20 9H10a6 6 0 0 0 0 12h2.5"/>',
+  expand: '<path d="M4 9V4h5M20 15v5h-5M15 4h5v5M9 20H4v-5"/>',
   trash: '<path d="M4 7h16M9 7V4h6v3M6 7l1 14h10l1-14"/>',
   chevron: '<path d="m9 5 7 7-7 7"/>',
   dots: '<circle cx="12" cy="5" r="1.4"/><circle cx="12" cy="12" r="1.4"/><circle cx="12" cy="19" r="1.4"/>',

--- a/src/components/Inspector.tsx
+++ b/src/components/Inspector.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Icon, ICONS } from './Icon';
 import { ICON_KEYS, deleteComponent, slugify } from '@/lib/defaults';
 import { displayLayerLabel } from '@/lib/layers';
@@ -10,18 +10,24 @@ import {
 import { LIFECYCLES, STATE_BLURBS, STATE_LABELS } from '@/lib/lifecycle';
 import { MARK_BLURBS, MARK_ICON, MARK_LABELS, SECURITY_MARKS } from '@/lib/marks';
 import { describeZone } from '@/lib/zones';
+import type { Notify } from '@/lib/undo';
 import type { Architecture, Component, Link, LinkKind } from '@/lib/types';
 
 type Patch = (fn: (d: Architecture) => Architecture) => void;
 
-export default function Inspector({ doc, patch, component, onClose, onSelect }: {
+export default function Inspector({ doc, patch, component, notify, openLink, onClose, onSelect }: {
   doc: Architecture; patch: Patch; component: Component | null;
+  notify: Notify;
+  /** A dependency selected on the canvas — its row opens on its own, so clicking
+   *  a line lands on the three fields that describe it. */
+  openLink?: string | null;
   onClose: () => void; onSelect: (id: string) => void;
 }) {
   return (
     <aside className="inspector">
       {component
-        ? <ComponentForm doc={doc} patch={patch} comp={component} onClose={onClose} onSelect={onSelect} />
+        ? <ComponentForm doc={doc} patch={patch} comp={component} notify={notify}
+            openLink={openLink ?? null} onClose={onClose} onSelect={onSelect} />
         : <DocumentForm doc={doc} patch={patch} />}
     </aside>
   );
@@ -29,8 +35,9 @@ export default function Inspector({ doc, patch, component, onClose, onSelect }: 
 
 /* ------------------------------------------------------------------ component */
 
-function ComponentForm({ doc, patch, comp, onClose, onSelect }: {
-  doc: Architecture; patch: Patch; comp: Component; onClose: () => void; onSelect: (id: string) => void;
+function ComponentForm({ doc, patch, comp, notify, openLink, onClose, onSelect }: {
+  doc: Architecture; patch: Patch; comp: Component; notify: Notify; openLink: string | null;
+  onClose: () => void; onSelect: (id: string) => void;
 }) {
   const [techDraft, setTechDraft] = useState('');
   const [showIcons, setShowIcons] = useState(false);
@@ -204,7 +211,7 @@ function ComponentForm({ doc, patch, comp, onClose, onSelect }: {
         <div className="cardlist">
           {outbound.map(t => (
             <LinkRow key={t.id} comp={comp} target={t} colour={colourOf(t.group)}
-              set={set} onSelect={onSelect} />
+              set={set} notify={notify} reveal={openLink === t.id} onSelect={onSelect} />
           ))}
         </div>
         <select className="select" style={{ marginTop: 6 }} value=""
@@ -237,13 +244,16 @@ function ComponentForm({ doc, patch, comp, onClose, onSelect }: {
       )}
 
       <div className="insp-sep" />
+      {/* No confirm: the deletion is one step on the undo stack and the notice
+          that follows offers it back. A dialog here would tax every deliberate
+          delete to insure against the rare accidental one. */}
       <button className="btn danger" style={{ width: '100%', justifyContent: 'center' }}
         onClick={() => {
-          if (!confirm(`Delete "${comp.name}"? Dependencies pointing at it are removed too.`)) return;
           patch(d => {
             deleteComponent(d, comp.id);
             return d;
           });
+          notify(`"${comp.name}" deleted — dependencies pointing at it went with it`);
           onClose();
         }}>
         <Icon name="trash" size={15} />Delete component
@@ -258,13 +268,26 @@ function ComponentForm({ doc, patch, comp, onClose, onSelect }: {
  * twist and the head carries what they add up to — "SQL · async". A dependency
  * nobody has annotated shows nothing extra, which is also what it draws on the
  * canvas: a plain solid edge. */
-function LinkRow({ comp, target, colour, set, onSelect }: {
+function LinkRow({ comp, target, colour, set, notify, reveal, onSelect }: {
   comp: Component; target: Component; colour: string;
-  set: (fn: (c: Component) => void) => void; onSelect: (id: string) => void;
+  set: (fn: (c: Component) => void) => void; notify: Notify;
+  /** This is the line that was just clicked on the canvas. */
+  reveal: boolean;
+  onSelect: (id: string) => void;
 }) {
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(reveal);
   const link = linkOf(comp, target.id);
   const summary = shortLink(link);
+
+  /* Opens on reveal but never closes on it: the canvas says which row to show,
+   * and the twist stays the reader's after that. `scrollIntoView` because a
+   * caller with a dozen dependencies has this one below the fold. */
+  const row = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!reveal) return;
+    setOpen(true);
+    row.current?.scrollIntoView({ block: 'nearest' });
+  }, [reveal]);
 
   /* Links are keyed by target, so an edit is an upsert and clearing every
    * field removes the row — normalisation would drop an empty one anyway, and
@@ -280,7 +303,7 @@ function LinkRow({ comp, target, colour, set, onSelect }: {
   });
 
   return (
-    <div className={`elist${open ? ' open' : ''}`}>
+    <div className={`elist${open ? ' open' : ''}${reveal ? ' revealed' : ''}`} ref={row}>
       <div className="elist-head">
         <button className="iconbtn twist" onClick={() => setOpen(o => !o)}
           aria-expanded={open} aria-label={open ? 'Collapse' : 'Describe this dependency'}>
@@ -293,10 +316,13 @@ function LinkRow({ comp, target, colour, set, onSelect }: {
           {summary && <em className="mono"> {summary}</em>}
         </span>
         <button className="iconbtn" title="Remove this dependency"
-          onClick={() => set(c => {
-            c.deps = (c.deps || []).filter(x => x !== target.id);
-            c.links = (c.links || []).filter(l => l.to !== target.id);
-          })}><Icon name="trash" size={13} /></button>
+          onClick={() => {
+            set(c => {
+              c.deps = (c.deps || []).filter(x => x !== target.id);
+              c.links = (c.links || []).filter(l => l.to !== target.id);
+            });
+            notify(`${comp.name} → ${target.name} removed`);
+          }}><Icon name="trash" size={13} /></button>
       </div>
 
       {open && (

--- a/src/components/Workspace.tsx
+++ b/src/components/Workspace.tsx
@@ -7,6 +7,7 @@ import {
   useDraggable, useDroppable, type DragEndEvent, type DragStartEvent
 } from '@dnd-kit/core';
 import { Icon } from './Icon';
+import { useAsk } from './Ask';
 import { Lockup } from './Brand';
 import { AnalyseNewDialog, useAiStatus } from './Analyse';
 import { SettingsDialog } from './Settings';
@@ -37,6 +38,7 @@ export default function Workspace({
    * exists to explain why it cannot work is worse than no button. */
   const ai = useAiStatus();
   const [busy, setBusy] = useState(false);
+  const ask = useAsk();
 
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }));
 
@@ -97,25 +99,34 @@ export default function Workspace({
   }
 
   async function addFolder(parentId: string | null) {
-    const name = prompt(parentId ? 'Name of the sub-folder' : 'Name of the folder');
-    if (!name?.trim()) return;
+    const parent = parentId ? folders.find(f => f.id === parentId) : null;
+    const name = await ask.text({
+      title: parent ? `New folder in “${parent.name}”` : 'New folder',
+      label: 'Name', placeholder: 'Payments', confirmLabel: 'Create'
+    });
+    if (!name) return;
     const color = FOLDER_COLORS[folders.length % FOLDER_COLORS.length];
     const f = await api.json<FolderRecord>('/api/folders', {
-      method: 'POST', body: JSON.stringify({ name: name.trim(), parentId, color })
+      method: 'POST', body: JSON.stringify({ name, parentId, color })
     });
     setFolders(list => [...list, f]);
     setOpen(o => ({ ...o, [f.id]: true, ...(parentId ? { [parentId]: true } : {}) }));
   }
 
   async function renameFolder(f: FolderRecord) {
-    const name = prompt('Rename folder', f.name);
-    if (!name?.trim() || name === f.name) return;
-    await api.json(`/api/folders/${f.id}`, { method: 'PATCH', body: JSON.stringify({ name: name.trim() }) });
-    setFolders(list => list.map(x => (x.id === f.id ? { ...x, name: name.trim() } : x)));
+    const name = await ask.text({ title: 'Rename folder', label: 'Name', value: f.name });
+    if (!name || name === f.name) return;
+    await api.json(`/api/folders/${f.id}`, { method: 'PATCH', body: JSON.stringify({ name }) });
+    setFolders(list => list.map(x => (x.id === f.id ? { ...x, name } : x)));
   }
 
   async function removeFolder(f: FolderRecord) {
-    if (!confirm(`Delete "${f.name}"?\n\nSub-folders go with it. Projects inside are kept and moved to Unfiled.`)) return;
+    const ok = await ask.confirm({
+      title: `Delete “${f.name}”?`,
+      body: 'Sub-folders go with it. The projects inside are kept and moved to Unfiled.',
+      danger: true
+    });
+    if (!ok) return;
     await fetch(`/api/folders/${f.id}`, { method: 'DELETE' });
     if (scope.kind === 'folder' && scope.id === f.id) setScope({ kind: 'all' });
     refresh();
@@ -283,6 +294,7 @@ export default function Workspace({
             ? 'Reading documents needs a model. Choose a provider and give it a key, and “Read a document” starts working.'
             : undefined} />
       )}
+      {ask.dialog}
     </DndContext>
   );
 }
@@ -369,6 +381,7 @@ function ProjectCard({ project, folders, onOpen, onChanged }: {
 }) {
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({ id: project.id });
   const [menu, setMenu] = useState(false);
+  const ask = useAsk();
   const accent = project.accent || PALETTE[0];
   const folder = folders.find(f => f.id === project.folderId);
 
@@ -400,18 +413,38 @@ function ProjectCard({ project, folders, onOpen, onChanged }: {
             <button onClick={() => window.open(`/api/projects/${project.id}/export?format=json`, '_blank')}>
               <Icon name="download" size={14} />Download JSON
             </button>
+            <button onClick={() => window.open(`/api/projects/${project.id}/export?format=drawio`, '_blank')}>
+              <Icon name="download" size={14} />Download draw.io
+            </button>
             <button onClick={async () => {
               await fetch(`/api/projects/${project.id}`, { method: 'POST' });
               setMenu(false); onChanged();
             }}><Icon name="copy" size={14} />Duplicate</button>
             <hr />
             <button className="danger" onClick={async () => {
-              if (!confirm(`Delete "${project.name}"? This cannot be undone.`)) return;
+              /* The menu closes first: the confirm is a second surface, and
+                 leaving the popover open behind it means two things claiming to
+                 be the thing you clicked. The dialog itself is portalled out of
+                 this menu — see useAsk — because `.pcard .menu` is `opacity: 0`
+                 off-hover, which would have painted the confirm away the moment
+                 the pointer reached it. */
+              setMenu(false);
+              const ok = await ask.confirm({
+                title: `Delete “${project.name}”?`,
+                body: <>
+                  The architecture and its {project.componentCount} component
+                  {project.componentCount === 1 ? '' : 's'} go, along with every version in its
+                  history. There is no undo for this one — export it first if you are unsure.
+                </>,
+                danger: true
+              });
+              if (!ok) return;
               await fetch(`/api/projects/${project.id}`, { method: 'DELETE' });
-              setMenu(false); onChanged();
+              onChanged();
             }}><Icon name="trash" size={14} />Delete</button>
           </div>
         )}
+        {ask.dialog}
       </div>
     </div>
   );

--- a/src/components/editors/FlowPatterns.tsx
+++ b/src/components/editors/FlowPatterns.tsx
@@ -18,6 +18,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import { Icon } from '../Icon';
+import { useAsk } from '../Ask';
 import { ScopePicker, Text } from './Fields';
 import { api } from '@/lib/api';
 import { matchSteps, type Binding } from '@/lib/flows/match';
@@ -51,6 +52,7 @@ export default function FlowPatterns({ doc, catalog, onInsert, onClose }: {
   const [group, setGroup] = useState<string | undefined>();
   const [error, setError] = useState('');
   const [busy, setBusy] = useState(false);
+  const ask = useAsk();
 
   const lang = doc.meta.lang === 'fr' ? 'fr' : 'en';
 
@@ -72,7 +74,12 @@ export default function FlowPatterns({ doc, catalog, onInsert, onClose }: {
   };
 
   const remove = async (p: LibraryPattern) => {
-    if (!confirm(`Delete the pattern "${p.name}"? It is removed from every project.`)) return;
+    const ok = await ask.confirm({
+      title: `Delete the pattern “${p.name}”?`,
+      body: 'The library is shared, so it goes from every project at once. Flows already built from it are left alone.',
+      danger: true
+    });
+    if (!ok) return;
     setBusy(true);
     try {
       const { library } = await api.json<{ library: LibraryPattern[] }>(
@@ -104,6 +111,7 @@ export default function FlowPatterns({ doc, catalog, onInsert, onClose }: {
   })();
 
   return (
+    <>
     <div className="modal-scrim" onClick={onClose}>
       <div className="modal wide" onClick={e => e.stopPropagation()}
         style={{ maxHeight: '86vh', overflowY: 'auto' }}>
@@ -186,6 +194,8 @@ export default function FlowPatterns({ doc, catalog, onInsert, onClose }: {
         </div>
       </div>
     </div>
+    {ask.dialog}
+    </>
   );
 }
 

--- a/src/components/editors/FlowsEditor.tsx
+++ b/src/components/editors/FlowsEditor.tsx
@@ -34,19 +34,25 @@ export default function FlowsEditor({ doc, patch, catalog }: { doc: Architecture
   const [picking, setPicking] = useState(false);
   /* The id of the flow currently being saved, so only its own button says so. */
   const [saving, setSaving] = useState<string | null>(null);
+  /* Why the last save to the library failed. In the panel rather than in an
+   * `alert()`: the message is about the flow it sits next to, and a modal that
+   * has to be dismissed before you can look at that flow is the wrong shape for
+   * an error you are meant to act on. */
+  const [saveError, setSaveError] = useState('');
 
   /* Reads the document from React state rather than the database, so a pattern
    * saved before the 700 ms autosave has run still captures what is on screen —
    * which is what a button sitting next to the flow it copies has to do. */
   const saveAsPattern = async (flow: Flow) => {
     setSaving(flow.id);
+    setSaveError('');
     try {
       await api.json('/api/flow-templates/library', {
         method: 'POST',
         body: JSON.stringify(toFlowPattern(doc, flow, { from: doc.meta.name }))
       });
     } catch (e) {
-      alert((e as Error).message);
+      setSaveError((e as Error).message);
     } finally {
       setSaving(null);
     }
@@ -73,6 +79,12 @@ export default function FlowsEditor({ doc, patch, catalog }: { doc: Architecture
       </Group>
 
       <Group title={`Flows (${doc.flows.length})`}>
+        {saveError && (
+          <div className="warnbox">
+            <Icon name="alert" size={15} />
+            Could not save that flow to the pattern library — {saveError}
+          </div>
+        )}
         {noComponents && (
           <div className="warnbox">
             <Icon name="alert" size={15} />

--- a/src/components/editors/SectionsEditor.tsx
+++ b/src/components/editors/SectionsEditor.tsx
@@ -18,6 +18,7 @@ import type {
   Section, SectionType, TableColumn, TableSection, TextBlock, TextSection,
   TimelinePhase, TimelineSection
 } from '@/lib/types';
+import type { Notify } from '@/lib/undo';
 
 type Patch = (fn: (d: Architecture) => Architecture) => void;
 type Mut<T> = (fn: (draft: T) => void) => void;
@@ -29,20 +30,21 @@ function fitRows(rows: string[][], n: number): string[][] {
   return rows.map(r => Array.from({ length: n }, (_, i) => r[i] ?? ''));
 }
 
-export default function SectionsEditor({ doc, patch }: { doc: Architecture; patch: Patch }) {
+export default function SectionsEditor({ doc, patch, notify }: {
+  doc: Architecture; patch: Patch; notify: Notify;
+}) {
   const [newType, setNewType] = useState<SectionType>('cards');
   const chosen = SECTION_TYPES.find(t => t.type === newType)!;
   const missing = missingPresetSections(doc);
 
   /* The preset appends chapters without registering them as tabs, so the
    * viewer is left alone — hence no `setSections` here, which would. */
+  /* No confirm. The row this button sits in already says what the chapters are
+   * and that they arrive empty, and the action adds rather than destroys — a
+   * dialog here would only be the hint again, in the way. Undo covers the rest. */
   const addPreset = () => {
-    if (!confirm(
-      `Add the ${missing} missing design-document chapters (data, scaling, tenancy, recovery, `
-      + 'observability, IAM, networking, cost, delivery…)?\n\n'
-      + 'They are added empty, for the printable document only — the viewer keeps its current tabs.'
-    )) return;
     patch(d => { applyDesignDocumentPreset(d); return d; });
+    notify(`${missing} design-document chapter${missing === 1 ? '' : 's'} added, empty — the viewer keeps its current tabs`);
   };
 
   const setSections = (next: Section[]) => patch(d => {
@@ -90,23 +92,30 @@ export default function SectionsEditor({ doc, patch }: { doc: Architecture; patc
         blank={() => blankSection(newType, doc.sections.map(s => s.id))}
         summary={s => s.tab || s.title || s.id}
         badge={s => <span className="count">{s.type}</span>}
-        render={(sec, set) => <SectionForm doc={doc} sec={sec} set={set} />} />
+        render={(sec, set) => <SectionForm doc={doc} sec={sec} set={set} notify={notify} />} />
     </Panel>
   );
 }
 
 /* ------------------------------------------------------------------- shell */
 
-function SectionForm({ doc, sec, set }: { doc: Architecture; sec: Section; set: Mut<Section> }) {
+function SectionForm({ doc, sec, set, notify }: {
+  doc: Architecture; sec: Section; set: Mut<Section>; notify: Notify;
+}) {
+  /* Both of the destructive edits below drop content and neither asks. They go
+   * through `patch`, so each is one step on the editor's undo stack, and the
+   * notice says what went and offers it straight back — which is the answer this
+   * app gives everywhere the document itself is what changed. */
   const changeType = (type: SectionType) => {
     if (type === sec.type) return;
-    if (!confirm(`Switch "${sec.tab || sec.title}" to a ${type} section? Its current content is dropped.`)) return;
+    const was = sec.type;
     set(s => {
       Object.keys(s).forEach(k => { if (!KEEP.includes(k)) delete s[k]; });
       const fresh = blankSection(type, []) as Record<string, unknown>;
       Object.entries(fresh).forEach(([k, v]) => { if (!KEEP.includes(k)) s[k] = v; });
       s.type = type;
     });
+    notify(`“${sec.tab || sec.title}” switched from ${was} to ${type} — its ${was} content was dropped`);
   };
 
   return (
@@ -139,7 +148,8 @@ function SectionForm({ doc, sec, set }: { doc: Architecture; sec: Section; set: 
       {sec.type === 'cards' && <CardsForm doc={doc} sec={sec as CardsSection} set={set as Mut<CardsSection>} />}
       {sec.type === 'timeline' && <TimelineForm doc={doc} sec={sec as TimelineSection} set={set as Mut<TimelineSection>} />}
       {sec.type === 'table' && <TableForm doc={doc} sec={sec as TableSection} set={set as Mut<TableSection>} />}
-      {sec.type === 'compare' && <CompareForm doc={doc} sec={sec as CompareSection} set={set as Mut<CompareSection>} />}
+      {sec.type === 'compare' && <CompareForm doc={doc} sec={sec as CompareSection}
+        set={set as Mut<CompareSection>} notify={notify} />}
       {sec.type === 'text' && <TextForm doc={doc} sec={sec as TextSection} set={set as Mut<TextSection>} />}
     </>
   );
@@ -258,7 +268,9 @@ function TableForm({ doc, sec, set }: { doc: Architecture; sec: TableSection; se
 
 /* ----------------------------------------------------------------- compare */
 
-function CompareForm({ doc, sec, set }: { doc: Architecture; sec: CompareSection; set: Mut<CompareSection> }) {
+function CompareForm({ doc, sec, set, notify }: {
+  doc: Architecture; sec: CompareSection; set: Mut<CompareSection>; notify: Notify;
+}) {
   const poles = sec.columns || [];
   const tableHeaders = [sec.table?.firstColumn || 'Dimension', ...poles.map(p => p.short || p.title || '—')];
 
@@ -318,7 +330,9 @@ function CompareForm({ doc, sec, set }: { doc: Architecture; sec: CompareSection
               hint="One row per dimension. The remaining columns follow the poles above."
               onChange={rows => set(s => { s.table!.rows = rows; })} />
             <button className="btn sm danger" onClick={() => {
-              if (confirm('Remove the comparison table and its rows?')) set(s => { s.table = undefined; });
+              const rows = sec.table?.rows?.length ?? 0;
+              set(s => { s.table = undefined; });
+              notify(`Comparison table removed${rows ? ` — ${rows} row${rows === 1 ? '' : 's'} with it` : ''}`);
             }}>
               <Icon name="trash" size={13} />Remove the table
             </button>

--- a/src/lib/dnd.test.ts
+++ b/src/lib/dnd.test.ts
@@ -1,0 +1,165 @@
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+
+import { blankArchitecture, normalizeArchitecture } from './defaults';
+import {
+  bandDropId, DEPTH, dropChangesAnything, layerDropId, PALETTE_NEW, parseDropId,
+  railZoneDropId, resolveDrop
+} from './dnd';
+import type { Architecture, Component, Zone } from './types';
+
+const comp = (id: string, layer: string, zone?: string): Component => ({
+  id, name: id, group: 'core', layer, zone, icon: 'box',
+  tech: [], features: [], notes: [], deps: []
+});
+
+const build = (components: Component[], zones: Zone[] = []): Architecture =>
+  normalizeArchitecture({
+    ...blankArchitecture('Test'),
+    groups: [{ id: 'core', name: 'Core' }],
+    layers: [{ id: 'edge', name: 'Edge' }, { id: 'data', name: 'Data' }],
+    zones, components
+  });
+
+const ZONES: Zone[] = [{ id: 'ocp', name: 'OpenShift' }, { id: 'dmz', name: 'DMZ' }];
+
+/* ------------------------------------------------------------------- ids */
+
+test('a target id survives a round trip', () => {
+  assert.deepEqual(parseDropId(layerDropId('edge')), { kind: 'layer', layer: 'edge' });
+  assert.deepEqual(parseDropId(bandDropId('edge', 'ocp')), { kind: 'band', layer: 'edge', zone: 'ocp' });
+  assert.deepEqual(parseDropId(bandDropId('edge', undefined)), { kind: 'band', layer: 'edge', zone: undefined });
+  assert.deepEqual(parseDropId(railZoneDropId('ocp')), { kind: 'railzone', zone: 'ocp' });
+});
+
+test('an id containing the separator still parses', () => {
+  /* Slugs never contain a colon, but an imported document brings its own ids and
+   * nothing re-slugs them. JSON is what makes that a non-question. */
+  const id = bandDropId('a:b:c', 'x:y');
+  assert.deepEqual(parseDropId(id), { kind: 'band', layer: 'a:b:c', zone: 'x:y' });
+});
+
+test('a component id is not a target id', () => {
+  assert.equal(parseDropId('api-gateway'), null);
+  assert.equal(parseDropId('layer:not-json'), null);
+  assert.equal(parseDropId(PALETTE_NEW), null);
+});
+
+test('the most specific target outranks the ones holding it', () => {
+  assert.ok(DEPTH.component > DEPTH.band);
+  assert.ok(DEPTH.band > DEPTH.layer);
+});
+
+/* -------------------------------------------------------------- onto a card */
+
+test('dropping onto a card takes its place, its layer and its zone', () => {
+  const doc = build([comp('a', 'edge'), comp('b', 'data', 'ocp')], ZONES);
+  assert.deepEqual(resolveDrop(doc, 'a', 'b'),
+    { componentId: 'a', layer: 'data', zone: 'ocp', before: 'b' });
+});
+
+test('a card dropped beside an unzoned card leaves the zone it was in', () => {
+  /* The drawing would otherwise show a card inside a rectangle the data says it
+   * is not in. */
+  const doc = build([comp('a', 'edge', 'ocp'), comp('b', 'edge')], ZONES);
+  assert.equal(resolveDrop(doc, 'a', 'b')?.zone, undefined);
+});
+
+test('dropping a card on itself means nothing', () => {
+  const doc = build([comp('a', 'edge')]);
+  assert.equal(resolveDrop(doc, 'a', 'a'), null);
+});
+
+/* -------------------------------------------------------------- onto a band */
+
+test('dropping in a band moves into that zone and appends', () => {
+  const doc = build([comp('a', 'edge')], ZONES);
+  assert.deepEqual(resolveDrop(doc, 'a', bandDropId('data', 'ocp')),
+    { componentId: 'a', layer: 'data', zone: 'ocp', before: undefined });
+});
+
+test('the unzoned band is how a card leaves a zone', () => {
+  const doc = build([comp('a', 'edge', 'ocp')], ZONES);
+  assert.equal(resolveDrop(doc, 'a', bandDropId('edge', undefined))?.zone, undefined);
+});
+
+test('a band naming a zone that has been deleted lands unzoned, not in a ghost', () => {
+  const doc = build([comp('a', 'edge')], ZONES);
+  assert.equal(resolveDrop(doc, 'a', bandDropId('edge', 'gone'))?.zone, undefined);
+});
+
+test('a band naming a layer that does not exist is refused outright', () => {
+  const doc = build([comp('a', 'edge')], ZONES);
+  assert.equal(resolveDrop(doc, 'a', bandDropId('nowhere', 'ocp')), null);
+});
+
+/* --------------------------------------------------------------- onto a row */
+
+test('the bare row changes the layer and keeps the zone', () => {
+  /* On a zoned sheet the only bare row is the gutter between two bands — too
+   * ambiguous to read as "leave your zone". */
+  const doc = build([comp('a', 'edge', 'ocp')], ZONES);
+  assert.deepEqual(resolveDrop(doc, 'a', layerDropId('data')),
+    { componentId: 'a', layer: 'data', zone: 'ocp', before: undefined });
+});
+
+/* ------------------------------------------------------------- the palette */
+
+test('the palette creates rather than moves, and creates unzoned', () => {
+  const doc = build([comp('a', 'edge')], ZONES);
+  assert.deepEqual(resolveDrop(doc, PALETTE_NEW, layerDropId('data')),
+    { componentId: null, layer: 'data', zone: undefined, before: undefined });
+});
+
+test('the palette dropped in a band creates inside that zone', () => {
+  const doc = build([comp('a', 'edge')], ZONES);
+  assert.equal(resolveDrop(doc, PALETTE_NEW, bandDropId('edge', 'dmz'))?.zone, 'dmz');
+});
+
+test('the palette dropped on a rail zone row says nothing about the layer, so nothing happens', () => {
+  const doc = build([comp('a', 'edge')], ZONES);
+  assert.equal(resolveDrop(doc, PALETTE_NEW, railZoneDropId('ocp')), null);
+});
+
+/* ------------------------------------------------------------ the rail rows */
+
+test('a rail zone row changes the zone and leaves the layer alone', () => {
+  /* The only way into a zone that holds nothing yet: an empty zone reserves no
+   * band, so it has no target on the sheet. */
+  const doc = build([comp('a', 'edge')], ZONES);
+  assert.deepEqual(resolveDrop(doc, 'a', railZoneDropId('ocp')),
+    { componentId: 'a', layer: 'edge', zone: 'ocp', before: undefined });
+});
+
+/* -------------------------------------------------------------- no-op drops */
+
+test('a release that changes nothing is not a step on the undo stack', () => {
+  const doc = build([comp('a', 'edge'), comp('b', 'edge')]);
+  /* `b` is already last in its run; appending it again changes nothing. */
+  const drop = resolveDrop(doc, 'b', layerDropId('edge'))!;
+  assert.equal(dropChangesAnything(doc, drop), false);
+});
+
+test('dropping a card on the one already behind it changes nothing', () => {
+  const doc = build([comp('a', 'edge'), comp('b', 'edge'), comp('c', 'edge')]);
+  /* Dropping `a` in front of `b` leaves the order exactly as it was. */
+  assert.equal(dropChangesAnything(doc, resolveDrop(doc, 'a', 'b')!), false);
+  assert.equal(dropChangesAnything(doc, resolveDrop(doc, 'a', 'c')!), true);
+});
+
+test('a change of layer or zone always counts', () => {
+  const doc = build([comp('a', 'edge')], ZONES);
+  assert.equal(dropChangesAnything(doc, resolveDrop(doc, 'a', layerDropId('data'))!), true);
+  assert.equal(dropChangesAnything(doc, resolveDrop(doc, 'a', bandDropId('edge', 'ocp'))!), true);
+});
+
+test('appending a card that is not already last counts', () => {
+  const doc = build([comp('a', 'edge'), comp('b', 'edge')]);
+  assert.equal(dropChangesAnything(doc, resolveDrop(doc, 'a', layerDropId('edge'))!), true);
+});
+
+test('a creation always counts, even onto the row it would already be in', () => {
+  const doc = build([comp('a', 'edge')]);
+  assert.equal(
+    dropChangesAnything(doc, resolveDrop(doc, PALETTE_NEW, layerDropId('edge'))!), true);
+});

--- a/src/lib/dnd.ts
+++ b/src/lib/dnd.ts
@@ -1,0 +1,131 @@
+/* Where a dropped card lands.
+ *
+ * The sheet has four kinds of drop target and three of them are nested inside
+ * one another — a card sits in a band, a band sits in a layer — so "what is
+ * under the pointer" has more than one true answer and the drop has to pick the
+ * most specific one. That is `DEPTH`, read by the collision detection in
+ * Editor.tsx; without it dnd-kit's default ranks by intersected *area* and the
+ * biggest box wins, which is always the wrong one.
+ *
+ * The rest is `resolveDrop`: given what is being dragged and what it was
+ * released over, say which layer, which zone and which position. It is a pure
+ * function of the document because that is the half worth testing — the DOM
+ * half is dnd-kit's and it already works.
+ *
+ * Target ids carry two values (a layer and a zone), and component ids are not
+ * guaranteed to be slugs — an imported document brings its own. So the payload
+ * is JSON rather than a separator someone's id could contain. */
+
+import type { Architecture } from './types';
+
+/** The palette's draggable. Dropping it creates rather than moves. */
+export const PALETTE_NEW = 'palette:new';
+
+export type DropKind = 'component' | 'band' | 'layer' | 'railzone';
+
+/** Most specific wins. A card beats the band holding it, a band beats the row. */
+export const DEPTH: Record<DropKind, number> = {
+  component: 3,
+  railzone: 3,
+  band: 2,
+  layer: 1
+};
+
+export const layerDropId = (layer: string) => `layer:${JSON.stringify([layer])}`;
+export const bandDropId = (layer: string, zone: string | undefined) =>
+  `band:${JSON.stringify([layer, zone ?? null])}`;
+export const railZoneDropId = (zone: string) => `railzone:${JSON.stringify([zone])}`;
+
+export interface ParsedDrop { kind: Exclude<DropKind, 'component'>; layer?: string; zone?: string }
+
+export function parseDropId(id: string): ParsedDrop | null {
+  const at = id.indexOf(':');
+  if (at < 0) return null;
+  const kind = id.slice(0, at);
+  if (kind !== 'layer' && kind !== 'band' && kind !== 'railzone') return null;
+  let parts: unknown;
+  try { parts = JSON.parse(id.slice(at + 1)); } catch { return null; }
+  if (!Array.isArray(parts)) return null;
+  if (kind === 'layer') return { kind, layer: String(parts[0]) };
+  if (kind === 'railzone') return { kind, zone: String(parts[0]) };
+  return { kind, layer: String(parts[0]), zone: parts[1] == null ? undefined : String(parts[1]) };
+}
+
+export interface DropResult {
+  /** The component being placed, or null when the palette is creating one. */
+  componentId: string | null;
+  layer: string;
+  /** undefined is unzoned, and is a real answer rather than "unchanged". */
+  zone: string | undefined;
+  /** Insert in front of this component; undefined appends to the run. */
+  before: string | undefined;
+}
+
+/** What a release means, or null when it means nothing. */
+export function resolveDrop(
+  doc: Architecture, activeId: string, overId: string | null
+): DropResult | null {
+  if (!overId || overId === activeId) return null;
+
+  const creating = activeId === PALETTE_NEW;
+  const active = creating ? null : doc.components.find(c => c.id === activeId);
+  if (!creating && !active) return null;
+  const componentId = active?.id ?? null;
+
+  const known = (layer: string) => doc.layers.some(l => l.id === layer);
+  /* A zone that has been deleted since the drag started is unzoned, which is the
+   * same reading normalisation gives a stale `zone` — the two cannot disagree. */
+  const zoneOf = (zone: string | undefined) =>
+    (zone && doc.zones.some(z => z.id === zone) ? zone : undefined);
+
+  /* Onto another card: take its place, and with it its layer *and its zone*.
+   * Landing beside a card without joining what holds it would put the drawing
+   * and the data at odds — the card would sit inside a rectangle it does not
+   * belong to. */
+  const target = doc.components.find(c => c.id === overId);
+  if (target) {
+    return { componentId, layer: target.layer, zone: zoneOf(target.zone), before: target.id };
+  }
+
+  const parsed = parseDropId(overId);
+  if (!parsed) return null;
+
+  if (parsed.kind === 'band') {
+    if (!parsed.layer || !known(parsed.layer)) return null;
+    return { componentId, layer: parsed.layer, zone: zoneOf(parsed.zone), before: undefined };
+  }
+
+  if (parsed.kind === 'layer') {
+    if (!parsed.layer || !known(parsed.layer)) return null;
+    /* The bare row, which on a zoned sheet is only the gutters between bands.
+     * Too ambiguous to reassign a zone from, so the card keeps the one it had;
+     * a new component from the palette has none to keep. */
+    return { componentId, layer: parsed.layer, zone: zoneOf(active?.zone), before: undefined };
+  }
+
+  /* A zone row in the rail. This is the way into a zone that holds nothing yet:
+   * an empty zone reserves no band, so it has no target on the sheet at all. */
+  if (!active) return null;
+  return {
+    componentId: active.id, layer: active.layer, zone: zoneOf(parsed.zone), before: undefined
+  };
+}
+
+/** Whether a resolved drop would change anything, so a no-op release does not
+ *  land on the undo stack as a step with nothing in it. */
+export function dropChangesAnything(doc: Architecture, drop: DropResult): boolean {
+  if (!drop.componentId) return true;                       // a creation always does
+  const list = doc.components;
+  const at = list.findIndex(c => c.id === drop.componentId);
+  if (at < 0) return false;
+  const c = list[at];
+  if (c.layer !== drop.layer || (c.zone ?? undefined) !== drop.zone) return true;
+
+  /* Same row, same zone: only a change of position counts. Appending is a change
+   * unless the card is already the last of its run. */
+  const run = list.filter(x => x.layer === drop.layer && (x.zone ?? undefined) === drop.zone);
+  if (!drop.before) return run[run.length - 1]?.id !== drop.componentId;
+  const from = run.findIndex(x => x.id === drop.componentId);
+  const to = run.findIndex(x => x.id === drop.before);
+  return to >= 0 && to !== from && to !== from + 1;
+}

--- a/src/lib/export/drawio.test.ts
+++ b/src/lib/export/drawio.test.ts
@@ -1,0 +1,164 @@
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import { normalizeArchitecture } from '../defaults';
+import { LINK_DASH } from '../links';
+import type { Architecture } from '../types';
+import { buildDrawioXml } from './drawio';
+
+const doc = (over: Partial<Architecture> = {}): Architecture => normalizeArchitecture({
+  meta: { name: 'Landscape', lang: 'en' },
+  layers: [{ id: 'clients', name: 'Clients' }, { id: 'services', name: 'Services' }],
+  groups: [{ id: 'core', name: 'Core', color: '#0099A0' }],
+  zones: [{ id: 'openshift', name: 'OpenShift', kind: 'platform' }],
+  components: [
+    { id: 'web', name: 'Web', group: 'core', layer: 'clients', role: 'React SPA', deps: ['api'] },
+    { id: 'api', name: 'API', group: 'core', layer: 'services', zone: 'openshift', tech: ['Java'] }
+  ],
+  ...over
+});
+
+/* A hand-rolled walk over the tags, which is all these assertions need and is
+ * one fewer dependency than an XML parser. It also fails loudly on the one
+ * mistake that matters — an unbalanced or unescaped document — because the
+ * regexes below stop matching the moment the shape is wrong. */
+const cells = (xml: string): string[] => xml.match(/<(mxCell|object)\b[^>]*>/g) || [];
+
+test('the file is a well-formed mxfile with one diagram and a root', () => {
+  const xml = buildDrawioXml(doc());
+  assert.ok(xml.startsWith('<?xml version="1.0" encoding="UTF-8"?><mxfile '));
+  assert.ok(xml.includes('<diagram id="architecture" name="Landscape">'));
+  assert.ok(xml.includes('<mxGraphModel '));
+  assert.ok(xml.includes('<root><mxCell id="0"/><mxCell id="1" parent="0"/>'));
+  assert.ok(xml.endsWith('</mxGraphModel></diagram></mxfile>'));
+});
+
+test('every tag opened is closed, and every attribute quote is balanced', () => {
+  const xml = buildDrawioXml(doc());
+  const opens = (xml.match(/<(?!\/|\?)[a-zA-Z]/g) || []).length;
+  const closes = (xml.match(/<\//g) || []).length + (xml.match(/\/>/g) || []).length;
+  assert.equal(opens, closes, 'an unbalanced tag would be a file draw.io refuses to open');
+  assert.equal((xml.match(/"/g) || []).length % 2, 0);
+});
+
+test('every component is a cell, and every edge points at two of them', () => {
+  const xml = buildDrawioXml(doc());
+  assert.ok(xml.includes('<object id="n-web"'));
+  assert.ok(xml.includes('<object id="n-api"'));
+  assert.ok(xml.includes('source="n-web" target="n-api"'),
+    'the edge should reference its endpoints by id so draw.io reroutes them');
+  assert.ok(xml.includes('<mxGeometry relative="1" as="geometry"/>'));
+});
+
+test('the edge grammar survives the trip: a filled disc, an open circle, no arrowhead', () => {
+  const xml = buildDrawioXml(doc());
+  assert.ok(xml.includes('startArrow=oval;startFill=1'));
+  assert.ok(xml.includes('endArrow=oval;endFill=0'));
+  assert.ok(!/endArrow=(block|classic|open)/.test(xml), 'no arrowhead belongs on these lines');
+});
+
+test('a link kind crosses as the dash pattern it is drawn with here', () => {
+  const xml = buildDrawioXml(doc({
+    components: [
+      { id: 'web', name: 'Web', group: 'core', layer: 'clients', deps: ['api'],
+        links: [{ to: 'api', kind: 'async' }] },
+      { id: 'api', name: 'API', group: 'core', layer: 'services' }
+    ]
+  }));
+  assert.ok(xml.includes(`dashPattern=${LINK_DASH.async};`),
+    'the dash table in lib/links.ts is the single source and this export reads it');
+});
+
+test('a scope colour rides in the card label rather than on its border', () => {
+  const xml = buildDrawioXml(doc());
+  assert.ok(xml.includes('&lt;font color=&quot;#0099A0&quot;&gt;'),
+    'the scope square carries the colour, inside the value');
+
+  /* Rule 1 is about the card. An edge *is* drawn in its caller's scope colour —
+   * that is the reading the canvas and the printed sheet both give it — so the
+   * assertion has to be about the component cells and not about the file. */
+  const card = xml.match(/<object id="n-web"[\s\S]*?<\/object>/)![0];
+  assert.ok(!card.includes('strokeColor=#0099A0'), 'a scope colour never touches a border');
+  assert.ok(card.includes('strokeColor=#D3DEE5'), 'the border is the neutral card edge');
+});
+
+test('a platform zone is solid and a logical one is dashed', () => {
+  const solid = buildDrawioXml(doc());
+  assert.match(solid, /fillColor=#F8F8F9;[^"]*dashed=0;/);
+
+  const dashed = buildDrawioXml(doc({
+    zones: [{ id: 'dmz', name: 'DMZ', kind: 'network' }],
+    components: [{ id: 'api', name: 'API', group: 'core', layer: 'services', zone: 'dmz' }]
+  }));
+  assert.match(dashed, /fillColor=#F8F8F9;[^"]*dashed=1;dashPattern=5 4;/);
+});
+
+test('what the picture cannot carry travels as cell data', () => {
+  const xml = buildDrawioXml(doc({
+    components: [{
+      id: 'api', name: 'API', group: 'core', layer: 'services', zone: 'openshift',
+      tech: ['Java', 'Spring'], marks: ['sso', 'pii'], state: 'changed', url: 'https://x.test'
+    }]
+  }));
+  assert.ok(xml.includes('archId="api"'));
+  assert.ok(xml.includes('scope="Core"'));
+  assert.ok(xml.includes('layer="Services"'));
+  assert.ok(xml.includes('zone="OpenShift"'));
+  assert.ok(xml.includes('tech="Java, Spring"'));
+  assert.ok(xml.includes('security="SSO protected, holds personal data"'));
+  assert.ok(xml.includes('state="updated"'));
+  assert.ok(xml.includes('link="https://x.test"'));
+});
+
+/* The bug this file exists to prevent. A cell's value is HTML inside an XML
+ * attribute, so authored text is escaped twice; getting either half wrong is
+ * either a card reading "R&amp;D" or a file draw.io will not open at all. */
+test('an ampersand in a name survives both parsers', () => {
+  const xml = buildDrawioXml(doc({
+    groups: [{ id: 'core', name: 'R&D <ops>', color: '#0099A0' }],
+    components: [{ id: 'web', name: 'Search & Rescue', group: 'core', layer: 'clients' }]
+  }));
+  assert.ok(xml.includes('Search &amp;amp; Rescue'),
+    'the HTML parser has to see &amp; so the reader sees &');
+  assert.ok(!/&(?!amp;|lt;|gt;|quot;|#)/.test(xml),
+    'a bare ampersand anywhere is a file that will not parse');
+  assert.ok(xml.includes('R&amp;amp;D &amp;lt;ops&amp;gt;'),
+    'angle brackets in a legend label must not become markup');
+  /* Cell *data* is plain text rather than HTML, so it is escaped once — the
+   * asymmetry is deliberate and this is where it would silently drift. */
+  assert.ok(xml.includes('scope="R&amp;D &lt;ops&gt;"'));
+});
+
+test('a quote in a name cannot break out of an attribute', () => {
+  const xml = buildDrawioXml(doc({
+    components: [{ id: 'web', name: 'The "Web" app', group: 'core', layer: 'clients' }]
+  }));
+  assert.ok(xml.includes('&quot;Web&quot;'));
+  assert.equal((xml.match(/"/g) || []).length % 2, 0);
+});
+
+test('an id that is not a slug cannot break a cell reference', () => {
+  const xml = buildDrawioXml({
+    ...doc(),
+    zones: [],
+    components: [
+      { id: 'a b"c', name: 'A', group: 'core', layer: 'clients', deps: ['d/e'] },
+      { id: 'd/e', name: 'D', group: 'core', layer: 'services' }
+    ]
+  });
+  assert.ok(xml.includes('<object id="n-a_b_c"'));
+  assert.ok(xml.includes('source="n-a_b_c" target="n-d_e"'));
+});
+
+test('zones come before the cards they sit behind, and cards before their lines', () => {
+  const xml = buildDrawioXml(doc());
+  const order = cells(xml).map(c =>
+    /id="z-/.test(c) ? 'zone' : /id="n-/.test(c) ? 'node' : /id="e-/.test(c) ? 'edge' : 'other');
+  assert.ok(order.indexOf('zone') < order.indexOf('node'), 'a zone is the ground, not the figure');
+  assert.ok(order.indexOf('node') < order.indexOf('edge'));
+});
+
+test('an empty document still produces a file draw.io can open', () => {
+  const xml = buildDrawioXml(normalizeArchitecture({ meta: { name: 'Empty' } }));
+  assert.ok(xml.includes('<root><mxCell id="0"/><mxCell id="1" parent="0"/>'));
+  assert.ok(xml.endsWith('</mxfile>'));
+});

--- a/src/lib/export/drawio.ts
+++ b/src/lib/export/drawio.ts
@@ -1,0 +1,270 @@
+/* The diagram as a draw.io file.
+ *
+ * Every other export leaves with the drawing finished: the standalone HTML is a
+ * viewer, the SVG and the PNG are pictures. This one leaves with it *open*. The
+ * reason to want that is not that draw.io draws better — it does not draw this
+ * at all — it is that an architecture diagram has a second life in rooms this
+ * app is not in, where someone has to move a box during the meeting, and the
+ * tool in that room is draw.io.
+ *
+ * -------------------------------------------------------------------- fidelity
+ *
+ * What crosses intact: the band layout, the zone rectangles and their two stroke
+ * treatments, the scope colour, the layer rules and their tint, every
+ * dependency with its kind (the dash), its protocol (the label) and its
+ * transition mark, and the edge grammar — a filled disc at the caller, an open
+ * circle at the callee, which draw.io spells `startArrow=oval;startFill=1` and
+ * `endArrow=oval;endFill=0`. No arrowheads, here as everywhere.
+ *
+ * What does not: the icons, and the security marks. Both are glyph sets this app
+ * ships and draw.io does not, and a wrong glyph is worse than none. The marks
+ * ride along as cell data instead (see below), so nothing is lost from the file
+ * even though it is lost from the picture.
+ *
+ * ---------------------------------------------------------------------- shape
+ *
+ * Flat, not nested. draw.io containers would let a reader drag a zone and take
+ * its contents with it, which is tempting — but a container's children carry
+ * geometry relative to it, and zones here nest three deep across reserved bands.
+ * Getting that wrong produces a file that opens to a pile. A flat sheet in the
+ * right order is a file that opens to the drawing, and the reader can still
+ * group by hand.
+ *
+ * Edges reference their endpoints by id rather than by waypoint, so moving a
+ * card in draw.io reroutes its lines — which is the entire point of exporting
+ * something editable.
+ *
+ * Components ship as `<object>` rather than bare `<mxCell>`, so the id, the
+ * scope, the layer, the zone, the technologies and the security marks land in
+ * draw.io's own Edit Data panel. That is what makes the export searchable there
+ * instead of merely visible.
+ */
+
+import type { Architecture } from '../types';
+import { MARK_LABELS } from '../marks';
+import { STATE_LABELS } from '../lifecycle';
+import {
+  INK, LAYER_PAD_TOP, SHEET_PAD_X, layoutSheet, zoneFill,
+  type EdgePlacement, type LayerPlacement, type NodePlacement, type Sheet, type ZonePlacement
+} from './layout';
+
+/** draw.io's own A4 landscape, and the one a new file opens on. The sheet almost
+ *  always runs wider; `page="1"` then tiles it, which is what a reader printing
+ *  a landscape diagram wants anyway. */
+const PAGE_W = 1169;
+const PAGE_H = 826;
+
+const MONO_FONT = 'Courier New';
+const SANS_FONT = 'Helvetica';
+
+export function buildDrawioXml(doc: Architecture): string {
+  return renderSheet(layoutSheet(doc));
+}
+
+export function renderSheet(sheet: Sheet): string {
+  const cells: string[] = ['<mxCell id="0"/>', '<mxCell id="1" parent="0"/>'];
+
+  if (sheet.title) cells.push(headingCells(sheet));
+  /* Outermost first: draw.io paints in document order, so a nested rectangle has
+   * to come after the one it sits inside or its tint is buried. */
+  sheet.zones.forEach((z, i) => cells.push(zoneCell(z, i)));
+  sheet.layers.forEach(l => cells.push(layerCells(l, sheet.w)));
+  sheet.nodes.forEach(n => cells.push(nodeCell(n, sheet)));
+  sheet.edges.forEach((e, i) => cells.push(edgeCell(e, i)));
+  cells.push(footerCells(sheet));
+
+  const model = `<mxGraphModel dx="${Math.round(sheet.w)}" dy="${Math.round(sheet.h)}" `
+    + `grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" `
+    + `page="1" pageScale="1" pageWidth="${PAGE_W}" pageHeight="${PAGE_H}" math="0" shadow="0">`
+    + `<root>${cells.filter(Boolean).join('')}</root>`
+    + `</mxGraphModel>`;
+
+  const name = sheet.title || 'Architecture';
+  return `<?xml version="1.0" encoding="UTF-8"?>`
+    + `<mxfile host="Architecture Studio" agent="Architecture Studio" type="device">`
+    + `<diagram id="architecture" name="${attr(name)}">${model}</diagram>`
+    + `</mxfile>`;
+}
+
+/* -------------------------------------------------------------------- cells */
+
+function headingCells(sheet: Sheet): string {
+  let out = vertex('title', `<b>${esc(sheet.title!)}</b>`,
+    `text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;`
+    + `fontSize=16;fontColor=${INK.ink};fontFamily=${SANS_FONT};`,
+    { x: SHEET_PAD_X, y: 8, w: sheet.w - SHEET_PAD_X * 2, h: 22 });
+  if (sheet.subtitle) {
+    out += vertex('subtitle', esc(sheet.subtitle),
+      `text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;`
+      + `fontSize=11;fontColor=${INK.ink2};fontFamily=${SANS_FONT};`,
+      { x: SHEET_PAD_X, y: 30, w: sheet.w - SHEET_PAD_X * 2, h: 16 });
+  }
+  return out;
+}
+
+function footerCells(sheet: Sheet): string {
+  let out = '';
+  if (sheet.legend.length) {
+    /* One cell rather than one per scope: a legend is read as a line, and eight
+     * loose text boxes is eight things to move by accident. */
+    const body = sheet.legend
+      .map(g => `<font color="${g.color}">&#9632;</font> ${esc(g.label)}`)
+      .join('&nbsp;&nbsp;&nbsp;&nbsp;');
+    out += vertex('legend', body,
+      `text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;`
+      + `fontSize=10;fontColor=${INK.ink2};fontFamily=${SANS_FONT};`,
+      { x: SHEET_PAD_X, y: sheet.legendY - 4, w: sheet.w - SHEET_PAD_X * 2, h: 18 });
+  }
+  if (sheet.note) {
+    out += vertex('note', esc(sheet.note),
+      `text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;`
+      + `fontSize=10;fontColor=${INK.ink3};fontFamily=${MONO_FONT};`,
+      { x: SHEET_PAD_X, y: sheet.noteY - 2, w: sheet.w - SHEET_PAD_X * 2, h: 16 });
+  }
+  return out;
+}
+
+/* Solid for a boundary you could point at in a room, dashed for one that only
+ * exists in a document. `connectable=0` so a reader dragging a new dependency
+ * across the sheet cannot accidentally anchor it to the ground. */
+function zoneCell(z: ZonePlacement, index: number): string {
+  const style = `rounded=0;whiteSpace=wrap;html=1;`
+    + `fillColor=${zoneFill(z.depth)};strokeColor=${INK.line3};`
+    + (z.physical ? `dashed=0;` : `dashed=1;dashPattern=5 4;`)
+    + `verticalAlign=top;align=left;spacingLeft=6;spacingTop=2;`
+    + `fontSize=9;fontColor=${INK.ink3};fontFamily=${MONO_FONT};connectable=0;`;
+  return vertex(`z-${index}-${slug(z.zone.id)}`, esc(z.label.toUpperCase()), style, {
+    x: z.box.x, y: z.box.y, w: z.box.w, h: z.box.h
+  });
+}
+
+function layerCells(l: LayerPlacement, sheetW: number): string {
+  const colour = l.tint || INK.ink3;
+  let out = '';
+  if (l.label) {
+    const body = l.layer.desc
+      ? `${esc(l.label.toUpperCase())} <font color="${INK.ink3}">${esc(l.layer.desc)}</font>`
+      : esc(l.label.toUpperCase());
+    out += vertex(`l-${l.index}`, body,
+      `text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;`
+      + `fontSize=10;fontColor=${colour};fontFamily=${MONO_FONT};connectable=0;`,
+      { x: SHEET_PAD_X, y: l.y + LAYER_PAD_TOP - 2, w: sheetW - SHEET_PAD_X * 2, h: 16 });
+  }
+  /* draw.io's `line` shape draws across the vertical middle of its geometry, so
+   * the box is centred on the rule rather than starting at it. */
+  return out + vertex(`lr-${l.index}`, '',
+    `line;html=1;strokeColor=${colour};strokeWidth=1;dashed=1;dashPattern=4 4;`
+    + `opacity=42;connectable=0;`,
+    { x: SHEET_PAD_X, y: l.ruleY - 4, w: sheetW - SHEET_PAD_X * 2, h: 8 });
+}
+
+/* The card. Colour rides in the label as a filled square rather than on the
+ * border — rule 1 travels with the drawing, and a square inside the value moves
+ * with the cell where a second shape would be left behind the first time someone
+ * drags it. */
+function nodeCell(n: NodePlacement, sheet: Sheet): string {
+  const c = n.component;
+  const removed = c.state === 'removed';
+  const marked = c.state === 'new' || c.state === 'changed';
+
+  const lines = [
+    `<font color="${n.color}">&#9632;</font> <b>${esc(c.name)}</b>`
+    + (n.tick ? ` <font color="${INK.ink2}" style="font-size:8px">${esc(n.tick)}</font>` : '')
+  ];
+  if (c.role) lines.push(`<font color="${INK.ink2}" style="font-size:9px">${esc(c.role)}</font>`);
+  const lower = [c.badge, ...(c.tech || [])].filter(Boolean).join(' · ');
+  if (lower) lines.push(`<font color="${INK.ink3}" style="font-size:8px">${esc(lower)}</font>`);
+
+  const style = `rounded=0;whiteSpace=wrap;html=1;fillColor=${INK.paper};`
+    + `strokeColor=${marked ? INK.ink2 : INK.line3};strokeWidth=${marked ? 1.8 : 1};`
+    + (removed ? `dashed=1;dashPattern=4 3;opacity=55;` : '')
+    + `align=left;verticalAlign=top;spacingLeft=6;spacingTop=2;`
+    + `fontSize=11;fontColor=${INK.ink};fontFamily=${SANS_FONT};`;
+
+  /* What the picture cannot carry, carried as data: draw.io shows these in Edit
+   * Data, and its search finds them. The icon and the security glyphs are this
+   * app's own sets — a wrong glyph is worse than a named field. */
+  const data: Record<string, string> = { archId: c.id };
+  const scope = sheet.legend.find(g => g.id === c.group);
+  if (scope) data.scope = scope.label;
+  const layer = sheet.layers.find(l => l.layer.id === c.layer);
+  if (layer?.label) data.layer = layer.label;
+  const zone = sheet.zones.find(z => z.zone.id === c.zone);
+  if (zone) data.zone = zone.zone.name;
+  if (c.tech?.length) data.tech = c.tech.join(', ');
+  if (c.marks?.length) data.security = c.marks.map(m => MARK_LABELS[m][sheet.lang]).join(', ');
+  if (c.state) data.state = STATE_LABELS[c.state][sheet.lang];
+  if (c.url) data.link = c.url;
+
+  return object(`n-${slug(c.id)}`, lines.join("<br>"), data,
+    `<mxCell style="${attr(style)}" vertex="1" parent="1">`
+    + geometry({ x: n.box.x, y: n.box.y, w: n.box.w, h: n.box.h })
+    + `</mxCell>`);
+}
+
+/* Source and target rather than waypoints: a reader who moves a card gets its
+ * lines redrawn, which is why they opened this in draw.io at all. */
+function edgeCell(e: EdgePlacement, index: number): string {
+  const style = `edgeStyle=none;curved=1;html=1;rounded=0;`
+    + `startArrow=oval;startFill=1;startSize=7;endArrow=oval;endFill=0;endSize=7;`
+    + `strokeColor=${e.color};strokeWidth=${e.width};`
+    + (e.dash ? `dashed=1;dashPattern=${e.dash};` : `dashed=0;`)
+    + (e.opacity < 0.45 ? `opacity=${Math.round(e.opacity * 100)};` : '')
+    + `fontSize=9;fontColor=${INK.ink3};fontFamily=${MONO_FONT};`
+    + `labelBackgroundColor=${INK.paper};`;
+  return `<mxCell id="e-${index}" value="${attr(esc(e.label || ''))}" style="${attr(style)}" `
+    + `edge="1" parent="1" source="n-${attr(slug(e.from))}" target="n-${attr(slug(e.to))}">`
+    + `<mxGeometry relative="1" as="geometry"/>`
+    + `</mxCell>`;
+}
+
+/* --------------------------------------------------------------- primitives */
+
+interface Rect { x: number; y: number; w: number; h: number }
+
+function vertex(id: string, value: string, style: string, r: Rect): string {
+  return `<mxCell id="${attr(id)}" value="${attr(value)}" style="${attr(style)}" `
+    + `vertex="1" parent="1">${geometry(r)}</mxCell>`;
+}
+
+function object(id: string, label: string, data: Record<string, string>, cell: string): string {
+  const attrs = Object.entries(data)
+    .map(([k, v]) => ` ${k}="${attr(v)}"`).join('');
+  return `<object id="${attr(id)}" label="${attr(label)}"${attrs}>${cell}</object>`;
+}
+
+const geometry = (r: Rect): string =>
+  `<mxGeometry x="${round(r.x)}" y="${round(r.y)}" `
+  + `width="${round(r.w)}" height="${round(r.h)}" as="geometry"/>`;
+
+const round = (n: number): number => Math.round(n * 10) / 10;
+
+/* Escaped twice, and that is not a bug.
+ *
+ * Every style here says `html=1`, so a cell's value is HTML — which then has to
+ * survive being an XML attribute. So authored text is escaped once for the HTML
+ * parser (`esc`, applied to the text and never to the `<font>` and `<b>` tags
+ * around it), and the finished markup is escaped again for the XML parser
+ * (`attr`, applied to the whole value). A component called "R&D" leaves here as
+ * `R&amp;amp;D`, arrives at draw.io's HTML parser as `R&amp;D`, and is drawn as
+ * "R&D". Escaping either half only once is what turns that into "R&amp;D" on the
+ * card, or into a file draw.io refuses to open.
+ *
+ * Both are strict — every `&`, with no lookahead for things that already look
+ * like entities. A lookahead reads "R&D;" as an entity and lets it through
+ * unescaped, and an unescaped ampersand is not a wrong drawing, it is a broken
+ * file. Entities this module writes itself (`&#9632;`, the scope square) survive
+ * anyway: double-escaped here, decoded by the XML parser, decoded again by the
+ * HTML one. */
+
+const esc = (s: string): string =>
+  s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+const attr = (s: string): string =>
+  s.replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+
+/** Component ids are slugs, but an imported document's need not be, and a cell
+ *  id with a quote in it is a broken file rather than a wrong drawing. */
+const slug = (id: string): string => id.replace(/[^A-Za-z0-9_.-]/g, '_');

--- a/src/lib/export/layout.test.ts
+++ b/src/lib/export/layout.test.ts
@@ -1,0 +1,216 @@
+import { strict as assert } from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+import { test } from 'node:test';
+import { normalizeArchitecture } from '../defaults';
+import { BAND_GUTTER } from '../zones';
+import type { Architecture } from '../types';
+import { CARD_GAP, CARD_H, CARD_W, bandWidth, columnX, clip, layoutSheet } from './layout';
+
+/* A small landscape that exercises the four things the layout has to get right:
+ * two layers, two scopes, a nested zone, and one dependency in each direction. */
+const doc = (over: Partial<Architecture> = {}): Architecture => normalizeArchitecture({
+  meta: { name: 'Landscape', lang: 'en' },
+  layers: [{ id: 'clients', name: 'Clients' }, { id: 'services', name: 'Services' }],
+  groups: [{ id: 'core', name: 'Core' }, { id: 'vendor', name: 'Third parties' }],
+  zones: [
+    { id: 'internal', name: 'Internal', kind: 'network' },
+    { id: 'openshift', name: 'OpenShift', kind: 'platform', parent: 'internal' }
+  ],
+  components: [
+    { id: 'web', name: 'Web', group: 'core', layer: 'clients', deps: ['api'] },
+    { id: 'api', name: 'API', group: 'core', layer: 'services', zone: 'openshift' },
+    { id: 'jobs', name: 'Jobs', group: 'core', layer: 'services', zone: 'openshift' },
+    { id: 'psp', name: 'Payments', group: 'vendor', layer: 'services', deps: ['api'] }
+  ],
+  ...over
+});
+
+test('the grid arithmetic matches the stylesheet it mirrors', () => {
+  const css = fs.readFileSync(
+    path.join(process.cwd(), 'src', 'app', 'globals.css'), 'utf8');
+
+  /* Three numbers decide where every card lands, and two of them live in CSS.
+   * Nothing at runtime can notice they have drifted — the export would simply
+   * stop being the drawing the editor shows — so they are checked here. */
+  assert.match(css, new RegExp(`--card-w:\\s*${CARD_W}px`),
+    '--card-w on .canvas no longer matches CARD_W');
+  assert.match(css, new RegExp(`row-gap:\\s*${CARD_GAP}px;\\s*column-gap:\\s*${BAND_GUTTER}px`),
+    '.layer-drop.banded gaps no longer match CARD_GAP / BAND_GUTTER');
+  assert.match(css, new RegExp(`\\.zrun\\s*\\{[^}]*gap:\\s*${CARD_GAP}px`),
+    '.zrun gap no longer matches CARD_GAP');
+});
+
+test('a band of n columns holds exactly n cards on a row', () => {
+  /* The grid gutter is wider than the gap between two cards inside a run, so a
+   * band is always a little wider than the cards it holds. It must never be wide
+   * enough for one more, or a run would wrap differently from the band plan. */
+  for (let span = 1; span <= 6; span++) {
+    const room = bandWidth(span);
+    assert.equal(Math.floor((room + CARD_GAP) / (CARD_W + CARD_GAP)), span,
+      `a band of ${span} columns should hold ${span} cards`);
+    assert.ok(room < (span + 1) * CARD_W + span * CARD_GAP,
+      `a band of ${span} columns is wide enough for ${span + 1} cards`);
+  }
+});
+
+test('columns are one card plus one gutter apart', () => {
+  assert.equal(columnX(0), 0);
+  assert.equal(columnX(1) - columnX(0), CARD_W + BAND_GUTTER);
+  assert.equal(bandWidth(1), CARD_W);
+  assert.equal(bandWidth(3), 3 * CARD_W + 2 * BAND_GUTTER);
+});
+
+test('every component is placed exactly once, at the card size', () => {
+  const sheet = layoutSheet(doc());
+  assert.equal(sheet.nodes.length, 4);
+  assert.deepEqual(
+    [...sheet.nodes.map(n => n.component.id)].sort(),
+    ['api', 'jobs', 'psp', 'web']);
+  sheet.nodes.forEach(n => {
+    assert.equal(n.box.w, CARD_W);
+    assert.equal(n.box.h, CARD_H);
+  });
+});
+
+test('no two cards overlap', () => {
+  const boxes = layoutSheet(doc()).nodes.map(n => n.box);
+  for (let i = 0; i < boxes.length; i++) {
+    for (let j = i + 1; j < boxes.length; j++) {
+      const a = boxes[i], b = boxes[j];
+      const apart = a.x + a.w <= b.x || b.x + b.w <= a.x
+        || a.y + a.h <= b.y || b.y + b.h <= a.y;
+      assert.ok(apart, `cards ${i} and ${j} overlap`);
+    }
+  }
+});
+
+test('a zone rectangle holds its own members and nothing else', () => {
+  const sheet = layoutSheet(doc());
+  const openshift = sheet.zones.find(z => z.zone.id === 'openshift');
+  assert.ok(openshift, 'the platform zone should be drawn');
+
+  const inside = (id: string) => {
+    const n = sheet.nodes.find(c => c.component.id === id)!;
+    const b = openshift!.box;
+    return n.box.x >= b.x && n.box.x + n.box.w <= b.x + b.w
+      && n.box.y >= b.y && n.box.y + n.box.h <= b.y + b.h;
+  };
+  assert.ok(inside('api'), 'api is in the zone and should be inside its rectangle');
+  assert.ok(inside('jobs'), 'jobs is in the zone and should be inside its rectangle');
+  /* This is the whole reason bands are reserved: an unzoned card on the same row
+   * must not fall inside a rectangle the document never drew around it. */
+  assert.ok(!inside('psp'), 'an unzoned card fell inside the zone rectangle');
+  assert.ok(!inside('web'), 'a card on another layer fell inside the zone rectangle');
+});
+
+test('a nested zone is drawn after — and inside — its parent', () => {
+  const sheet = layoutSheet(doc());
+  const at = (id: string) => sheet.zones.findIndex(z => z.zone.id === id);
+  assert.ok(at('internal') < at('openshift'),
+    'the outer zone must be emitted first or the nested tint is buried');
+
+  const outer = sheet.zones[at('internal')].box;
+  const inner = sheet.zones[at('openshift')].box;
+  assert.ok(inner.x >= outer.x && inner.y >= outer.y
+    && inner.x + inner.w <= outer.x + outer.w
+    && inner.y + inner.h <= outer.y + outer.h,
+    'the nested rectangle should sit inside its parent');
+  assert.equal(sheet.zones[at('openshift')].depth, 1);
+  assert.equal(sheet.zones[at('openshift')].physical, true);
+  assert.equal(sheet.zones[at('internal')].physical, false);
+});
+
+test('an edge leaves the caller and arrives at the callee, on the right edges', () => {
+  const sheet = layoutSheet(doc());
+  const web = sheet.nodes.find(n => n.component.id === 'web')!.box;
+  const api = sheet.nodes.find(n => n.component.id === 'api')!.box;
+  const edge = sheet.edges.find(e => e.from === 'web' && e.to === 'api')!;
+
+  assert.equal(edge.x1, web.x + web.w / 2);
+  assert.equal(edge.x2, api.x + api.w / 2);
+  /* Clients is above Services, so the line leaves the bottom of the caller and
+   * arrives at the top of the callee — the same reading as `draw()`. */
+  assert.equal(edge.y1, web.y + web.h);
+  assert.equal(edge.y2, api.y);
+  assert.equal(edge.k1, -edge.k2, 'a cross-layer edge mirrors its control offsets');
+});
+
+test('a call that does not leave its layer arcs under the row', () => {
+  const sheet = layoutSheet(doc({
+    components: [
+      { id: 'a', name: 'A', group: 'core', layer: 'services', deps: ['b'] },
+      { id: 'b', name: 'B', group: 'core', layer: 'services' }
+    ]
+  }));
+  const edge = sheet.edges[0];
+  assert.equal(edge.k1, 30);
+  assert.equal(edge.k2, 30);
+});
+
+test('a dependency on a component that is gone draws no line', () => {
+  const sheet = layoutSheet({
+    ...doc(),
+    components: [{ id: 'web', name: 'Web', group: 'core', layer: 'clients', deps: ['ghost'] }]
+  });
+  assert.equal(sheet.edges.length, 0);
+});
+
+test('the transition rides on stroke and opacity, never on colour', () => {
+  const sheet = layoutSheet(doc({
+    components: [
+      { id: 'web', name: 'Web', group: 'core', layer: 'clients', state: 'new', deps: ['api'],
+        links: [{ to: 'api', kind: 'async', state: 'removed', protocol: 'Kafka' }] },
+      { id: 'api', name: 'API', group: 'core', layer: 'services' }
+    ],
+    ui: { architecture: { protocolLabels: 'all' } }
+  }));
+
+  assert.equal(sheet.nodes.find(n => n.component.id === 'web')!.tick, 'NEW');
+  const edge = sheet.edges[0];
+  assert.equal(edge.dash, '6 4', 'an asynchronous call is dashed');
+  assert.ok(edge.opacity < 0.45, 'a removed edge is a ghost of an ordinary one');
+  assert.equal(edge.label, '- Kafka', 'the sign leads the protocol in the plate');
+});
+
+test('an empty document lays out without throwing, and has room for nothing', () => {
+  const sheet = layoutSheet(normalizeArchitecture({ meta: { name: 'Empty' } }));
+  assert.equal(sheet.nodes.length, 0);
+  assert.equal(sheet.edges.length, 0);
+  assert.equal(sheet.zones.length, 0);
+  assert.ok(sheet.w > 0 && sheet.h > 0);
+});
+
+test('a document with components but no layers still draws them', () => {
+  const sheet = layoutSheet({
+    ...normalizeArchitecture({ meta: { name: 'Flat' } }),
+    layers: [],
+    groups: [{ id: 'core', name: 'Core', color: '#0099A0' }],
+    components: [
+      { id: 'a', name: 'A', group: 'core', layer: 'gone', deps: ['b'] },
+      { id: 'b', name: 'B', group: 'core', layer: 'gone' }
+    ]
+  });
+  assert.equal(sheet.nodes.length, 2);
+  assert.equal(sheet.edges.length, 1);
+});
+
+test('the legend names only the scopes the drawing uses', () => {
+  const sheet = layoutSheet(doc({
+    components: [{ id: 'web', name: 'Web', group: 'core', layer: 'clients' }]
+  }));
+  assert.deepEqual(sheet.legend.map(g => g.id), ['core']);
+});
+
+test('turning layer tints off emits no colour at all', () => {
+  assert.ok(layoutSheet(doc()).layers.every(l => l.tint));
+  const off = layoutSheet(doc({ ui: { architecture: { layerTint: false } } }));
+  assert.ok(off.layers.every(l => l.tint === null));
+});
+
+test('a string too wide for its box is cut rather than allowed to run over', () => {
+  assert.equal(clip('Web', 200, 12, 0.53), 'Web');
+  const cut = clip('An extremely long component name that will not fit', 80, 12, 0.53);
+  assert.ok(cut.endsWith('…'));
+  assert.ok(cut.length < 'An extremely long component name that will not fit'.length);
+});

--- a/src/lib/export/layout.ts
+++ b/src/lib/export/layout.ts
@@ -1,0 +1,413 @@
+/* The sheet, laid out without a DOM.
+ *
+ * The three renderers that already exist all *measure*: the editor and the
+ * viewer read `getBoundingClientRect`, the printed document reads
+ * `offsetLeft/offsetTop`. That works because all three run in a browser with the
+ * cards already in flow. An export to a foreign tool has neither — a draw.io
+ * file is written on the server, and a `<text>` in an SVG has no flow to be
+ * measured in — so this module computes the same drawing arithmetically.
+ *
+ * It can, and this is the whole reason the band plan exists: a card has a fixed
+ * width, so a band is a column count (see `bandPlan` in ../zones). Everything
+ * below is that plan turned into pixels, plus one fixed card height. The result
+ * is not a screenshot of the canvas — the cards there grow with their content —
+ * but it is the same drawing: same bands, same order, same zone rectangles from
+ * the same `inflatedUnion`, same cubic for every edge.
+ *
+ * ------------------------------------------------------------------ mirroring
+ *
+ * The numbers below mirror `globals.css`, and `layout.test.ts` guards the pair
+ * that would silently drift: `--card-w` and `column-gap` on `.layer-drop.banded`.
+ * The edge geometry mirrors `draw()` in components/Editor.tsx — if that cubic
+ * changes, this one has to change with it or an export stops looking like the
+ * studio.
+ *
+ * ------------------------------------------------------------------- the ground
+ *
+ * White, not the studio's calque. An exported diagram is pasted into a slide, a
+ * wiki or a draw.io page, and all three are white; carrying `--bg` across would
+ * put a grey plate around the drawing in every one of them. So the neutrals
+ * below are the light theme's ink composited over paper rather than over the
+ * calque, and the two agree everywhere it matters — the ink itself is the same.
+ */
+
+import type { Architecture, Component, Layer, Zone } from '../types';
+import {
+  BAND_GUTTER, bandPlan, describeZone, inflatedUnion, layerRuns, withDescendants,
+  zoneDepth, zoneIsPhysical, zonePad, zonesInUse, type Box
+} from '../zones';
+import { dashFor, edgePlateText, linkOf, protocolConvention, protocolNote } from '../links';
+import { edgeOpacity, edgeStroke, stateTick } from '../lifecycle';
+import { layerTintEnabled } from '../layers';
+import { PALETTE } from '../defaults';
+
+/* ------------------------------------------------------------------ the ink */
+
+/** The light theme's tokens, resolved. Custom properties do not survive the trip
+ *  into a foreign tool, so every colour has to be a literal by the time it
+ *  leaves here. MIRRORS the `:root` block in app/globals.css. */
+export const INK = {
+  ink: '#0B1B2B',
+  ink2: '#3D566B',
+  ink3: '#8CA1B2',
+  line2: '#DCE5EB',
+  line3: '#D3DEE5',
+  paper: '#FFFFFF'
+} as const;
+
+/** `--lt1..--lt6`, the layer ramp. */
+export const LAYER_TINT_HEX = ['#5B7FA6', '#5E9070', '#9A8149', '#A5735F', '#8474A8', '#4E8C93'];
+
+/** A zone's ground at nesting depth 0, 1 and 2 — `--ink` at 3 %, 6 % and 9 %,
+ *  composited over paper. Deeper zones reuse the last one, exactly as the
+ *  stylesheet does (it only defines `[data-depth]` up to 2). */
+export const ZONE_FILL = ['#F8F8F9', '#F0F1F2', '#E9EAEC'];
+
+export const zoneFill = (depth: number): string =>
+  ZONE_FILL[Math.min(depth, ZONE_FILL.length - 1)];
+
+/** The resting opacity of an ordinary edge. The canvas sits at .34 because it is
+ *  a working surface with cards to click through; an export is read once and at
+ *  a distance, so it takes the printed document's .45 instead. */
+export const EDGE_BASE_OPACITY = 0.45;
+
+/* ------------------------------------------------------------- the geometry */
+
+/** MIRRORS `--card-w` on `.canvas` in app/globals.css. */
+export const CARD_W = 206;
+
+/** The one number that is a decision rather than a mirror.
+ *
+ *  On screen a card grows with its content, which is right for a surface you
+ *  author on and wrong for a drawing that has to be one shape repeated. Sixty
+ *  four holds the three lines the export draws — name, role, technologies — at
+ *  the sizes below, and a component with none of the optional two simply leaves
+ *  the lower half empty rather than making the row ragged. */
+export const CARD_H = 64;
+
+/** `gap` on `.zrun`: the space between two cards inside one band. */
+export const CARD_GAP = 10;
+
+/** The band label and the rule under it. */
+export const LAYER_HEAD_H = 22;
+export const LAYER_PAD_TOP = 16;
+export const LAYER_PAD_BOTTOM = 12;
+
+/** Room around the drawing. Wider than the deepest zone inset (19 px across,
+ *  32 px down, from `zonePad`) so a rectangle around a band at the edge of the
+ *  sheet still has paper to sit on. */
+export const SHEET_PAD_X = 28;
+export const SHEET_PAD_Y = 30;
+
+/** A within-layer edge arcs 30 px below the cards it joins and reaches about
+ *  three quarters of that at its belly. The last layer has no next band to lend
+ *  it the room, so the sheet keeps some back. */
+const EDGE_SLACK = 30;
+
+const TITLE_H = 26;
+const SUBTITLE_H = 18;
+const LEGEND_H = 22;
+const NOTE_H = 18;
+
+/* ------------------------------------------------------------- the placement */
+
+export interface NodePlacement {
+  component: Component;
+  box: Box;
+  /** The scope's colour, resolved. */
+  color: string;
+  /** "NEW" / "MOD" / "DEL", or null. */
+  tick: string | null;
+}
+
+export interface ZonePlacement {
+  zone: Zone;
+  box: Box;
+  depth: number;
+  /** Drawn solid rather than dashed — a boundary you could point at in a room. */
+  physical: boolean;
+  label: string;
+}
+
+export interface LayerPlacement {
+  layer: Layer;
+  index: number;
+  label: string;
+  /** `--lt1..--lt6` resolved, or null when the document turns tints off. */
+  tint: string | null;
+  /** Top of the band, top of its cards, and the dashed rule closing it. */
+  y: number;
+  bodyY: number;
+  ruleY: number;
+}
+
+/** One dependency, as the cubic all four surfaces draw.
+ *
+ *  `M x1,y1 C x1,y1+k1 x2,y2+k2 x2,y2` — the control points are vertical
+ *  offsets, which is what keeps a line leaving the bottom of a card looking like
+ *  it left the bottom of a card. */
+export interface EdgePlacement {
+  from: string;
+  to: string;
+  x1: number; y1: number; k1: number;
+  x2: number; y2: number; k2: number;
+  color: string;
+  opacity: number;
+  width: number;
+  /** SVG `stroke-dasharray`; empty for a synchronous call. */
+  dash: string;
+  /** What goes in the plate on the line — "+ JDBC" — or null. */
+  label: string | null;
+}
+
+export interface Sheet {
+  w: number;
+  h: number;
+  title: string | null;
+  subtitle: string | null;
+  /** "All calls are REST unless the line says otherwise.", or null. */
+  note: string | null;
+  layers: LayerPlacement[];
+  zones: ZonePlacement[];
+  nodes: NodePlacement[];
+  edges: EdgePlacement[];
+  /** The scopes in use, in declaration order. Colour carries scope on every
+   *  surface, so an export that drops the key drops half the drawing. */
+  legend: { id: string; label: string; color: string }[];
+  /** Where the legend row's baseline sits. */
+  legendY: number;
+  noteY: number;
+  lang: 'en' | 'fr';
+}
+
+/** The x of a 0-based grid column. Every column is `BAND_GUTTER` from the next,
+ *  including two columns inside one band — that is `column-gap` on the grid,
+ *  where `CARD_GAP` is the flex gap *within* a run. The two are different
+ *  numbers on purpose; see the note above `.layer-drop.banded`. */
+export const columnX = (index: number): number => index * (CARD_W + BAND_GUTTER);
+
+/** How wide a band of `span` columns is. */
+export const bandWidth = (span: number): number =>
+  span * CARD_W + (span - 1) * BAND_GUTTER;
+
+/** Cards per row inside a band. A band of `span` columns is exactly wide enough
+ *  for `span` cards at `CARD_GAP`, because the grid's gutter is the wider of the
+ *  two — the arithmetic is checked in `layout.test.ts`. */
+const perRow = (span: number): number =>
+  Math.max(1, Math.floor((bandWidth(span) + CARD_GAP) / (CARD_W + CARD_GAP)));
+
+/** Lay the whole document out. Pure: same document in, same numbers out. */
+export function layoutSheet(doc: Architecture): Sheet {
+  const lang = doc.meta?.lang === 'fr' ? 'fr' : 'en';
+  const zones = doc.zones || [];
+
+  /* A component whose layer is gone would be counted by no band and placed on no
+   * row. Every read path normalises that away, but the fallback is one line and
+   * it keeps this function total. */
+  const known = new Set(doc.layers.map(l => l.id));
+  const fallbackLayer = doc.layers[0]?.id ?? '';
+  const components: Component[] = doc.components.map(c =>
+    doc.layers.length && known.has(c.layer) ? c : { ...c, layer: fallbackLayer });
+
+  /* An unlayered document still draws: everything lands on one nameless band,
+   * which is what the band plan already does internally. */
+  const layers: Layer[] = doc.layers.length
+    ? doc.layers
+    : (components.length ? [{ id: fallbackLayer, name: '' }] : []);
+
+  const plan = bandPlan(components, zones, doc.layers);
+  const colour = groupColours(doc);
+  const tinted = layerTintEnabled(doc.ui?.architecture);
+
+  const title = doc.ui?.architecture?.title?.trim() || doc.meta?.name?.trim() || null;
+  const subtitle = doc.ui?.architecture?.subtitle?.trim() || null;
+  const conv = protocolConvention(doc.ui?.architecture);
+  const note = protocolNote(conv, lang);
+
+  const originX = SHEET_PAD_X;
+  let y = SHEET_PAD_Y + (title ? TITLE_H : 0) + (subtitle ? SUBTITLE_H : 0);
+
+  const placedLayers: LayerPlacement[] = [];
+  const nodes: NodePlacement[] = [];
+  /** One box per zone run, which is what the zone rectangles are measured from —
+   *  the same choice `zoneLayer` makes on the canvas, and for the same reason: a
+   *  run is already a tight, band-shaped box around a zone's members in one row. */
+  const runBoxes = new Map<string, Box[]>();
+
+  layers.forEach((layer, index) => {
+    const here = components.filter(c => c.layer === layer.id);
+    const bodyY = y + LAYER_PAD_TOP + LAYER_HEAD_H;
+    let bodyH = 0;
+
+    layerRuns(here, zones).forEach(run => {
+      const band = plan.band(run.zone);
+      if (!band) return;
+      const x = originX + columnX(band.start - 1);
+      const cols = perRow(band.span);
+      const rows = Math.ceil(run.items.length / cols);
+
+      run.items.forEach((component, i) => {
+        nodes.push({
+          component,
+          box: {
+            x: x + (i % cols) * (CARD_W + CARD_GAP),
+            y: bodyY + Math.floor(i / cols) * (CARD_H + CARD_GAP),
+            w: CARD_W,
+            h: CARD_H
+          },
+          color: colour(component.group),
+          tick: stateTick(component.state)
+        });
+      });
+
+      if (run.zone) {
+        const boxes = runBoxes.get(run.zone) || [];
+        /* The run's own box, not the union of its cards: on the canvas a run
+         * stretches to fill its band, so the rectangle is band-shaped on every
+         * layer instead of jumping in and out with the card count. */
+        boxes.push({
+          x, y: bodyY,
+          w: bandWidth(band.span),
+          h: rows * (CARD_H + CARD_GAP) - CARD_GAP
+        });
+        runBoxes.set(run.zone, boxes);
+      }
+      bodyH = Math.max(bodyH, rows * (CARD_H + CARD_GAP) - CARD_GAP);
+    });
+
+    const h = LAYER_PAD_TOP + LAYER_HEAD_H + bodyH + LAYER_PAD_BOTTOM;
+    placedLayers.push({
+      layer,
+      index,
+      label: layer.name || layer.id,
+      tint: tinted ? LAYER_TINT_HEX[index % LAYER_TINT_HEX.length] : null,
+      y, bodyY, ruleY: y + h
+    });
+    y += h;
+  });
+
+  /* Outermost first, so a nested rectangle paints over its parent's fill rather
+   * than under it — the tint is what makes depth read and it only stacks one way. */
+  const placedZones: ZonePlacement[] = [];
+  zonesInUse(zones, components).forEach(zone => {
+    const family = withDescendants(zone.id, zones);
+    const boxes: Box[] = [];
+    family.forEach(id => (runBoxes.get(id) || []).forEach(b => boxes.push(b)));
+    const box = inflatedUnion(boxes, zonePad(zone.id, zones));
+    if (!box) return;
+    placedZones.push({
+      zone, box,
+      depth: zoneDepth(zone.id, zones),
+      physical: zoneIsPhysical(zone.kind),
+      label: describeZone(zone, lang)
+    });
+  });
+
+  const edges = layoutEdges(components, nodes, layers, colour, conv);
+
+  const legend = (doc.groups || [])
+    .filter(g => components.some(c => c.group === g.id))
+    .map(g => ({ id: g.id, label: g.name || g.id, color: colour(g.id) }));
+
+  const bottom = y + EDGE_SLACK;
+  const legendY = legend.length ? bottom + 12 : bottom;
+  const noteY = legendY + (legend.length ? LEGEND_H : 0);
+
+  const contentW = plan.total ? bandWidth(plan.total) : 320;
+  const legendW = legend.reduce((w, g) => w + 16 + textWidth(g.label, 10, 0.53), 0);
+
+  return {
+    w: originX * 2 + Math.max(contentW, legendW, note ? textWidth(note, 10, 0.6) : 0),
+    h: noteY + (note ? NOTE_H : 0) + SHEET_PAD_Y,
+    title, subtitle, note,
+    layers: placedLayers,
+    zones: placedZones,
+    nodes, edges, legend, legendY, noteY,
+    lang
+  };
+}
+
+/* ---------------------------------------------------------------- the edges */
+
+/** Every dependency as a cubic.
+ *
+ *  MIRRORS `draw()` in components/Editor.tsx, which is where this geometry is
+ *  authored: same sign convention, same 24 px floor on the control offset, same
+ *  arc under the row for a call that does not leave its layer. */
+function layoutEdges(
+  components: Component[],
+  nodes: NodePlacement[],
+  layers: Layer[],
+  colour: (group: string) => string,
+  conv: ReturnType<typeof protocolConvention>
+): EdgePlacement[] {
+  const boxOf = new Map(nodes.map(n => [n.component.id, n.box]));
+  const byId = new Map(components.map(c => [c.id, c]));
+  const layerAt = new Map(layers.map((l, i) => [l.id, i]));
+  const out: EdgePlacement[] = [];
+
+  components.forEach(c => (c.deps || []).forEach(dep => {
+    const a = boxOf.get(c.id);
+    const b = boxOf.get(dep);
+    const callee = byId.get(dep);
+    if (!a || !b || !callee) return;
+
+    const x1 = a.x + a.w / 2;
+    const x2 = b.x + b.w / 2;
+    const la = layerAt.get(c.layer);
+    const lb = layerAt.get(callee.layer);
+    let y1: number, y2: number, k1: number, k2: number;
+    if (la === lb) {
+      y1 = a.y + a.h; y2 = b.y + b.h; k1 = 30; k2 = 30;
+    } else {
+      const up = (la ?? 0) > (lb ?? 0);
+      y1 = up ? a.y : a.y + a.h;
+      y2 = up ? b.y + b.h : b.y;
+      const k = (up ? -1 : 1) * Math.max(24, Math.abs(y2 - y1) * 0.5);
+      k1 = k; k2 = -k;
+    }
+
+    const link = linkOf(c, dep);
+    out.push({
+      from: c.id, to: dep,
+      x1, y1, k1, x2, y2, k2,
+      /* An edge belongs to its caller's scope, which is the reading the canvas
+       * and the printed sheet both give it. */
+      color: colour(c.group),
+      opacity: edgeOpacity(link?.state, EDGE_BASE_OPACITY),
+      width: edgeStroke(link?.state, 1.2),
+      dash: dashFor(link?.kind),
+      label: edgePlateText(link, conv)
+    });
+  }));
+
+  return out;
+}
+
+/* --------------------------------------------------------------- the extras */
+
+/** The scope palette, resolved to literals. `paintGroups` has already filled
+ *  `color` on anything that came through normalisation; the modulo is the floor
+ *  for a group that somehow did not. */
+function groupColours(doc: Architecture): (group: string) => string {
+  const by = new Map<string, string>();
+  (doc.groups || []).forEach((g, i) => by.set(g.id, g.color || PALETTE[i % PALETTE.length]));
+  return group => by.get(group) || INK.ink3;
+}
+
+/** Text width without a DOM, the way `labelPlateWidth` already estimates one:
+ *  an average advance per character times the size. Overshooting is harmless
+ *  everywhere it is used — it only ever decides how much room to leave. */
+export const textWidth = (text: string, size: number, ratio: number): number =>
+  text.length * size * ratio;
+
+/** `text` cut to fit `max` pixels, with an ellipsis when it had to be cut.
+ *
+ *  The alternative is SVG's own overflow, which is to draw the whole string over
+ *  whatever sits next to it — on a grid of fixed-width cards that is every
+ *  neighbouring card. */
+export function clip(text: string, max: number, size: number, ratio: number): string {
+  if (textWidth(text, size, ratio) <= max) return text;
+  const room = Math.max(1, Math.floor(max / (size * ratio)) - 1);
+  return text.slice(0, room).trimEnd() + '…';
+}

--- a/src/lib/export/png.test.ts
+++ b/src/lib/export/png.test.ts
@@ -1,0 +1,112 @@
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import { normalizeArchitecture } from '../defaults';
+import { buildDrawioXml } from './drawio';
+import {
+  DRAWIO_KEYWORD, crc32, drawioChunkText, isPng, readTextChunk, textChunk,
+  withDrawioXml, withTextChunk
+} from './png';
+
+/* The smallest legal PNG: signature, IHDR, one IDAT, IEND. Handmade rather than
+ * fetched, because what is under test is the chunk arithmetic and a real image
+ * would only make the fixture heavier. */
+function tinyPng(): Uint8Array {
+  const chunk = (type: string, data: number[]) => {
+    const body = [...type].map(c => c.charCodeAt(0)).concat(data);
+    const out = new Uint8Array(8 + data.length + 4);
+    new DataView(out.buffer).setUint32(0, data.length);
+    out.set(body, 4);
+    new DataView(out.buffer).setUint32(8 + data.length, crc32(new Uint8Array(body)));
+    return out;
+  };
+  const ihdr = chunk('IHDR', [0, 0, 0, 1, 0, 0, 0, 1, 8, 6, 0, 0, 0]);
+  const idat = chunk('IDAT', [0x78, 0x9c, 0x63, 0x00, 0x01]);
+  const iend = chunk('IEND', []);
+  const out = new Uint8Array(8 + ihdr.length + idat.length + iend.length);
+  out.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+  out.set(ihdr, 8);
+  out.set(idat, 8 + ihdr.length);
+  out.set(iend, 8 + ihdr.length + idat.length);
+  return out;
+}
+
+test('the CRC is the one every PNG decoder checks', () => {
+  /* The two published check values for CRC-32/ISO-HDLC, which is what PNG uses.
+   * A decoder that disagrees with this table rejects the file outright. */
+  assert.equal(crc32(new Uint8Array([...'123456789'].map(c => c.charCodeAt(0)))), 0xcbf43926);
+  assert.equal(crc32(new Uint8Array(0)), 0);
+});
+
+test('a text chunk is a length, a type, a keyword, a NUL and a CRC', () => {
+  const chunk = textChunk('mxfile', 'abc');
+  const view = new DataView(chunk.buffer);
+  assert.equal(view.getUint32(0), 'mxfile'.length + 1 + 3);
+  assert.equal(String.fromCharCode(...chunk.subarray(4, 8)), 'tEXt');
+  assert.equal(chunk[8 + 'mxfile'.length], 0, 'the keyword is NUL-terminated');
+  assert.equal(view.getUint32(chunk.length - 4), crc32(chunk.subarray(4, chunk.length - 4)));
+});
+
+test('a keyword outside the spec is refused rather than silently truncated', () => {
+  assert.throws(() => textChunk('', 'x'), /1 to 79/);
+  assert.throws(() => textChunk('k'.repeat(80), 'x'), /1 to 79/);
+  /* "é" is legal — `tEXt` is Latin-1, not ASCII. What is not is anything above
+   *  U+00FF, and the payload this module writes is URI-encoded precisely so no
+   *  such character ever reaches here. */
+  assert.doesNotThrow(() => textChunk('mxfile', 'données'));
+  assert.throws(() => textChunk('mxfile', '日本'), /Latin-1/);
+});
+
+test('the chunk goes before IEND, and the image is otherwise byte-for-byte itself', () => {
+  const png = tinyPng();
+  const out = withTextChunk(png, 'mxfile', 'abc');
+
+  assert.ok(isPng(out));
+  assert.equal(out.length, png.length + textChunk('mxfile', 'abc').length);
+  /* Everything up to IEND is untouched, and IEND is still last: a PNG whose
+   * final chunk is not IEND is a file some decoders stop reading early. */
+  const iendAt = out.length - 12;
+  assert.equal(String.fromCharCode(...out.subarray(iendAt + 4, iendAt + 8)), 'IEND');
+  assert.deepEqual([...out.subarray(0, png.length - 12)], [...png.subarray(0, png.length - 12)]);
+});
+
+test('what went in comes back out', () => {
+  const out = withTextChunk(tinyPng(), 'mxfile', 'hello');
+  assert.equal(readTextChunk(out, 'mxfile'), 'hello');
+  assert.equal(readTextChunk(out, 'other'), null);
+});
+
+test('two chunks can coexist — the walk does not assume it is the only one', () => {
+  const once = withTextChunk(tinyPng(), 'first', 'a');
+  const twice = withTextChunk(once, 'second', 'b');
+  assert.equal(readTextChunk(twice, 'first'), 'a');
+  assert.equal(readTextChunk(twice, 'second'), 'b');
+});
+
+test('anything that is not a PNG is refused, never silently passed through', () => {
+  assert.throws(() => withTextChunk(new Uint8Array([1, 2, 3]), 'k', 'v'), /not a PNG/);
+  assert.equal(isPng(new Uint8Array([1, 2, 3])), false);
+});
+
+/* The round trip that is the whole point: a picture anyone can open, that
+ * draw.io opens as a diagram. This mirrors draw.io's own reader — find the
+ * `mxfile` text chunk, `decodeURIComponent` it, expect an `<mxfile>`. */
+test('an architecture survives a trip through a PNG and back', () => {
+  const xml = buildDrawioXml(normalizeArchitecture({
+    meta: { name: 'Paiement Données', lang: 'fr' },
+    layers: [{ id: 'services', name: 'Services' }],
+    groups: [{ id: 'core', name: 'Cœur' }],
+    components: [{ id: 'api', name: 'API « façade »', group: 'core', layer: 'services' }]
+  }));
+
+  const png = withDrawioXml(tinyPng(), xml);
+  assert.ok(isPng(png), 'it still has to be an ordinary PNG');
+
+  const carried = readTextChunk(png, DRAWIO_KEYWORD);
+  assert.ok(carried);
+  assert.ok(!/[^\x00-\x7F]/.test(carried!), 'the chunk payload has to be plain ASCII');
+  assert.equal(decodeURIComponent(carried!), xml, 'the accents have to survive');
+});
+
+test('the payload is URI-encoded, which is what draw.io reads back', () => {
+  assert.equal(drawioChunkText('<mxfile a="b"/>'), encodeURIComponent('<mxfile a="b"/>'));
+});

--- a/src/lib/export/png.ts
+++ b/src/lib/export/png.ts
@@ -1,0 +1,180 @@
+/* Putting the diagram back inside its own picture.
+ *
+ * A PNG of an architecture is the format everyone actually forwards — it goes in
+ * the slide, in the ticket, in the chat — and it is also the format where the
+ * drawing dies: the next person to need a change gets an image and redraws it by
+ * hand. draw.io solved this years ago by hiding the source in the file. A PNG is
+ * a signature followed by a chain of length-prefixed chunks, decoders skip the
+ * ones they do not recognise, and a `tEXt` chunk is exactly a keyword and a
+ * string. So the whole `<mxfile>` rides along in one, under the keyword
+ * `mxfile`, URI-encoded — which is the form draw.io's own reader expects, and
+ * the reason it can reopen an image as an editable diagram.
+ *
+ * The result stays a perfectly ordinary PNG. Every viewer that has ever existed
+ * ignores the chunk; draw.io opens it and finds the drawing.
+ *
+ * ------------------------------------------------------------------- why here
+ *
+ * The bytes are assembled in the browser — the canvas that rasterises the SVG is
+ * the only rasteriser this codebase has — but none of *this* is browser work. It
+ * is a CRC and some offset arithmetic, which is the half worth testing, so it
+ * lives here as plain functions over `Uint8Array` and the component keeps the
+ * canvas.
+ */
+
+const SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+/** draw.io's keyword. Its reader checks for `mxfile\0` at the head of a text
+ *  chunk's data and hands what follows to `decodeURIComponent`. */
+export const DRAWIO_KEYWORD = 'mxfile';
+
+/** The XML as a text chunk's payload.
+ *
+ *  `tEXt` is a Latin-1 field and an `<mxfile>` holds component names in whatever
+ *  the author typed, so the encoding is not decoration — it is what makes an
+ *  architecture with "Données" in it survive the trip. It is also pure ASCII
+ *  afterwards, which is what keeps the chunk inside the spec. */
+export const drawioChunkText = (xml: string): string => encodeURIComponent(xml);
+
+/* ------------------------------------------------------------------- the crc */
+
+let table: Uint32Array | null = null;
+
+/** The PNG CRC-32 (reflected, polynomial 0xEDB88320), built once on first use.
+ *
+ *  Every chunk carries one over its type and its data, and a decoder that finds
+ *  a bad one is entitled to reject the file — so an appended chunk with a
+ *  plausible-looking wrong CRC is worse than no chunk at all. */
+export function crc32(bytes: Uint8Array): number {
+  if (!table) {
+    table = new Uint32Array(256);
+    for (let n = 0; n < 256; n++) {
+      let c = n;
+      for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+      table[n] = c >>> 0;
+    }
+  }
+  let c = 0xffffffff;
+  for (let i = 0; i < bytes.length; i++) c = table[(c ^ bytes[i]) & 0xff] ^ (c >>> 8);
+  return (c ^ 0xffffffff) >>> 0;
+}
+
+/* ---------------------------------------------------------------- the chunks */
+
+export const isPng = (bytes: Uint8Array): boolean =>
+  bytes.length > 8 && SIGNATURE.every((b, i) => bytes[i] === b);
+
+/** One `tEXt` chunk: `[length][type][keyword\0text][crc]`, big-endian.
+ *
+ *  Both halves are Latin-1 by the spec. The keyword is ours and the text is
+ *  URI-encoded, so both are ASCII in practice; anything outside the range is a
+ *  caller error rather than something to silently mangle. */
+export function textChunk(keyword: string, text: string): Uint8Array {
+  if (!keyword.length || keyword.length > 79) {
+    throw new Error(`a PNG text keyword is 1 to 79 characters, got ${keyword.length}`);
+  }
+  const key = latin1(keyword, 'keyword');
+  const body = latin1(text, 'text');
+  const data = new Uint8Array(key.length + 1 + body.length);
+  data.set(key, 0);
+  data[key.length] = 0;
+  data.set(body, key.length + 1);
+
+  const type = latin1('tEXt', 'type');
+  const chunk = new Uint8Array(12 + data.length);
+  const view = new DataView(chunk.buffer);
+  view.setUint32(0, data.length);
+  chunk.set(type, 4);
+  chunk.set(data, 8);
+  const crcOver = new Uint8Array(4 + data.length);
+  crcOver.set(type, 0);
+  crcOver.set(data, 4);
+  view.setUint32(8 + data.length, crc32(crcOver));
+  return chunk;
+}
+
+/** The same PNG with one more text chunk, placed just before `IEND`.
+ *
+ *  Walked rather than assumed: `IEND` is the last chunk in every well-formed
+ *  file, but "the last twelve bytes" is a guess about a format that explicitly
+ *  allows chunks a reader does not know, and this function exists precisely
+ *  because such chunks are allowed. Throws on anything that is not a PNG — a
+ *  silently unmodified image would be a download that quietly lost its diagram.
+ *
+ *  The return type names its buffer, which is not pedantry: a bare `Uint8Array`
+ *  widens to `ArrayBufferLike`, and `Blob` — the only consumer these bytes ever
+ *  have — will not take one. Saying it here removes a cast from every caller. */
+export function withTextChunk(
+  png: Uint8Array, keyword: string, text: string
+): Uint8Array<ArrayBuffer> {
+  if (!isPng(png)) throw new Error('not a PNG');
+  const view = new DataView(png.buffer, png.byteOffset, png.byteLength);
+
+  let at = 8;
+  let end = -1;
+  while (at + 8 <= png.length) {
+    const length = view.getUint32(at);
+    const type = String.fromCharCode(png[at + 4], png[at + 5], png[at + 6], png[at + 7]);
+    if (type === 'IEND') { end = at; break; }
+    at += 12 + length;
+  }
+  if (end < 0) throw new Error('PNG has no IEND chunk');
+
+  const chunk = textChunk(keyword, text);
+  const out = new Uint8Array(png.length + chunk.length);
+  out.set(png.subarray(0, end), 0);
+  out.set(chunk, end);
+  out.set(png.subarray(end), end + chunk.length);
+  return out;
+}
+
+/** A PNG carrying its own draw.io source. */
+export const withDrawioXml = (png: Uint8Array, xml: string): Uint8Array<ArrayBuffer> =>
+  withTextChunk(png, DRAWIO_KEYWORD, drawioChunkText(xml));
+
+/** Read back what `withTextChunk` wrote — the round trip the tests turn on, and
+ *  the same walk draw.io does. Returns null when the keyword is not there. */
+export function readTextChunk(png: Uint8Array, keyword: string): string | null {
+  if (!isPng(png)) return null;
+  const view = new DataView(png.buffer, png.byteOffset, png.byteLength);
+  let at = 8;
+  while (at + 8 <= png.length) {
+    const length = view.getUint32(at);
+    const type = String.fromCharCode(png[at + 4], png[at + 5], png[at + 6], png[at + 7]);
+    if (type === 'IEND') return null;
+    if (type === 'tEXt') {
+      const data = png.subarray(at + 8, at + 8 + length);
+      const nul = data.indexOf(0);
+      if (nul > 0 && latin1String(data.subarray(0, nul)) === keyword) {
+        return latin1String(data.subarray(nul + 1));
+      }
+    }
+    at += 12 + length;
+  }
+  return null;
+}
+
+/** Bytes back to a string, a window at a time.
+ *
+ *  `String.fromCharCode(...bytes)` reads better and blows the argument limit on
+ *  a real payload — an embedded architecture is tens of kilobytes, and the
+ *  ceiling is somewhere around a hundred thousand arguments depending on the
+ *  engine. A file that decodes on the machine that wrote it and throws on a
+ *  bigger diagram is the worst kind of working. */
+function latin1String(bytes: Uint8Array): string {
+  let out = '';
+  for (let i = 0; i < bytes.length; i += 8192) {
+    out += String.fromCharCode(...bytes.subarray(i, i + 8192));
+  }
+  return out;
+}
+
+function latin1(s: string, what: string): Uint8Array {
+  const out = new Uint8Array(s.length);
+  for (let i = 0; i < s.length; i++) {
+    const code = s.charCodeAt(i);
+    if (code > 0xff) throw new Error(`a PNG ${what} is Latin-1; "${s[i]}" is not`);
+    out[i] = code;
+  }
+  return out;
+}

--- a/src/lib/export/svg.test.ts
+++ b/src/lib/export/svg.test.ts
@@ -1,0 +1,128 @@
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import { normalizeArchitecture } from '../defaults';
+import type { Architecture } from '../types';
+import { buildDiagramSvg } from './svg';
+
+const doc = (over: Partial<Architecture> = {}): Architecture => normalizeArchitecture({
+  meta: { name: 'Landscape', lang: 'en' },
+  layers: [{ id: 'clients', name: 'Clients' }, { id: 'services', name: 'Services' }],
+  groups: [{ id: 'core', name: 'Core', color: '#0099A0' }],
+  zones: [{ id: 'openshift', name: 'OpenShift', kind: 'platform' }],
+  components: [
+    { id: 'web', name: 'Web', group: 'core', layer: 'clients', role: 'React SPA', deps: ['api'] },
+    { id: 'api', name: 'API', group: 'core', layer: 'services', zone: 'openshift', tech: ['Java'] }
+  ],
+  ...over
+});
+
+test('the file is a standalone SVG with its own size', () => {
+  const svg = buildDiagramSvg(doc());
+  assert.ok(svg.startsWith('<svg xmlns="http://www.w3.org/2000/svg" '));
+  assert.match(svg, /width="\d+(\.\d)?" height="\d+(\.\d)?" viewBox="0 0 /);
+  assert.ok(svg.endsWith('</svg>'));
+});
+
+test('every tag opened is closed', () => {
+  const svg = buildDiagramSvg(doc());
+  const opens = (svg.match(/<(?!\/)[a-zA-Z]/g) || []).length;
+  const closes = (svg.match(/<\//g) || []).length + (svg.match(/\/>/g) || []).length;
+  assert.equal(opens, closes);
+});
+
+/* The constraint the whole module is shaped by: this SVG is rasterised inside an
+ * `<img>`, where an external request is not slow, it is blocked. */
+test('nothing in the drawing reaches outside the file', () => {
+  const svg = buildDiagramSvg(doc());
+  assert.ok(!/xlink:href|<image|url\(http|src=/.test(svg));
+  assert.ok(!svg.includes('foreignObject'), 'an <img> will not render one');
+  assert.ok(!svg.includes('var(--'), 'a custom property has no stylesheet on the other side');
+});
+
+test('the typefaces travel with it when the caller supplies them', () => {
+  const plain = buildDiagramSvg(doc());
+  assert.ok(!plain.includes('@font-face'));
+  const carried = buildDiagramSvg(doc(), { fontCss: "@font-face{font-family:'Archivo'}" });
+  assert.ok(carried.includes('@font-face'));
+});
+
+test('every component appears once, with its role and its technologies', () => {
+  const svg = buildDiagramSvg(doc());
+  assert.equal((svg.match(/>Web</g) || []).length, 1);
+  assert.ok(svg.includes('>React SPA<'));
+  assert.ok(svg.includes('>Java<'));
+});
+
+test('an edge carries the two shapes that say which way it runs', () => {
+  const svg = buildDiagramSvg(doc());
+  const path = svg.match(/<path d="M[^"]+C[^"]+" fill="none" stroke="#0099A0"/);
+  assert.ok(path, 'the cubic should be drawn in the caller scope colour');
+  assert.match(svg, /<circle cx="[\d.]+" cy="[\d.]+" r="3.5" fill="#0099A0"\/>/);
+  assert.match(svg, /<circle cx="[\d.]+" cy="[\d.]+" r="3" fill="#FFFFFF" stroke="#0099A0"/);
+  assert.ok(!svg.includes('marker-end'), 'no arrowhead belongs on these lines');
+});
+
+test('a zone is drawn behind the cards, solid when you could point at it', () => {
+  const svg = buildDiagramSvg(doc());
+  const zoneAt = svg.indexOf('fill="#F8F8F9"');
+  const cardAt = svg.indexOf('fill="#0099A0"');
+  assert.ok(zoneAt > 0 && zoneAt < cardAt, 'the zone is the ground, not the figure');
+  assert.ok(svg.includes('>OPENSHIFT — PLATFORM<'));
+  assert.ok(!/fill="#F8F8F9"[^/]*stroke-dasharray/.test(svg), 'a platform is drawn solid');
+});
+
+test('a logical boundary is drawn dashed', () => {
+  const svg = buildDiagramSvg(doc({
+    zones: [{ id: 'dmz', name: 'DMZ', kind: 'network' }],
+    components: [{ id: 'api', name: 'API', group: 'core', layer: 'services', zone: 'dmz' }]
+  }));
+  assert.match(svg, /fill="#F8F8F9" stroke="#D3DEE5" stroke-width="1" stroke-dasharray="5 4"/);
+});
+
+test('the transition takes the border and a tick, never a hue', () => {
+  const svg = buildDiagramSvg(doc({
+    components: [
+      { id: 'web', name: 'Web', group: 'core', layer: 'clients', state: 'new' },
+      { id: 'old', name: 'Old', group: 'core', layer: 'services', state: 'removed' }
+    ]
+  }));
+  assert.ok(svg.includes('>NEW<'));
+  assert.ok(svg.includes('>DEL<'));
+  assert.match(svg, /stroke="#3D566B" stroke-width="1.8"/, 'a new component is drawn heavier');
+  assert.match(svg, /stroke-dasharray="4 3"/, 'a removal is drawn as a ghost');
+});
+
+test('authored text cannot become markup', () => {
+  const svg = buildDiagramSvg(doc({
+    components: [{
+      id: 'web', name: '<script>x</script> & co', group: 'core', layer: 'clients'
+    }]
+  }));
+  assert.ok(!svg.includes('<script>'));
+  assert.ok(svg.includes('&lt;script&gt;'));
+  assert.ok(!/&(?!amp;|lt;|gt;|quot;|#)/.test(svg), 'a bare ampersand is a broken SVG');
+});
+
+test('a name too wide for its card is cut rather than allowed to run over', () => {
+  const svg = buildDiagramSvg(doc({
+    components: [{
+      id: 'web', group: 'core', layer: 'clients',
+      name: 'A component whose name is far wider than two hundred and six pixels'
+    }]
+  }));
+  assert.ok(svg.includes('…'));
+  assert.ok(!svg.includes('two hundred and six pixels<'));
+});
+
+test('the legend and the protocol note are on the sheet', () => {
+  const svg = buildDiagramSvg(doc({ ui: { architecture: { defaultProtocol: 'REST' } } }));
+  assert.ok(svg.includes('>Core<'), 'colour carries scope; a sheet without the key is half a drawing');
+  assert.ok(svg.includes('All calls are REST unless the line says otherwise.'));
+});
+
+test('an empty document still produces a valid picture', () => {
+  const svg = buildDiagramSvg(normalizeArchitecture({ meta: { name: 'Empty' } }));
+  assert.ok(svg.startsWith('<svg '));
+  assert.ok(svg.endsWith('</svg>'));
+  assert.ok(svg.includes('>Empty<'));
+});

--- a/src/lib/export/svg.ts
+++ b/src/lib/export/svg.ts
@@ -1,0 +1,253 @@
+/* The diagram as one standalone SVG.
+ *
+ * Two things need this and they want it for opposite reasons. A vector export is
+ * what you drop into Figma or a design document and scale without it turning to
+ * mush. And it is the only honest way to reach a PNG from a codebase with no
+ * headless browser in it: rasterising happens in the reader's own browser, by
+ * loading this string into an `<img>` and painting it onto a canvas.
+ *
+ * That second consumer is what fixes the constraints, because SVG inside an
+ * `<img>` runs in a restricted mode:
+ *
+ *   no external requests   so a typeface has to arrive as a base64 `@font-face`
+ *                          or not at all (`fontCss`, injected by the caller —
+ *                          this module reads no files, so it stays testable and
+ *                          usable from the browser)
+ *   no `<foreignObject>`   so every string is a real `<text>`, which means no
+ *                          wrapping and no measuring: `clip` in ./layout cuts
+ *                          each one to the room its box actually has
+ *   no scripts, no CSS vars so every colour is a literal, which is what the INK
+ *                          table in ./layout is for
+ *
+ * Paint order is the canvas's, and it is not the order you would guess. Zones are
+ * the ground, so they go first. Then the lines and their plates. Then the layer
+ * band — its label *and* its rule — because on the sheet a `.layer` sits at
+ * z-index 2 and the edge SVG at 1: a band's name is furniture the reader orients
+ * by, and twenty lines crossing a diagram will cross it. Then the cards, on top
+ * of everything. A line running under a card is the card's, which is the same
+ * answer the editor gives and the right one.
+ */
+
+import type { Architecture } from '../types';
+import {
+  CARD_H, INK, LAYER_PAD_TOP, SHEET_PAD_X, clip, layoutSheet, textWidth, zoneFill,
+  type EdgePlacement, type LayerPlacement, type NodePlacement, type Sheet, type ZonePlacement
+} from './layout';
+
+const SANS = "Archivo, 'Helvetica Neue', Helvetica, Arial, sans-serif";
+const MONO = "'Space Mono', ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace";
+
+/** Average advance per character, as a fraction of the font size. Archivo sits
+ *  near .52 for mixed case; Space Mono advances a flat .6 by construction. The
+ *  numbers only decide where to cut a string, so a hair of overshoot is free. */
+const SANS_RATIO = 0.53;
+const MONO_RATIO = 0.6;
+
+export interface SvgOptions {
+  /** `@font-face` rules with the faces inlined as data URIs. Without them the
+   *  drawing falls back to the reader's Helvetica, which is legible and is not
+   *  the studio. Injected rather than read here so this module has no `node:fs`
+   *  in it and can run on either side of the wire. */
+  fontCss?: string;
+}
+
+export function buildDiagramSvg(doc: Architecture, options: SvgOptions = {}): string {
+  return renderSheet(layoutSheet(doc), options);
+}
+
+export function renderSheet(sheet: Sheet, options: SvgOptions = {}): string {
+  const w = round(sheet.w);
+  const h = round(sheet.h);
+
+  const style = [
+    options.fontCss || '',
+    `.s{font-family:${SANS}}`,
+    `.m{font-family:${MONO}}`
+  ].filter(Boolean).join('\n');
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" `
+    + `viewBox="0 0 ${w} ${h}" role="img"${sheet.title ? ` aria-label="${attr(sheet.title)}"` : ''}>`
+    + `<style>${style}</style>`
+    + (sheet.title ? `<title>${esc(sheet.title)}</title>` : '')
+    + `<rect width="${w}" height="${h}" fill="${INK.paper}"/>`
+    + heading(sheet)
+    + group(sheet.zones.map(zoneSvg).join(''))
+    + group(sheet.edges.map(edgeSvg).join(''))
+    + group(sheet.edges.map(edgeLabelSvg).join(''))
+    + group(sheet.layers.map(l => layerSvg(l, sheet.w)).join(''))
+    + group(sheet.nodes.map(nodeSvg).join(''))
+    + footer(sheet)
+    + `</svg>`;
+}
+
+/* ------------------------------------------------------------------- pieces */
+
+function heading(sheet: Sheet): string {
+  if (!sheet.title) return '';
+  const x = SHEET_PAD_X;
+  let out = text(x, 22, esc(sheet.title), {
+    cls: 's', size: 16, fill: INK.ink, weight: '700'
+  });
+  if (sheet.subtitle) {
+    out += text(x, 40, esc(sheet.subtitle), { cls: 's', size: 11, fill: INK.ink2 });
+  }
+  return out;
+}
+
+function footer(sheet: Sheet): string {
+  let out = '';
+  let x = SHEET_PAD_X;
+  sheet.legend.forEach(g => {
+    out += `<rect x="${round(x)}" y="${round(sheet.legendY)}" width="9" height="9" fill="${g.color}"/>`;
+    out += text(x + 14, sheet.legendY + 8.5, esc(g.label), {
+      cls: 's', size: 10, fill: INK.ink2
+    });
+    x += 14 + textWidth(g.label, 10, SANS_RATIO) + 16;
+  });
+  if (sheet.note) {
+    out += text(SHEET_PAD_X, sheet.noteY + 10, esc(sheet.note), {
+      cls: 'm', size: 10, fill: INK.ink3
+    });
+  }
+  return out;
+}
+
+/* Two treatments and no hue — colour is scope's. Solid is a boundary you could
+ * point at in a room, dashed one that exists in a document. MIRRORS `zoneSvg` in
+ * ../zones, which builds the same rectangle for the three browser renderers; the
+ * difference here is only that the fill and the stroke are literals rather than
+ * classes, because there is no stylesheet on the other side of this file. */
+function zoneSvg(z: ZonePlacement): string {
+  return `<rect x="${round(z.box.x)}" y="${round(z.box.y)}" `
+    + `width="${round(z.box.w)}" height="${round(z.box.h)}" `
+    + `fill="${zoneFill(z.depth)}" stroke="${INK.line3}" stroke-width="1"`
+    + (z.physical ? '' : ' stroke-dasharray="5 4"') + `/>`
+    + text(z.box.x + 9, z.box.y + 11, esc(z.label.toUpperCase()), {
+      cls: 'm', size: 9.5, fill: INK.ink3, spacing: 0.08 * 9.5
+    });
+}
+
+function layerSvg(l: LayerPlacement, sheetW: number): string {
+  const label = (l.label || '').toUpperCase();
+  let out = '';
+  if (label) {
+    out += text(SHEET_PAD_X, l.y + LAYER_PAD_TOP + 10, esc(label), {
+      cls: 'm', size: 10, fill: l.tint || INK.ink3, spacing: 0.06 * 10
+    });
+    if (l.layer.desc) {
+      out += text(
+        SHEET_PAD_X + textWidth(label, 10, MONO_RATIO) + 0.06 * 10 * label.length + 12,
+        l.y + LAYER_PAD_TOP + 10,
+        esc(l.layer.desc),
+        { cls: 'm', size: 10, fill: INK.ink3, opacity: 0.8 }
+      );
+    }
+  }
+  return out + `<line x1="${SHEET_PAD_X}" y1="${round(l.ruleY)}" `
+    + `x2="${round(sheetW - SHEET_PAD_X)}" y2="${round(l.ruleY)}" `
+    + `stroke="${l.tint || INK.line3}" stroke-width="1" stroke-dasharray="4 4" opacity="0.42"/>`;
+}
+
+/* The card. One shape repeated, three lines of content, and the two channels the
+ * transition is allowed to use: the border treatment and a monospace tick in the
+ * corner. Colour stays on the chip, where scope lives. */
+function nodeSvg(n: NodePlacement): string {
+  const { box: b, component: c } = n;
+  const removed = c.state === 'removed';
+  const marked = c.state === 'new' || c.state === 'changed';
+
+  let out = `<g${removed ? ' opacity="0.55"' : ''}>`
+    + `<rect x="${round(b.x)}" y="${round(b.y)}" width="${b.w}" height="${b.h}" `
+    + `fill="${INK.paper}" stroke="${marked ? INK.ink2 : INK.line3}" `
+    + `stroke-width="${marked ? 1.8 : 1}"`
+    + (removed ? ' stroke-dasharray="4 3"' : '') + `/>`
+    + `<rect x="${round(b.x + 12)}" y="${round(b.y + 13)}" width="9" height="9" fill="${n.color}"/>`;
+
+  const tickW = n.tick ? 28 : 0;
+  out += text(b.x + 27, b.y + 21.5,
+    esc(clip(c.name, b.w - 27 - 12 - tickW, 12, SANS_RATIO)),
+    { cls: 's', size: 12, fill: INK.ink, weight: '600' });
+
+  if (n.tick) {
+    out += text(b.x + b.w - 12, b.y + 21, esc(n.tick),
+      { cls: 'm', size: 8.5, fill: INK.ink2, anchor: 'end', spacing: 0.06 * 8.5 });
+  }
+
+  if (c.role) {
+    out += text(b.x + 12, b.y + 38, esc(clip(c.role, b.w - 24, 10, SANS_RATIO)),
+      { cls: 's', size: 10, fill: INK.ink2 });
+  }
+
+  const lower = [c.badge, ...(c.tech || [])].filter(Boolean).join(' · ');
+  if (lower) {
+    out += text(b.x + 12, b.y + CARD_H - 11, esc(clip(lower, b.w - 24, 9, MONO_RATIO)),
+      { cls: 'm', size: 9, fill: INK.ink3 });
+  }
+
+  return out + `</g>`;
+}
+
+/* The line, and the two shapes that carry its direction: a filled disc at the
+ * caller, an open circle at the callee. No arrowhead anywhere — that grammar is
+ * the same on all four surfaces and it survives a monochrome print. */
+function edgeSvg(e: EdgePlacement): string {
+  const d = `M${round(e.x1)},${round(e.y1)} C${round(e.x1)},${round(e.y1 + e.k1)} `
+    + `${round(e.x2)},${round(e.y2 + e.k2)} ${round(e.x2)},${round(e.y2)}`;
+  return `<g opacity="${e.opacity}">`
+    + `<path d="${d}" fill="none" stroke="${e.color}" stroke-width="${e.width}" `
+    + `stroke-linecap="round"${e.dash ? ` stroke-dasharray="${e.dash}"` : ''}/>`
+    + `<circle cx="${round(e.x1)}" cy="${round(e.y1)}" r="3.5" fill="${e.color}"/>`
+    + `<circle cx="${round(e.x2)}" cy="${round(e.y2)}" r="3" fill="${INK.paper}" `
+    + `stroke="${e.color}" stroke-width="1.5"/>`
+    + `</g>`;
+}
+
+/* The plate on the line, collected apart from the curves so every one of them
+ * paints over every line rather than only over the ones drawn before it — the
+ * same two-pass the canvas does. Opaque rather than a halo: the curve runs
+ * underneath, and a stroked outline on 9 px type turns to mud. */
+function edgeLabelSvg(e: EdgePlacement): string {
+  if (!e.label) return '';
+  const x = (e.x1 + e.x2) / 2;
+  const y = (4 * e.y1 + 4 * e.y2 + 3 * e.k1 + 3 * e.k2) / 8;
+  const w = e.label.length * 5.4 + 11;
+  return `<rect x="${round(x - w / 2)}" y="${round(y - 6.5)}" width="${round(w)}" height="13" `
+    + `fill="${INK.paper}" stroke="${INK.line3}" stroke-width="1"/>`
+    + text(x, y + 3.2, esc(e.label), {
+      cls: 'm', size: 9, fill: INK.ink3, anchor: 'middle'
+    });
+}
+
+/* -------------------------------------------------------------- primitives */
+
+interface TextOptions {
+  cls: 's' | 'm';
+  size: number;
+  fill: string;
+  weight?: string;
+  anchor?: 'middle' | 'end';
+  spacing?: number;
+  opacity?: number;
+}
+
+function text(x: number, y: number, body: string, o: TextOptions): string {
+  if (!body) return '';
+  return `<text class="${o.cls}" x="${round(x)}" y="${round(y)}" `
+    + `font-size="${o.size}" fill="${o.fill}"`
+    + (o.weight ? ` font-weight="${o.weight}"` : '')
+    + (o.anchor ? ` text-anchor="${o.anchor}"` : '')
+    + (o.spacing ? ` letter-spacing="${round(o.spacing)}"` : '')
+    + (o.opacity ? ` opacity="${o.opacity}"` : '')
+    + `>${body}</text>`;
+}
+
+const group = (body: string): string => (body ? `<g>${body}</g>` : '');
+
+/** Half a pixel is below anything a reader can see and above what a coordinate
+ *  needs to say; rounding to one decimal keeps the file readable and small. */
+const round = (n: number): number => Math.round(n * 10) / 10;
+
+const esc = (s: string): string =>
+  s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+const attr = (s: string): string => esc(s).replace(/"/g, '&quot;');

--- a/src/lib/exportHtml.ts
+++ b/src/lib/exportHtml.ts
@@ -38,6 +38,22 @@ const UNICODE_RANGE = {
     'U+2C60-2C7F, U+A720-A7FF'
 } as const;
 
+let fontCache: { css: string; mtime: number } | null = null;
+
+/** The `@font-face` rules with every face inlined as a data URI.
+ *
+ *  Exported because the HTML is no longer the only export that has to carry its
+ *  own typography: an SVG is read by whatever opens it, and a PNG is rasterised
+ *  from that SVG inside an `<img>`, where an external font request is not merely
+ *  slow — it is blocked. Same faces, same reason, one place. */
+export function inlineFontCss(): string {
+  const mtime = Math.max(...FONT_FACES.map(f => fs.statSync(path.join(FONT_DIR, f.file)).mtimeMs));
+  if (!fontCache || fontCache.mtime !== mtime) {
+    fontCache = { css: fontCss(), mtime };
+  }
+  return fontCache.css;
+}
+
 function fontCss(): string {
   return FONT_FACES.map(f => {
     const b64 = fs.readFileSync(path.join(FONT_DIR, f.file)).toString('base64');

--- a/src/lib/layers.test.ts
+++ b/src/lib/layers.test.ts
@@ -1,0 +1,57 @@
+import { strict as assert } from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { test } from 'node:test';
+
+import { LAYER_TINTS, layerTintEnabled, layerTintVar } from './layers';
+
+test('the ramp maps a band index onto a token, one per band', () => {
+  assert.equal(layerTintVar(0), 'var(--lt1)');
+  assert.equal(layerTintVar(5), 'var(--lt6)');
+});
+
+test('a seventh band restarts the ramp rather than asking for a token that does not exist', () => {
+  /* `var(--lt7)` resolves to nothing and the rule falls back to the neutral —
+   * so a seventh layer would silently lose its tint instead of cycling. */
+  assert.equal(layerTintVar(6), 'var(--lt1)');
+  assert.equal(layerTintVar(13), 'var(--lt2)');
+});
+
+test('a negative index cannot produce var(--lt0) or a fractional token', () => {
+  /* JavaScript's % keeps the sign of the dividend, so a plain modulo would emit
+   * `var(--lt-1)` here — valid CSS syntax, resolving to nothing. */
+  assert.equal(layerTintVar(-1), 'var(--lt6)');
+  assert.equal(layerTintVar(-7), 'var(--lt6)');
+  for (let i = -20; i < 40; i++) {
+    assert.match(layerTintVar(i), /^var\(--lt[1-6]\)$/, `index ${i} produced ${layerTintVar(i)}`);
+  }
+});
+
+test('tints are on unless the document says otherwise', () => {
+  assert.equal(layerTintEnabled(undefined), true);
+  assert.equal(layerTintEnabled({}), true);
+  assert.equal(layerTintEnabled({ layerTint: true }), true);
+  assert.equal(layerTintEnabled({ layerTint: false }), false);
+});
+
+test('all three stylesheets declare the whole ramp, in both themes', () => {
+  /* The renderers emit only an index; a stylesheet missing `--lt5` would drop
+   * the fifth band's tint on that surface alone — the kind of gap that only
+   * shows on a document with five layers, printed. */
+  const sheets = [
+    'viewer/style.css',
+    'src/app/globals.css',
+    'src/app/projects/[id]/document/document.css'
+  ];
+  for (const sheet of sheets) {
+    const text = readFileSync(join(import.meta.dirname, '..', '..', sheet), 'utf8');
+    for (let i = 1; i <= LAYER_TINTS; i++) {
+      const declarations = text.match(new RegExp(`--lt${i}\\s*:`, 'g')) ?? [];
+      /* Two: the light block and the dark one. The printed sheet has no dark
+       * theme, so one is right there. */
+      const expected = sheet.includes('document.css') ? 1 : 2;
+      assert.equal(declarations.length, expected,
+        `${sheet} declares --lt${i} ${declarations.length} time(s), expected ${expected}`);
+    }
+  }
+});

--- a/src/lib/layers.ts
+++ b/src/lib/layers.ts
@@ -27,3 +27,41 @@ export function displayLayerLabel(idOrName: string, lang: Lang = 'en'): string {
   if (known) return known[lang];
   return idOrName.replace(/(^|[\s/_-]| & )(\p{Ll})/gu, (_, sep: string, ch: string) => sep + ch.toUpperCase());
 }
+
+/* ------------------------------------------------------------- layer tints
+ *
+ * A tall landscape sheet has six or seven bands and, until now, one way to tell
+ * them apart: a 10 px monospace label in `--ink-3`, which on a full-height
+ * drawing is very close to nothing.
+ *
+ * The constraint is rule 1 — colour belongs to scope. What makes a layer tint
+ * safe is not the hue, it is the *position*: a scope colour lives on the icon
+ * chip and the technology pills, and a layer tint lives on the band's label and
+ * on the rule under it. The two never meet on the same element, so neither can
+ * be mistaken for the other. The ramp is deliberately low-chroma besides, so a
+ * band label never competes with a chip for attention.
+ *
+ * The ground is not available: zones already own it, at 3–9 % ink, and stacking
+ * a second tint under a zone rectangle would make both unreadable.
+ *
+ * The values live in the three stylesheets as `--lt1..--lt6`, which is what
+ * makes them theme-aware for free. What the renderers emit is only the index. */
+
+/** How many tints the ramp holds before it repeats. */
+export const LAYER_TINTS = 6;
+
+/** The token for the nth band — `var(--lt3)`. Cycles past the sixth.
+ *
+ *  Six, where scopes stop at five: the scope ceiling is an argument about one
+ *  hue circle at fixed lightness, and this ramp spans a wider arc at a lower
+ *  chroma, where a sixth step is still a step. Layers routinely run to six. */
+export const layerTintVar = (index: number): string =>
+  `var(--lt${(((index % LAYER_TINTS) + LAYER_TINTS) % LAYER_TINTS) + 1})`;
+
+/** On unless the document turns it off.
+ *
+ *  Off emits no custom property at all, and every rule that uses one falls back
+ *  to the neutral it used before — so `layerTint: false` is not a second look to
+ *  maintain, it is the absence of this one. */
+export const layerTintEnabled = (arch?: { layerTint?: boolean }): boolean =>
+  arch?.layerTint !== false;

--- a/src/lib/navigate.test.ts
+++ b/src/lib/navigate.test.ts
@@ -1,0 +1,154 @@
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+
+import { blankArchitecture, normalizeArchitecture } from './defaults';
+import { isArrowKey, searchComponents, sheetRows, stepSelection } from './navigate';
+import type { Architecture, Component } from './types';
+
+const comp = (id: string, layer: string, over: Partial<Component> = {}): Component => ({
+  id, name: id, group: 'core', layer, icon: 'box',
+  tech: [], features: [], notes: [], deps: [], ...over
+});
+
+/** Three layers; `mid` is deliberately left empty in some tests. */
+const build = (components: Component[], layers = ['edge', 'mid', 'data']): Architecture =>
+  normalizeArchitecture({
+    ...blankArchitecture('Test'),
+    groups: [{ id: 'core', name: 'Core' }],
+    layers: layers.map(id => ({ id, name: id })),
+    components
+  });
+
+/* ---------------------------------------------------------------- the rows */
+
+test('the sheet reads as layers top to bottom, cards left to right', () => {
+  const doc = build([
+    comp('web', 'edge'), comp('api', 'mid'), comp('db', 'data'), comp('mobile', 'edge')
+  ]);
+  assert.deepEqual(sheetRows(doc), [['web', 'mobile'], ['api'], ['db']]);
+});
+
+test('an empty layer keeps its row, so an index still means a layer', () => {
+  const doc = build([comp('web', 'edge'), comp('db', 'data')]);
+  assert.deepEqual(sheetRows(doc), [['web'], [], ['db']]);
+});
+
+/* -------------------------------------------------------------- the arrows */
+
+test('left and right walk the row', () => {
+  const doc = build([comp('a', 'edge'), comp('b', 'edge'), comp('c', 'edge')]);
+  assert.equal(stepSelection(doc, 'b', 'ArrowRight'), 'c');
+  assert.equal(stepSelection(doc, 'b', 'ArrowLeft'), 'a');
+});
+
+test('an arrow off the end of a row goes nowhere rather than wrapping', () => {
+  /* Wrapping would move the eye across the whole sheet for a keystroke that
+   * looks like it should move it one card. */
+  const doc = build([comp('a', 'edge'), comp('b', 'edge')]);
+  assert.equal(stepSelection(doc, 'b', 'ArrowRight'), null);
+  assert.equal(stepSelection(doc, 'a', 'ArrowLeft'), null);
+});
+
+test('up and down cross layers and keep the column', () => {
+  const doc = build([
+    comp('a', 'edge'), comp('b', 'edge'), comp('c', 'edge'),
+    comp('x', 'mid'), comp('y', 'mid'), comp('z', 'mid')
+  ]);
+  assert.equal(stepSelection(doc, 'b', 'ArrowDown'), 'y');
+  assert.equal(stepSelection(doc, 'y', 'ArrowUp'), 'b');
+});
+
+test('a column past the end of the row below lands on its last card', () => {
+  const doc = build([comp('a', 'edge'), comp('b', 'edge'), comp('c', 'edge'), comp('x', 'mid')]);
+  assert.equal(stepSelection(doc, 'c', 'ArrowDown'), 'x');
+});
+
+test('an empty layer is stepped over, not landed on', () => {
+  /* `mid` holds nothing. Stopping there would be a keystroke that appears to do
+   * nothing at all, which reads as the key being broken. */
+  const doc = build([comp('a', 'edge'), comp('d', 'data')]);
+  assert.equal(stepSelection(doc, 'a', 'ArrowDown'), 'd');
+  assert.equal(stepSelection(doc, 'd', 'ArrowUp'), 'a');
+});
+
+test('the top and bottom of the sheet are ends, not loops', () => {
+  const doc = build([comp('a', 'edge'), comp('d', 'data')]);
+  assert.equal(stepSelection(doc, 'a', 'ArrowUp'), null);
+  assert.equal(stepSelection(doc, 'd', 'ArrowDown'), null);
+});
+
+test('a component that is not on the sheet moves nothing', () => {
+  const doc = build([comp('a', 'edge')]);
+  assert.equal(stepSelection(doc, 'ghost', 'ArrowRight'), null);
+});
+
+test('only the four arrows are arrows', () => {
+  assert.equal(isArrowKey('ArrowUp'), true);
+  assert.equal(isArrowKey('Tab'), false);
+  assert.equal(isArrowKey('a'), false);
+});
+
+/* -------------------------------------------------------------- the search */
+
+test('an empty query lists the sheet in reading order', () => {
+  const doc = build([comp('web', 'edge'), comp('db', 'data'), comp('api', 'mid')]);
+  assert.deepEqual(searchComponents(doc, '').map(h => h.component.id), ['web', 'api', 'db']);
+});
+
+test('a name beats a role, and a role beats a layer', () => {
+  const doc = build([
+    comp('gateway', 'edge', { name: 'Gateway' }),
+    comp('router', 'edge', { name: 'Router', role: 'Sits behind the gateway' }),
+    comp('worker', 'mid', { name: 'Worker' })
+  ], ['edge', 'gateway-layer', 'data']);
+  const hits = searchComponents(doc, 'gateway').map(h => h.component.id);
+  assert.deepEqual(hits.slice(0, 2), ['gateway', 'router']);
+});
+
+test('an exact name wins over a name that merely starts with the query', () => {
+  const doc = build([
+    comp('api', 'edge', { name: 'API' }),
+    comp('api-gw', 'edge', { name: 'API gateway' })
+  ]);
+  assert.equal(searchComponents(doc, 'api')[0].component.id, 'api');
+});
+
+test('a technology is searchable, which is most of why anyone opens this', () => {
+  const doc = build([
+    comp('store', 'data', { name: 'Store', tech: ['PostgreSQL'] }),
+    comp('cache', 'data', { name: 'Cache', tech: ['Redis'] })
+  ]);
+  assert.deepEqual(searchComponents(doc, 'postgres').map(h => h.component.id), ['store']);
+});
+
+test('the search is case-insensitive and ignores the spaces around the query', () => {
+  const doc = build([comp('gw', 'edge', { name: 'Gateway' })]);
+  assert.equal(searchComponents(doc, '  GATE  ')[0].component.id, 'gw');
+});
+
+test('a hit carries the layer and scope names, so the list can say where it is', () => {
+  /* The *names*, not the ids — normalisation gives a known layer id its proper
+   * label ("edge" becomes "Edge & API"), and that label is what the row shows. */
+  const doc = build([comp('gw', 'edge', { name: 'Gateway' })]);
+  const hit = searchComponents(doc, 'gate')[0];
+  assert.equal(hit.layerName, doc.layers.find(l => l.id === 'edge')!.name);
+  assert.equal(hit.groupName, 'Core');
+});
+
+test('a component pointing at a layer that is gone falls back to the id', () => {
+  /* Not hypothetical: normalisation prunes an unused layer, and a card can be
+   * moved onto one that was created for it and later deleted. */
+  const doc = build([comp('gw', 'edge', { name: 'Gateway' })]);
+  doc.components[0].layer = 'vanished';
+  assert.equal(searchComponents(doc, 'gate')[0].layerName, 'vanished');
+});
+
+test('nothing matching is an empty list, not the whole sheet', () => {
+  const doc = build([comp('gw', 'edge', { name: 'Gateway' })]);
+  assert.deepEqual(searchComponents(doc, 'kafka'), []);
+});
+
+test('the list is capped, so a hundred-component document does not render a hundred rows', () => {
+  const many = Array.from({ length: 60 }, (_, i) => comp(`c${i}`, 'edge'));
+  assert.equal(searchComponents(build(many), '', 40).length, 40);
+});

--- a/src/lib/navigate.ts
+++ b/src/lib/navigate.ts
@@ -1,0 +1,104 @@
+/* Moving around the sheet without the mouse, and finding one card among two
+ * hundred.
+ *
+ * Both are the same missing idea: the canvas had exactly one way in, the
+ * pointer. The cards were divs with no tab stop, no role and no key that did
+ * anything, so a diagram past one screen could only be worked through by
+ * scrolling and aiming. What follows is the part of that with no DOM in it —
+ * where an arrow key lands, and which components a query names — so the
+ * component code is left with focus and scrolling. */
+
+import type { Architecture, Component } from './types';
+
+export type ArrowKey = 'ArrowLeft' | 'ArrowRight' | 'ArrowUp' | 'ArrowDown';
+
+export function isArrowKey(key: string): key is ArrowKey {
+  return key === 'ArrowLeft' || key === 'ArrowRight' || key === 'ArrowUp' || key === 'ArrowDown';
+}
+
+/** The sheet as the eye reads it: one row per layer, in layer order, each row in
+ *  document order. Empty layers keep their row so an index still means a layer. */
+export function sheetRows(doc: Architecture): string[][] {
+  return doc.layers.map(l => doc.components.filter(c => c.layer === l.id).map(c => c.id));
+}
+
+/** Where an arrow key lands from `from`, or null when it runs off the sheet.
+ *
+ * Left and right walk the row. Up and down cross to the nearest layer that has
+ * anything on it — stopping on an empty row would be a keystroke that appears to
+ * do nothing — and keep the column, clamped to the width of the row they land in
+ * so the last card of a short row is where a rightmost card goes. */
+export function stepSelection(doc: Architecture, from: string, key: ArrowKey): string | null {
+  const rows = sheetRows(doc);
+  let r = -1, i = -1;
+  rows.forEach((row, ri) => {
+    const at = row.indexOf(from);
+    if (at >= 0) { r = ri; i = at; }
+  });
+  if (r < 0) return null;
+
+  if (key === 'ArrowLeft') return i > 0 ? rows[r][i - 1] : null;
+  if (key === 'ArrowRight') return i < rows[r].length - 1 ? rows[r][i + 1] : null;
+
+  const dir = key === 'ArrowUp' ? -1 : 1;
+  for (let k = r + dir; k >= 0 && k < rows.length; k += dir) {
+    if (rows[k].length) return rows[k][Math.min(i, rows[k].length - 1)];
+  }
+  return null;
+}
+
+/* -------------------------------------------------------------------- search */
+
+/** How well a component answers a query. Higher is better; 0 is no match.
+ *
+ * The ladder is about where the words were found rather than how many matched:
+ * someone typing "gate" wants the component called Gateway before the one whose
+ * role happens to mention a gateway, and both before the three that merely sit
+ * in a layer of that name. */
+function score(c: Component, q: string, layerName: string, groupName: string): number {
+  const name = c.name.toLowerCase();
+  if (name === q) return 100;
+  if (name.startsWith(q)) return 80;
+  if (name.includes(q)) return 60;
+  if (c.id.includes(q)) return 50;
+  if ((c.tech || []).some(t => t.toLowerCase().includes(q))) return 40;
+  if ((c.role || '').toLowerCase().includes(q)) return 30;
+  if ((c.badge || '').toLowerCase().includes(q)) return 25;
+  if (layerName.includes(q) || groupName.includes(q)) return 10;
+  return 0;
+}
+
+export interface Hit { component: Component; layerName: string; groupName: string }
+
+/** Components a query names, best first. An empty query returns the sheet in
+ *  reading order, because the palette opens on it and a blank list would be a
+ *  worse first impression than the document itself. */
+export function searchComponents(doc: Architecture, query: string, limit = 40): Hit[] {
+  const layerOf = new Map(doc.layers.map(l => [l.id, l.name]));
+  const groupOf = new Map(doc.groups.map(g => [g.id, g.name]));
+  const decorate = (c: Component): Hit => ({
+    component: c,
+    layerName: layerOf.get(c.layer) ?? c.layer,
+    groupName: groupOf.get(c.group) ?? c.group
+  });
+
+  const q = query.trim().toLowerCase();
+  if (!q) {
+    const order = sheetRows(doc).flat();
+    const byId = new Map(doc.components.map(c => [c.id, c]));
+    return order.map(id => byId.get(id)).filter(Boolean).slice(0, limit).map(c => decorate(c!));
+  }
+
+  return doc.components
+    .map(c => {
+      const hit = decorate(c);
+      return { hit, s: score(c, q, hit.layerName.toLowerCase(), hit.groupName.toLowerCase()) };
+    })
+    .filter(x => x.s > 0)
+    /* Ties keep document order rather than falling to whatever sort() does with
+     * them, so the list does not reshuffle between two keystrokes that score the
+     * same. */
+    .sort((a, b) => b.s - a.s)
+    .slice(0, limit)
+    .map(x => x.hit);
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -44,6 +44,10 @@ export interface Ui {
      *  "REST", "HTTPS". Naming it draws the exceptions on their edges and puts
      *  the convention in words under the diagram. */
     defaultProtocol?: string;
+    /** Tint each layer's label and the rule under it, from a ramp separate from
+     *  the scope palette. On unless set to `false`, which emits no colour at all
+     *  and leaves the neutral bands exactly as they were. */
+    layerTint?: boolean;
     /** Where the Transition toggle starts. Unset = on as soon as the document
      *  marks anything, so a landscape opens on the delta it was drawn for; the
      *  reader can still flip to the target state from the toolbar. */

--- a/src/lib/undo.test.ts
+++ b/src/lib/undo.test.ts
@@ -1,0 +1,219 @@
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+
+import { blankArchitecture, normalizeArchitecture } from './defaults';
+import {
+  canRedo, canUndo, COALESCE_MS, docShape, initUndo, record, redo, undo, typingInField, UNDO_LIMIT
+} from './undo';
+import type { Architecture, Component } from './types';
+
+const comp = (id: string, over: Partial<Component> = {}): Component => ({
+  id, name: id, group: 'core', layer: 'services', icon: 'box',
+  tech: [], features: [], notes: [], deps: [], ...over
+});
+
+const build = (components: Component[] = []): Architecture =>
+  normalizeArchitecture({
+    ...blankArchitecture('Test'),
+    groups: [{ id: 'core', name: 'Core' }],
+    layers: [{ id: 'services', name: 'Services' }],
+    components
+  });
+
+/** The same document with one component renamed — a text edit, no shape change. */
+const renamed = (doc: Architecture, id: string, name: string): Architecture => {
+  const next = structuredClone(doc);
+  next.components.find(c => c.id === id)!.name = name;
+  return next;
+};
+
+/* ------------------------------------------------------------------- shape */
+
+test('renaming a component does not change the shape', () => {
+  const doc = build([comp('api')]);
+  assert.equal(docShape(doc), docShape(renamed(doc, 'api', 'Gateway')));
+});
+
+test('the shape ignores every field a keystroke can reach', () => {
+  const doc = build([comp('api')]);
+  const edited = structuredClone(doc);
+  const c = edited.components[0];
+  c.role = 'Answers the front end';
+  c.tech = ['Node'];
+  c.notes = ['todo'];
+  c.badge = 'B2B';
+  edited.meta.intro = 'Rewritten';
+  edited.groups[0].color = '#123456';
+  assert.equal(docShape(doc), docShape(edited));
+});
+
+test('moving a component between layers changes the shape', () => {
+  const doc = build([comp('api')]);
+  const moved = structuredClone(doc);
+  moved.components[0].layer = 'edge';
+  assert.notEqual(docShape(doc), docShape(moved));
+});
+
+test('gaining or losing a dependency changes the shape', () => {
+  const doc = build([comp('api'), comp('db')]);
+  const linked = structuredClone(doc);
+  linked.components[0].deps = ['db'];
+  assert.notEqual(docShape(doc), docShape(linked));
+});
+
+test('reordering two components changes the shape — a drop in front of another is a move', () => {
+  const doc = build([comp('api'), comp('db')]);
+  const swapped = structuredClone(doc);
+  swapped.components.reverse();
+  assert.notEqual(docShape(doc), docShape(swapped));
+});
+
+test('changing a zone parent changes the shape, so re-nesting is its own step', () => {
+  const doc = normalizeArchitecture({
+    ...blankArchitecture('Test'),
+    zones: [{ id: 'net', name: 'Internal' }, { id: 'ocp', name: 'OpenShift' }]
+  });
+  const nested = structuredClone(doc);
+  nested.zones[1].parent = 'net';
+  assert.notEqual(docShape(doc), docShape(nested));
+});
+
+/* ------------------------------------------------------------------ record */
+
+test('a fresh stack has nothing to undo and nothing to redo', () => {
+  const stack = initUndo(build([comp('api')]));
+  assert.equal(canUndo(stack), false);
+  assert.equal(canRedo(stack), false);
+});
+
+test('the first edit is always its own step, however soon it arrives', () => {
+  /* `initUndo` stamps -Infinity precisely so that a document opened and
+   * immediately typed into still leaves a state to come back to. */
+  const doc = build([comp('api')]);
+  const stack = record(initUndo(doc), renamed(doc, 'api', 'A'), 0);
+  assert.equal(stack.past.length, 1);
+  assert.equal(stack.past[0].components[0].name, 'api');
+});
+
+test('a run of keystrokes collapses into one step', () => {
+  const doc = build([comp('api')]);
+  let stack = initUndo(doc);
+  stack = record(stack, renamed(doc, 'api', 'G'), 1000);
+  stack = record(stack, renamed(doc, 'api', 'Ga'), 1100);
+  stack = record(stack, renamed(doc, 'api', 'Gat'), 1200);
+  stack = record(stack, renamed(doc, 'api', 'Gate'), 1300);
+  assert.equal(stack.past.length, 1);
+  assert.equal(stack.present.components[0].name, 'Gate');
+  assert.equal(undo(stack).present.components[0].name, 'api');
+});
+
+test('a pause longer than the window closes the step', () => {
+  const doc = build([comp('api')]);
+  let stack = initUndo(doc);
+  stack = record(stack, renamed(doc, 'api', 'G'), 1000);
+  stack = record(stack, renamed(doc, 'api', 'Gateway'), 1000 + COALESCE_MS + 1);
+  assert.equal(stack.past.length, 2);
+  assert.equal(undo(stack).present.components[0].name, 'G');
+});
+
+test('a structural change never merges, however fast it followed a keystroke', () => {
+  /* The case time alone would get wrong: typing a name and immediately dragging
+   * the card to another layer are two edits, and undoing the drop must not also
+   * undo the name. */
+  const doc = build([comp('api')]);
+  let stack = record(initUndo(doc), renamed(doc, 'api', 'Gateway'), 1000);
+  const moved = structuredClone(stack.present);
+  moved.components[0].layer = 'edge';
+  stack = record(stack, moved, 1050);
+
+  assert.equal(stack.past.length, 2);
+  const back = undo(stack);
+  assert.equal(back.present.components[0].layer, 'services');
+  assert.equal(back.present.components[0].name, 'Gateway');
+});
+
+test('two structural edits in the same millisecond are still two steps', () => {
+  const doc = build([comp('api')]);
+  let stack = initUndo(doc);
+  const one = structuredClone(doc); one.components.push(comp('db'));
+  stack = record(stack, one, 500);
+  const two = structuredClone(one); two.components.push(comp('cache'));
+  stack = record(stack, two, 500);
+  assert.equal(stack.past.length, 2);
+});
+
+test('the stack is bounded, and it drops the oldest state rather than the newest', () => {
+  const doc = build([comp('api')]);
+  let stack = initUndo(doc);
+  for (let i = 0; i < UNDO_LIMIT + 20; i++) {
+    stack = record(stack, renamed(doc, 'api', `n${i}`), i * (COALESCE_MS + 1));
+  }
+  assert.equal(stack.past.length, UNDO_LIMIT);
+  assert.equal(stack.past[stack.past.length - 1].components[0].name, `n${UNDO_LIMIT + 18}`);
+});
+
+/* -------------------------------------------------------------- undo, redo */
+
+test('undo walks back and redo walks forward over the same states', () => {
+  const doc = build([comp('api')]);
+  let stack = initUndo(doc);
+  stack = record(stack, renamed(doc, 'api', 'A'), 0);
+  stack = record(stack, renamed(doc, 'api', 'B'), COALESCE_MS * 2);
+
+  stack = undo(stack);
+  assert.equal(stack.present.components[0].name, 'A');
+  stack = undo(stack);
+  assert.equal(stack.present.components[0].name, 'api');
+  assert.equal(canUndo(stack), false);
+
+  stack = redo(stack);
+  assert.equal(stack.present.components[0].name, 'A');
+  stack = redo(stack);
+  assert.equal(stack.present.components[0].name, 'B');
+  assert.equal(canRedo(stack), false);
+});
+
+test('undo at the bottom returns the very same stack, so nothing re-renders', () => {
+  const stack = initUndo(build([comp('api')]));
+  assert.equal(undo(stack), stack);
+  assert.equal(redo(stack), stack);
+});
+
+test('a new edit after an undo drops the redo branch', () => {
+  const doc = build([comp('api')]);
+  let stack = record(initUndo(doc), renamed(doc, 'api', 'A'), 0);
+  stack = undo(stack);
+  assert.equal(canRedo(stack), true);
+  stack = record(stack, renamed(doc, 'api', 'Z'), COALESCE_MS * 3);
+  assert.equal(canRedo(stack), false);
+});
+
+test('the edit after an undo never merges into the state it just restored', () => {
+  /* Same shape and the same instant: only the -Infinity stamp keeps the undone
+   * step from being swallowed by the keystroke that follows it. */
+  const doc = build([comp('api')]);
+  let stack = record(initUndo(doc), renamed(doc, 'api', 'A'), 1000);
+  stack = undo(stack);
+  stack = record(stack, renamed(doc, 'api', 'B'), 1000);
+  assert.equal(stack.past.length, 1);
+  assert.equal(undo(stack).present.components[0].name, 'api');
+});
+
+test('undo restores the whole document, not just the part that changed', () => {
+  const doc = build([comp('api'), comp('db')]);
+  const wired = structuredClone(doc);
+  wired.components[0].deps = ['db'];
+  wired.components[0].links = [{ to: 'db', protocol: 'SQL' }];
+  const stack = undo(record(initUndo(doc), wired, 0));
+  assert.deepEqual(stack.present.components[0].deps, []);
+  assert.equal(stack.present.components[0].links, undefined);
+});
+
+/* ------------------------------------------------------------------ fields */
+
+test('a keystroke inside a text field belongs to the field, not to the canvas', () => {
+  const fake = (selector: string | null) => ({ closest: (q: string) => (selector === q ? {} : null) });
+  assert.equal(typingInField(fake('input, textarea, select, [contenteditable="true"]') as never), true);
+  assert.equal(typingInField(fake(null) as never), false);
+  assert.equal(typingInField(null), false);
+});

--- a/src/lib/undo.ts
+++ b/src/lib/undo.ts
@@ -1,0 +1,124 @@
+/* The stack that sits in front of History.
+ *
+ * Nothing in the editor has a Save button — an edit lands 700 ms after you stop
+ * typing — and History writes a snapshot at most once every five minutes. Between
+ * those two facts, the way back from a misdrop or a scope deleted by accident was
+ * a snapshot that could be five minutes old. This is the step in between.
+ *
+ * One rule decides both of the things an undo stack has to get right. A push
+ * merges into the previous one only when the document's *shape* is unchanged and
+ * the last one was recent: renaming a component keeps the shape, so a run of
+ * keystrokes collapses into a single step that closes when you pause; moving that
+ * component to another layer changes the shape and takes its own step however
+ * fast it followed. Time alone would have merged a drop into the rename before
+ * it, and shape alone would have made every letter undoable.
+ *
+ * The stack is in memory and per-session on purpose. What survives a reload is
+ * History, which is the other half of the same answer and already durable. */
+
+import type { Architecture } from './types';
+
+/** Deep enough to cover a working session, short enough that the retained
+ *  documents stay a few megabytes rather than a few hundred. */
+export const UNDO_LIMIT = 60;
+
+/** How long a run of keystrokes may pause before it becomes its own step. Half
+ *  the autosave delay, so a merged run is still one write. */
+export const COALESCE_MS = 700;
+
+export interface UndoStack {
+  past: readonly Architecture[];
+  present: Architecture;
+  future: readonly Architecture[];
+  /** `present`'s shape, kept so a push does not recompute the old one. */
+  shape: string;
+  /** When `present` was written, in ms. */
+  stamp: number;
+}
+
+/* Everything a structural edit changes and nothing a text edit does. Names,
+ * roles, protocols and colours are absent on purpose: those are the edits that
+ * arrive one keystroke at a time, and they are exactly what should merge.
+ *
+ * Order is part of the shape — reordering the layers or dropping a card in front
+ * of another one is a move, and a move is undoable on its own. */
+export function docShape(doc: Architecture): string {
+  return [
+    doc.layers.map(l => l.id).join(','),
+    doc.groups.map(g => g.id).join(','),
+    (doc.zones ?? []).map(z => `${z.id}>${z.parent ?? ''}`).join(','),
+    doc.components
+      .map(c => `${c.id}@${c.layer}/${c.group}/${c.zone ?? ''}:${(c.deps ?? []).join('+')}`)
+      .join(','),
+    doc.sections.map(s => s.id).join(','),
+    doc.flows.map(f => f.id).join(',')
+  ].join('|');
+}
+
+export function initUndo(present: Architecture): UndoStack {
+  return { past: [], present, future: [], shape: docShape(present), stamp: -Infinity };
+}
+
+/** Adopt `next` as the present. Merges into the current step when the shape is
+ *  unchanged and the last write was under `COALESCE_MS` ago. */
+export function record(stack: UndoStack, next: Architecture, now: number): UndoStack {
+  const shape = docShape(next);
+  if (shape === stack.shape && now - stack.stamp < COALESCE_MS) {
+    return { ...stack, present: next, future: [], stamp: now };
+  }
+  return {
+    past: [...stack.past, stack.present].slice(-UNDO_LIMIT),
+    present: next,
+    future: [],
+    shape,
+    stamp: now
+  };
+}
+
+export const canUndo = (stack: UndoStack) => stack.past.length > 0;
+export const canRedo = (stack: UndoStack) => stack.future.length > 0;
+
+/** Say what just happened. The step back is offered unless `undoable` is false,
+ *  which is how a refusal ("keep at least one layer") says its piece without
+ *  putting an Undo next to an edit that never landed. */
+export type Notify = (text: string, undoable?: boolean) => void;
+
+/* Both moves stamp `-Infinity` rather than the clock: the first edit after a
+ * step through the stack must never merge into the state it just restored, or
+ * undoing a rename and typing again would silently swallow the undo. */
+
+export function undo(stack: UndoStack): UndoStack {
+  if (!stack.past.length) return stack;
+  const present = stack.past[stack.past.length - 1];
+  return {
+    past: stack.past.slice(0, -1),
+    present,
+    future: [stack.present, ...stack.future].slice(0, UNDO_LIMIT),
+    shape: docShape(present),
+    stamp: -Infinity
+  };
+}
+
+export function redo(stack: UndoStack): UndoStack {
+  if (!stack.future.length) return stack;
+  const [present, ...rest] = stack.future;
+  return {
+    past: [...stack.past, stack.present].slice(-UNDO_LIMIT),
+    present,
+    future: rest,
+    shape: docShape(present),
+    stamp: -Infinity
+  };
+}
+
+/* Whether a keystroke belongs to the document or to the field it was typed in.
+ *
+ * A text input has its own undo and the browser's is better than ours inside it
+ * — it restores the caret. The canvas shortcut has to stand back for that, and
+ * the check is by element rather than by focus ring because a `contenteditable`
+ * is not an input and still owns its own history. */
+export function typingInField(target: EventTarget | null): boolean {
+  const el = target as HTMLElement | null;
+  if (!el || typeof el.closest !== 'function') return false;
+  return !!el.closest('input, textarea, select, [contenteditable="true"]');
+}

--- a/src/lib/viewport.test.ts
+++ b/src/lib/viewport.test.ts
@@ -1,0 +1,74 @@
+import { strict as assert } from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { test } from 'node:test';
+
+import {
+  anchoredScroll, clampZoom, fitLadder, zoomStyle, ZOOM_MAX, ZOOM_MIN, ZOOM_STEP
+} from './viewport';
+
+test('a factor is held between the two ends of the range', () => {
+  assert.equal(clampZoom(5), ZOOM_MAX);
+  assert.equal(clampZoom(0.01), ZOOM_MIN);
+  assert.equal(clampZoom(1), 1);
+});
+
+test('stepping does not drift off whole percents', () => {
+  /* 0.7 + 0.1 is 0.7999999999999999 in binary floating point, which would print
+   * as 80 % and still compare unequal to 0.8 — so the button would go dead. */
+  let z = 1;
+  for (let i = 0; i < 6; i++) z = clampZoom(z - ZOOM_STEP);
+  assert.equal(z, 0.4);
+  for (let i = 0; i < 6; i++) z = clampZoom(z + ZOOM_STEP);
+  assert.equal(z, 1);
+});
+
+test('a broken factor falls back to 100 % rather than to a blank sheet', () => {
+  assert.equal(clampZoom(NaN), 1);
+  assert.equal(clampZoom(Infinity), 1);
+});
+
+test('100 % emits no style at all, so an unzoomed canvas is untouched', () => {
+  assert.deepEqual(zoomStyle(1, true), {});
+  assert.deepEqual(zoomStyle(1, false), {});
+});
+
+test('below 100 % scales the layout, above it magnifies the paint', () => {
+  assert.deepEqual(zoomStyle(0.7, true), { zoom: '0.7' });
+  assert.deepEqual(zoomStyle(1.5, true), { transform: 'scale(1.5)', transformOrigin: 'top left' });
+});
+
+test('without the zoom property the transform does both directions', () => {
+  assert.deepEqual(zoomStyle(0.7, false), { transform: 'scale(0.7)', transformOrigin: 'top left' });
+});
+
+test('Fit walks down from 100 % and stops at the floor', () => {
+  const ladder = fitLadder();
+  assert.equal(ladder[0], 1);
+  assert.equal(ladder[ladder.length - 1], ZOOM_MIN);
+  for (let i = 1; i < ladder.length; i++) assert.ok(ladder[i] < ladder[i - 1]);
+});
+
+test('zooming about a point leaves that point where it was', () => {
+  /* The pixel under the cursor is at sheet coordinate (0 + 100)/1 = 100. At 2×
+   * it sits at 200, so the frame has to scroll to 100 to keep it under the
+   * cursor at offset 100. */
+  const next = anchoredScroll(1, 2, { left: 0, top: 0 }, { x: 100, y: 50 });
+  assert.deepEqual(next, { left: 100, top: 50 });
+});
+
+test('zooming out never asks the frame to scroll to a negative offset', () => {
+  const next = anchoredScroll(1, 0.5, { left: 0, top: 0 }, { x: 100, y: 100 });
+  assert.deepEqual(next, { left: 0, top: 0 });
+});
+
+test('the editor and the viewer agree on the range and the step', () => {
+  /* Two surfaces scaling the same sheet. A viewer at 40 % and an editor at 25 %
+   * would make "what it looks like at Fit" a different drawing in each. */
+  const engine = readFileSync(join(import.meta.dirname, '..', '..', 'viewer', 'engine.js'), 'utf8');
+  const line = engine.match(/const ZMIN\s*=\s*([\d.]+),\s*ZMAX\s*=\s*([\d.]+),\s*ZSTEP\s*=\s*([\d.]+)/);
+  assert.ok(line, 'viewer/engine.js no longer declares ZMIN/ZMAX/ZSTEP on one line');
+  assert.equal(Number(line[1]), ZOOM_MIN);
+  assert.equal(Number(line[2]), ZOOM_MAX);
+  assert.equal(Number(line[3]), ZOOM_STEP);
+});

--- a/src/lib/viewport.ts
+++ b/src/lib/viewport.ts
@@ -1,0 +1,64 @@
+/* Zoom for the editing canvas — the same two-mechanism answer the viewer gives,
+ * because it is the same problem: the sheet is HTML flow, not an absolutely
+ * positioned drawing, and the two directions do not want the same tool.
+ *
+ * Out, below 100 %, uses the `zoom` property: it scales the layout itself, so
+ * the sheet still resolves to the width of the frame and reflows into it. More
+ * cards land on each row instead of the drawing shrinking away from the right
+ * edge, and there is nothing to pan sideways to.
+ *
+ * In, above 100 %, uses `transform`: the layout is left alone and the frame
+ * scrolls over a magnified sheet, which is what you want when you are reading
+ * one corner of it. A transform cannot do the job below 100 % — the untransformed
+ * box still counts towards the scroll container's width, so the frame would offer
+ * a horizontal scrollbar over empty paper.
+ *
+ * MIRRORS the ZOOM & PAN block in viewer/engine.js. The editor and the export
+ * scale the same sheet; they should not disagree about what 70 % means. */
+
+export const ZOOM_MIN = 0.4;
+export const ZOOM_MAX = 2;
+export const ZOOM_STEP = 0.1;
+
+/** Snapped to whole percents before clamping, so repeated steps cannot drift
+ *  onto 0.7000000000000001 and print as 70 % while comparing unequal. */
+export function clampZoom(z: number): number {
+  if (!Number.isFinite(z)) return 1;
+  return Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, Math.round(z * 100) / 100));
+}
+
+export interface ZoomStyle { zoom?: string; transform?: string }
+
+/** The inline style a factor asks for. `hasZoomProperty` is false on browsers
+ *  that never learned `zoom` (Firefox before 126), where the transform does both
+ *  directions: a worse view below 100 %, because the sheet shrinks away from the
+ *  right edge rather than reflowing into it, but a true one — and the edges still
+ *  land on their cards, because both mechanisms scale what a rect reports. */
+export function zoomStyle(zoom: number, hasZoomProperty: boolean): ZoomStyle {
+  if (zoom === 1) return {};
+  if (hasZoomProperty && zoom < 1) return { zoom: String(zoom) };
+  return { transform: `scale(${zoom})`, transformOrigin: 'top left' } as ZoomStyle;
+}
+
+/** The factors Fit tries, largest first. Scaling reflows, so the height at a
+ *  given factor cannot be calculated — it has to be measured, and this is the
+ *  ladder to measure down. */
+export function fitLadder(): number[] {
+  const out: number[] = [];
+  const lo = Math.round(ZOOM_MIN * 100);
+  const step = Math.round(ZOOM_STEP * 100);
+  for (let pct = 100; pct >= lo; pct -= step) out.push(pct / 100);
+  return out;
+}
+
+/** Keep the point under `anchor` where it was while the factor changes.
+ *  Returns the frame's new scroll offsets. */
+export function anchoredScroll(
+  from: number, to: number,
+  scroll: { left: number; top: number },
+  anchor: { x: number; y: number }
+): { left: number; top: number } {
+  const cx = (scroll.left + anchor.x) / from;
+  const cy = (scroll.top + anchor.y) / from;
+  return { left: Math.max(0, cx * to - anchor.x), top: Math.max(0, cy * to - anchor.y) };
+}

--- a/src/lib/zones.test.ts
+++ b/src/lib/zones.test.ts
@@ -4,7 +4,7 @@ import { test } from 'node:test';
 import { blankArchitecture, normalizeArchitecture } from './defaults';
 import { diffArchitecture } from './diff';
 import {
-  ancestry, BAND_GUTTER, BAND_MAX, bandPlan, describeZone, inflatedUnion, isZoneKind, layerRuns, subtreeHeight,
+  ancestry, BAND_BUDGET, BAND_GUTTER, BAND_MAX, bandPlan, canMoveZone, moveZone, describeZone, inflatedUnion, isZoneKind, layerRuns, subtreeHeight,
   withDescendants, zonesInTreeOrder,
   zoneDepth, zoneIndex, zonePad, zoneSortKey, zoneSvg, zonesInUse, type Box, type ZoneKind
 } from './zones';
@@ -407,4 +407,117 @@ test('a document with no layers still gets one band per bucket', () => {
   const plan = bandPlan([comp('a', { zone: 'ocp' }), comp('b')], NESTED, []);
   assert.deepEqual(plan.bands.map(b => b.zone), [undefined, 'ocp']);
   assert.equal(plan.total, 2);
+});
+
+/* ------------------------------------------- the budget and the reordering */
+
+const WIDE: Zone[] = [
+  { id: 'a', name: 'A' }, { id: 'b', name: 'B' }, { id: 'c', name: 'C' }, { id: 'd', name: 'D' }
+];
+
+/** `n` components in `zone`, all on the same layer — the busiest-layer case. */
+const fill = (zone: string | undefined, n: number, layer = 'clients') =>
+  Array.from({ length: n }, (_, i) => comp(`${zone ?? 'bare'}${i}`, { layer, zone }));
+
+test('a sheet that fits the budget is left exactly as it was', () => {
+  const items = [...fill(undefined, 2), ...fill('a', 3), ...fill('b', 1)];
+  const plan = bandPlan(items, WIDE, LAYERS);
+  assert.deepEqual(plan.bands.map(b => b.span), [2, 3, 1]);
+  assert.equal(plan.total, 6);
+});
+
+test('four full bands would run off the frame, so the sheet is narrowed to the budget', () => {
+  /* Unbounded before this: BAND_MAX capped one band and nothing capped the sum,
+   * so each zone added a column-load of width until the drawing left the frame
+   * — with no zoom in the editor to pull it back, only a scrollbar. */
+  const items = [
+    ...fill(undefined, 6), ...fill('a', 6), ...fill('b', 6), ...fill('c', 6)
+  ];
+  const plan = bandPlan(items, WIDE, LAYERS);
+  assert.equal(plan.total, BAND_BUDGET);
+  /* No card is lost — a narrowed band wraps inside itself. */
+  assert.ok(plan.bands.every(b => b.span >= 1));
+});
+
+test('the widest band gives up its columns first', () => {
+  const items = [...fill(undefined, 1), ...fill('a', 6), ...fill('b', 6), ...fill('c', 2)];
+  const plan = bandPlan(items, WIDE, LAYERS);
+  const span = (z?: string) => plan.band(z)!.span;
+  assert.equal(plan.total, BAND_BUDGET);
+  /* The two six-wide bands absorbed the whole reduction; the narrow ones did
+   * not pay for a width they were not causing. */
+  assert.equal(span(undefined), 1);
+  assert.equal(span('c'), 2);
+  assert.equal(span('a') + span('b'), BAND_BUDGET - 3);
+});
+
+test('bands still tile without a gap after the budget has narrowed them', () => {
+  const items = [...fill('a', 6), ...fill('b', 6), ...fill('c', 6), ...fill('d', 6)];
+  const plan = bandPlan(items, WIDE, LAYERS);
+  let expected = 1;
+  for (const b of plan.bands) {
+    assert.equal(b.start, expected);
+    expected += b.span;
+  }
+  assert.equal(plan.total, expected - 1);
+});
+
+test('more buckets than columns means one each — the floor, not a crash', () => {
+  /* The budget is a ceiling, not a promise: below one column per band there is
+   * nothing left to take, and the loop has to stop rather than spin. */
+  const many: Zone[] = Array.from({ length: 15 }, (_, i) => ({ id: `z${i}`, name: `Z${i}` }));
+  const items = many.flatMap(z => fill(z.id, 2));
+  const plan = bandPlan(items, many, LAYERS);
+  assert.equal(plan.bands.length, 15);
+  assert.ok(plan.bands.every(b => b.span === 1));
+  assert.equal(plan.total, 15);
+});
+
+test('the plan does not depend on how the zones happen to be ordered in the file', () => {
+  /* Ties go to the earliest band, so the *set* of spans is stable even when the
+   * declaration order changes — otherwise reordering a zone would silently
+   * reflow every other one. */
+  const items = [...fill('a', 6), ...fill('b', 6), ...fill('c', 6)];
+  const spans = (zones: Zone[]) =>
+    bandPlan(items, zones, LAYERS).bands.map(b => b.span).sort();
+  assert.deepEqual(spans(WIDE), spans([WIDE[2], WIDE[0], WIDE[1], WIDE[3]]));
+});
+
+test('a zone moves among its siblings, and its children follow it', () => {
+  const zones: Zone[] = [
+    { id: 'a', name: 'A' },
+    { id: 'b', name: 'B' },
+    { id: 'b1', name: 'B1', parent: 'b' },
+    { id: 'c', name: 'C' }
+  ];
+  const moved = moveZone(zones, 'b', -1);
+  assert.deepEqual(zonesInTreeOrder(moved).map(z => z.id), ['b', 'b1', 'a', 'c']);
+  /* Contiguity survives: the child stayed with the parent it belongs to. */
+  assert.deepEqual(zonesInTreeOrder(zones).map(z => z.id), ['a', 'b', 'b1', 'c']);
+});
+
+test('a nested zone slides inside its parent and never out of it', () => {
+  const zones: Zone[] = [
+    { id: 'p', name: 'P' },
+    { id: 'x', name: 'X', parent: 'p' },
+    { id: 'y', name: 'Y', parent: 'p' },
+    { id: 'outside', name: 'Outside' }
+  ];
+  assert.deepEqual(zonesInTreeOrder(moveZone(zones, 'y', -1)).map(z => z.id),
+    ['p', 'y', 'x', 'outside']);
+  /* `y` is already the last child of `p`; the zone after it in the array is a
+   * root, which is not its sibling, so the move is refused rather than
+   * reparenting it. */
+  assert.equal(moveZone(zones, 'y', 1), zones);
+  assert.equal(canMoveZone(zones, 'y', 1), false);
+  assert.equal(canMoveZone(zones, 'y', -1), true);
+});
+
+test('a move with no sibling that way is refused by identity, not by a copy', () => {
+  /* The buttons read `canMoveZone`, which compares identity — a function that
+   * returned a fresh equal array would light both buttons for ever. */
+  const zones: Zone[] = [{ id: 'only', name: 'Only' }];
+  assert.equal(moveZone(zones, 'only', -1), zones);
+  assert.equal(moveZone(zones, 'only', 1), zones);
+  assert.equal(moveZone(zones, 'ghost', 1), zones);
 });

--- a/src/lib/zones.ts
+++ b/src/lib/zones.ts
@@ -215,6 +215,19 @@ export function layerRuns(components: Component[], zones: Zone[]): ZoneRun[] {
  *  pushing every other band off the page. */
 export const BAND_MAX = 6;
 
+/** Columns the whole sheet may reserve, across every band.
+ *
+ *  `BAND_MAX` caps one band; nothing capped their sum, so each zone added a
+ *  column-load of width and a sheet with four of them ran off the right of the
+ *  frame — where the editor has no zoom to pull it back, only a scrollbar to
+ *  discover it with. Twelve columns is about 2 900 px, which fits a laptop at
+ *  the viewer's Fit and stays scrollable everywhere else.
+ *
+ *  This is a ceiling, not a promise: a document with more buckets than columns
+ *  gets one column each and is wider than this. One card per band is the floor,
+ *  and below it there is nothing left to take. */
+export const BAND_BUDGET = 12;
+
 export interface Band {
   zone?: string;
   /** 1-based, for `grid-column`. */
@@ -267,12 +280,29 @@ export function bandPlan(components: Component[], zones: Zone[], layers: Layer[]
     ...zonesInTreeOrder(zones).map(z => z.id).filter(id => buckets.has(id))
   ];
 
+  /* What each bucket would take if width were free, then narrowed until the
+   * sheet fits the budget: the widest band gives up a column at a time, so the
+   * pressure lands on whatever is making the drawing wide rather than being
+   * spread evenly over buckets that were already narrow. A band that loses a
+   * column does not lose a card — it wraps inside itself and the layer grows
+   * taller, which is the trade a reader can actually scroll. */
+  const spans = ordered.map(zone => Math.min(BAND_MAX, Math.max(1, widest.get(zone) ?? 0)));
+  let total = spans.reduce((a, b) => a + b, 0);
+  while (total > BAND_BUDGET) {
+    /* Ties go to the earliest band, which keeps the result independent of how
+     * the zones happen to be ordered in the file. */
+    let widestAt = -1;
+    spans.forEach((s, i) => { if (s > 1 && (widestAt < 0 || s > spans[widestAt])) widestAt = i; });
+    if (widestAt < 0) break;   // every band is down to one column
+    spans[widestAt] -= 1;
+    total -= 1;
+  }
+
   const bands: Band[] = [];
   let at = 1;
-  ordered.forEach(zone => {
-    const span = Math.min(BAND_MAX, Math.max(1, widest.get(zone) ?? 0));
-    bands.push({ zone, start: at, span });
-    at += span;
+  ordered.forEach((zone, i) => {
+    bands.push({ zone, start: at, span: spans[i] });
+    at += spans[i];
   });
 
   const index = new Map(bands.map(b => [b.zone, b]));
@@ -294,6 +324,39 @@ export function zonesInUse(zones: Zone[], components: Component[]): Zone[] {
     .filter(z => held.has(z.id))
     .sort((a, b) => ancestry(a.id, by).length - ancestry(b.id, by).length);
 }
+
+/** Move a zone one place earlier or later *among its own siblings*.
+ *
+ *  Not a plain array swap. Band order comes from `zonesInTreeOrder`, where the
+ *  array index only ever breaks ties between zones sharing a parent — so
+ *  swapping with whatever happens to sit next in the array usually moves
+ *  nothing at all, and a button that sometimes does nothing is worse than no
+ *  button. This swaps with the nearest zone at the same level, which is exactly
+ *  the movement the drawing shows: the band slides one place left or right, and
+ *  its children follow it because their keys are built from its index.
+ *
+ *  Returns the list unchanged when there is no sibling that way, so the caller
+ *  can compare identity to decide whether the button is live. */
+export function moveZone(zones: Zone[], id: string, delta: -1 | 1): Zone[] {
+  const at = zones.findIndex(z => z.id === id);
+  if (at < 0) return zones;
+  const parent = zones[at].parent;
+
+  const siblings = zones
+    .map((z, i) => ({ z, i }))
+    .filter(({ z }) => z.parent === parent);
+  const seat = siblings.findIndex(({ z }) => z.id === id);
+  const target = siblings[seat + delta];
+  if (!target) return zones;
+
+  const out = [...zones];
+  [out[at], out[target.i]] = [out[target.i], out[at]];
+  return out;
+}
+
+/** Has this zone a sibling in that direction? Drives the buttons' disabled state. */
+export const canMoveZone = (zones: Zone[], id: string, delta: -1 | 1): boolean =>
+  moveZone(zones, id, delta) !== zones;
 
 export const zoneOf = (zones: Zone[], id: string | undefined): Zone | undefined =>
   id ? zones.find(z => z.id === id) : undefined;

--- a/viewer/engine.js
+++ b/viewer/engine.js
@@ -449,6 +449,11 @@ const ZONES_IN_USE = (() => {
  *
  * MIRROR of bandPlan in src/lib/zones.ts. */
 const BAND_MAX = 6;
+/* `BAND_MAX` caps one band; nothing capped their sum, so each zone added a
+ * column-load of width and four of them ran the sheet off the frame. Twelve is
+ * a ceiling, not a promise: more buckets than columns means one column each and
+ * a sheet wider than this, because one card per band is the floor. */
+const BAND_BUDGET = 12;
 
 /** Zones in tree order, so a subtree's bands are contiguous and a parent's box
  *  is one range of columns rather than two with a hole in the middle. */
@@ -477,13 +482,24 @@ const BAND_PLAN = (() => {
   });
 
   const ordered = [...(buckets.has('') ? [''] : []), ...ZONES_TREE_ORDER.filter(id => buckets.has(id))];
+
+  /* Narrowed until the sheet fits: the widest band gives up a column at a time,
+   * so the pressure lands on what is making the drawing wide. A band that loses
+   * a column keeps its cards — it wraps inside itself and the layer grows
+   * taller, which is the trade a reader can scroll. */
+  const spans = ordered.map(b => Math.min(BAND_MAX, Math.max(1, widest[b] || 0)));
+  let total = spans.reduce((a, b) => a + b, 0);
+  while (total > BAND_BUDGET) {
+    let widestAt = -1;
+    spans.forEach((s, i) => { if (s > 1 && (widestAt < 0 || s > spans[widestAt])) widestAt = i; });
+    if (widestAt < 0) break;
+    spans[widestAt] -= 1;
+    total -= 1;
+  }
+
   const byBucket = {};
   let at = 1;
-  ordered.forEach(b => {
-    const span = Math.min(BAND_MAX, Math.max(1, widest[b] || 0));
-    byBucket[b] = { start: at, span };
-    at += span;
-  });
+  ordered.forEach((b, i) => { byBucket[b] = { start: at, span: spans[i] }; at += spans[i]; });
   return { byBucket, total: at - 1 };
 })();
 

--- a/viewer/engine.js
+++ b/viewer/engine.js
@@ -581,6 +581,18 @@ const DENSE = DATA.components.length >= 24
  * by the colour on every chip and by the filter chips above the sheet. An author
  * who sets `cluster: true` on a zoned document gets the zones, and the README
  * says so. */
+/* A tall landscape has six or seven bands and, before this, one way to tell them
+ * apart: a 10 px label in `--ink-3`. Colour belongs to scope (rule 1), so what
+ * makes a layer tint safe is position, not hue — a scope colour lives on the
+ * icon chip and the technology pills, a layer tint on the band's label and the
+ * rule under it, and the two never meet on one element. The ground was not
+ * available: zones already own it.
+ *
+ * MIRROR of layerTintVar / layerTintEnabled in src/lib/layers.ts. */
+const LAYER_TINTS = 6;
+const layerTintVar = i => `var(--lt${(((i % LAYER_TINTS) + LAYER_TINTS) % LAYER_TINTS) + 1})`;
+const LAYER_TINT = ARCH_OPTS.layerTint !== false;
+
 const CLUSTER = ZONES_IN_USE.length ? false
   : ARCH_OPTS.cluster == null ? DENSE
   : !!ARCH_OPTS.cluster;
@@ -766,7 +778,7 @@ function renderArchitecture() {
  * curves instead of arcs across the whole sheet. A layer holding a single
  * scope keeps the plain row: a column header naming the only thing there is
  * would be noise. */
-function layerHTML(l) {
+function layerHTML(l, index) {
   const nodes = DATA.components.filter(c => c.layer === l.id);
   if (!nodes.length) return '';
   const head = `<div class="layer-head"><b>${esc(l.name)}</b>${l.desc ? `<em>${esc(l.desc)}</em>` : ''}</div>`;
@@ -791,7 +803,11 @@ function layerHTML(l) {
             bandStyle(run.zone)}>${run.items.map(nodeHTML).join('')}</div>`).join('')}</div>`
       : `<div class="nodes">${nodes.map(nodeHTML).join('')}</div>`;
 
-  return `<div class="layer" data-layer="${esc(l.id)}">${head}${body}</div>`;
+  /* Only the index travels: the six values live in the stylesheet, which is what
+   * makes them follow the theme without a second table here. Off emits nothing
+   * and every rule falls back to the neutral it had before. */
+  const tint = LAYER_TINT ? ` style="--lc:${layerTintVar(index)}"` : '';
+  return `<div class="layer" data-layer="${esc(l.id)}"${tint}>${head}${body}</div>`;
 }
 
 /* The key for the line styles, drawn only for the kinds this document uses. A

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -19,6 +19,13 @@
   --brand-soft:color-mix(in srgb,#0E7C8A 8%,transparent);
   --accent:#0E7C8A; --cyan:#00E5FF; --on-fill:#FFFFFF;
   --p1:#0099A0; --p2:#4F8AC6; --p3:#857AC4; --p4:#B26B9B; --p5:#519962;
+  /* The layer ramp. A separate palette from the scopes above, and separate on
+     purpose: lower chroma, a wider arc that includes warm hues the scope circle
+     never reaches, and it only ever appears on a band's label and the rule under
+     it — never on a chip or a pill. Position is what keeps the two readings
+     apart; the low chroma is what keeps a band from competing with a card. */
+  --lt1:#5B7FA6; --lt2:#5E9070; --lt3:#9A8149;
+  --lt4:#A5735F; --lt5:#8474A8; --lt6:#4E8C93;
   --bg:#EEF3F6; --panel:#FFFFFF; --panel-2:#F5F8FA; --panel-3:#F0F5F8;
   --ink:#0B1B2B; --ink-2:#3D566B; --ink-3:#8CA1B2;
   --line:#E7EEF2; --line-2:#DCE5EB; --line-3:#D3DEE5;
@@ -36,6 +43,10 @@ html[data-theme="dark"]{
   --brand-soft:color-mix(in srgb,#00E5FF 14%,transparent);
   --accent:#00E5FF; --cyan:#00E5FF; --on-fill:#0B1B2B;
   --p1:#14BBC2; --p2:#67AAED; --p3:#A497EA; --p4:#D686BC; --p5:#69BA7C;
+  /* The same six hues lifted onto the marine ground, where a .55-lightness ink
+     sinks into the navy and stops reading as a label at all. */
+  --lt1:#8FB3D9; --lt2:#8FC7A2; --lt3:#CFB57E;
+  --lt4:#D6A492; --lt5:#B5A6D6; --lt6:#85C0C7;
   --bg:#0B1B2B; --panel:#10263A; --panel-2:#142D42; --panel-3:#1A3650;
   --ink:#FFFFFF; --ink-2:#C3D0DA; --ink-3:#8CA1B2;
   --line:#1C3549; --line-2:#274459; --line-3:#2F4E64;
@@ -208,10 +219,16 @@ main{max-width:1440px;margin:0 auto;padding:28px 24px 90px}
   font-family:var(--mono);font-size:9px;letter-spacing:.02em;
   fill:var(--ink-3);text-anchor:middle;
 }
-.layer{position:relative;z-index:2;padding:16px 0 6px;border-bottom:1px dashed var(--line-3)}
+/* `--lc` is the band's tint, set by the renderer. Every rule that uses it falls
+   back to the neutral it used before, so `layerTint:false` — which emits no
+   property at all — is the absence of this look rather than a second one. */
+.layer{
+  position:relative;z-index:2;padding:16px 0 6px;
+  border-bottom:1px dashed color-mix(in srgb,var(--lc,var(--line-3)) 42%,var(--line-3));
+}
 .layer:last-child{border-bottom:0}
 .layer-head{display:flex;align-items:center;gap:10px;margin-bottom:12px}
-.layer-head b{font-family:var(--mono);font-size:10px;letter-spacing:.06em;text-transform:capitalize;color:var(--ink-3);font-weight:400}
+.layer-head b{font-family:var(--mono);font-size:10px;letter-spacing:.06em;text-transform:capitalize;color:var(--lc,var(--ink-3));font-weight:400}
 .layer-head em{font-style:normal;font-family:var(--mono);font-size:10px;color:var(--ink-3);opacity:.8}
 .nodes{display:flex;flex-wrap:wrap;gap:12px}
 /* A zone's cards in one layer. Present only on a document that has zones, and


### PR DESCRIPTION
## Summary by Sourcery

Improve the architecture editor with safer editing workflows, richer canvas navigation, consistent diagram exports, and stronger cross-surface rendering support.

New Features:
- Add comprehensive editor undo and redo support with keyboard shortcuts, actionable change notices, and safer component, dependency, layer, scope, and zone editing.
- Improve canvas navigation and editing with nested drag-and-drop zones, zoom and pan controls, fit-to-view, scope filtering, compact cards, keyboard selection, hover highlighting, and component search.
- Introduce styled dialogs for naming and confirmation flows, collapsible palette sections, inline layer renaming, and clearer editing feedback.
- Add HTML, data-file, JSON, draw.io, SVG, and browser-generated PNG exports, including embedded draw.io source in PNG files.
- Add configurable layer tints consistently across the editor, viewer, printable document, SVG, and draw.io exports.

Bug Fixes:
- Correct drag-and-drop collision handling so the most specific target receives drops and no-op drops do not create undo steps.
- Prevent duplicate dependency drags from removing existing links and make dependency lines selectable and removable.
- Keep zone membership and component placement consistent when moving cards across layers, bands, and zone targets.
- Replace fragile browser prompts and alerts with styled dialogs or inline error and notice feedback.

Enhancements:
- Cap and rebalance zone band widths while preserving readable layouts, and support sibling zone reordering.
- Unify diagram layout and rendering behavior across editor, viewer, printable documents, SVG, and draw.io exports.
- Improve accessibility and keyboard interaction for cards, dialogs, controls, dependency lines, and navigation.

Documentation:
- Document layer tint behavior, zone band budgeting, zone ordering, and canvas navigation guidance.

Tests:
- Add extensive unit coverage for undo/redo behavior, drag-and-drop resolution, navigation and search, viewport controls, layer tinting, zone layout, and PNG, SVG, and draw.io exports.

Chores:
- Centralize diagram layout, export generation, PNG metadata handling, viewport logic, navigation, drag-and-drop resolution, and undo-stack behavior in reusable library modules.