### PR TITLE
feat: add environments support to architecture and components

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ UPDATE_SNAPSHOTS=1 npm test     # accept a deliberate change
 
 ## The identity
 
-*Atelier* — an engineer's tool drawn like a workshop instrument, on the TonuxCorp colours.
+*Atelier* — an engineer's tool drawn like a workshop instrument, on the tonux colours.
 Marine ink on white paper, one teal for action, monospace for everything the machine knows.
 Square corners, hairline rules, no gradients, no shadows.
 
@@ -439,6 +439,27 @@ makes free text usable as a filter dimension anyway is one pass in the normalise
 spelling a document uses wins, and every later case-variant folds onto it, so a stray "openshift"
 cannot become a chip of its own. `src/lib/deployment.ts`.
 
+**And "where it runs" is not "which copy of it".** `deployedOn` names a platform; the
+**environments** name the stages the whole architecture runs in — dev, SA, production. They are
+declared once on the document, in the palette rail beside the layers and the scopes, and each
+component fills in the ones it lives in: an address, what version is running there, and a line of
+prose. A component list of its own `{ name, url }` pairs would have been less plumbing and useless
+within a week — one component says "SA", the next says "recette", the third says "staging", and
+*give me every SA address* has no answer a table can hold.
+
+Declaration order is the pipeline, which is why the rail moves them up and down rather than
+sorting them: every table reads its columns from that order, and one that sorted itself would put
+dev after SA and production first. The addresses surface on the component's inspector, in its
+detail sheet, in the viewer's drawer, as a column per environment in the viewer's overview table
+and in a generated **Environments** chapter under *DevOps & delivery* — the page someone prints
+before a release — and as one Edit Data field per environment in the draw.io export. Every one of
+those asks first: an environment nobody filled in draws no column.
+
+The version field is the one to be careful with, and the module says so where it is defined: it is
+the only thing here that goes stale on its own, nothing derives from it, and a document claiming
+"prod = 2.4.1" three releases later is worse than one that never said. It earns its place during a
+migration and should be cleared after. `src/lib/environments.ts`.
+
 **Two things to know before you reach for zones.**
 
 *Zones turn clustering off.* Two groupings cannot own one row: clustering splits a layer into
@@ -513,6 +534,7 @@ src/lib/links.ts       the protocol convention, and the plate's geometry
 src/lib/lifecycle.ts   the three transition marks and what each commits you to
 src/lib/marks.ts       the closed security set, its icons and its key
 src/lib/deployment.ts  where a component runs, and why it is not a zone
+src/lib/environments.ts dev / SA / prod, and one address per component per stage
 src/lib/zones.ts       the zone tree, the run ordering, and the measured union
 ```
 
@@ -765,8 +787,6 @@ automatically.
 - Multi-select and bulk move on the canvas
 
 ## Community
-
-[tonuxcorp.com](https://tonuxcorp.com)
 
 ## License
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -272,4 +272,4 @@ keep a file — a VPS, a Raspberry Pi, a container with a volume.
 
 ---
 
-MIT. [tonuxcorp.com](https://tonuxcorp.com)
+MIT. 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -897,6 +897,21 @@ input.input[type="color"] { height: 34px; padding: 3px; cursor: pointer; }
 .cgroup { margin-bottom: 28px; }
 .frow { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; align-items: start; }
 
+/* ------------------------------------------------ a component's environments
+   One block per declared environment, in the document's pipeline order. The
+   name is a monospace rail down the left rather than a label above each field:
+   three environments times three fields is nine labels nobody reads, and the
+   placeholders already say what each box is for. */
+.envrows { display: flex; flex-direction: column; gap: 10px; margin-bottom: 12px; }
+.envrow { border-left: 2px solid var(--line-2); padding-left: 9px; }
+.envname {
+  display: block; font-family: var(--mono); font-size: 10px; text-transform: uppercase;
+  letter-spacing: .1em; color: var(--ink-3); margin-bottom: 5px;
+}
+/* The address takes the room; the version is a short string and asking it to
+   share equally would leave "v2.4.1" in a box built for a domain name. */
+.envline { display: grid; grid-template-columns: 2.2fr 1fr; gap: 6px; margin-bottom: 6px; }
+
 /* One-click skeletons — today the design-document chapters, and whatever else
    turns out to be worth generating rather than typing sixteen times. */
 .preset-row {

--- a/src/app/projects/[id]/document/PaperDocument.tsx
+++ b/src/app/projects/[id]/document/PaperDocument.tsx
@@ -29,12 +29,15 @@ import {
 } from '@/lib/lifecycle';
 import { describeMarks, MARK_ICON, MARK_LABELS, marksInUse } from '@/lib/marks';
 import {
+  componentsWithEnvs, envEntry, environmentName, environmentsInUse, envsOf
+} from '@/lib/environments';
+import {
   bandPlan, describeZone, inflatedUnion, layerRuns, layerSlots, withDescendants, zoneDepth,
   zonePad, zoneSvg, zonesInUse, type BandPlan, type Box
 } from '@/lib/zones';
 import { anchor, buildOutline, supportLayerId, toc, type DocBody, type DocPart } from '@/lib/document/plan';
 import type {
-  Architecture, CardItem, CardsSection, CompareSection, Component, Flow,
+  Architecture, CardItem, CardsSection, CompareSection, Component, Environment, Flow,
   ProjectWithData, Section, TableSection, TextSection, TimelineSection
 } from '@/lib/types';
 import './document.css';
@@ -173,6 +176,7 @@ function Body({ body, doc, T }: { body: DocBody; doc: Architecture; T: Strings }
     case 'intro': return <Intro doc={doc} />;
     case 'diagram': return <Figure doc={doc} T={T} />;
     case 'inventory': return <Inventory doc={doc} T={T} />;
+    case 'environments': return <Environments doc={doc} T={T} />;
     case 'section': return <SectionBody doc={doc} section={body.section} />;
     case 'flow': return <FlowBody doc={doc} flow={body.flow} T={T} />;
     case 'stack': return <Stack doc={doc} T={T} />;
@@ -481,6 +485,62 @@ function LayerCards({ doc, layer, colour, plan }: {
   );
 }
 
+/* ------------------------------------------------------------- environments */
+
+/* One row per component, one column per environment in use. The page someone
+ * prints before a release, so it is addresses first: the version rides under
+ * the URL in a lighter ink rather than taking a column of its own, because a
+ * table three columns wide per environment does not fit A4 past two of them. */
+function Environments({ doc, T }: { doc: Architecture; T: Strings }) {
+  const envs = environmentsInUse(doc.components, doc.environments);
+  const rows = componentsWithEnvs(doc.components);
+  if (!envs.length || !rows.length) return null;
+
+  return (
+    <>
+      <table className="paper-table paper-envs">
+        <thead>
+          <tr>
+            <th style={{ width: '22%' }}>{T.component}</th>
+            {envs.map(env => <th key={env.id}>{env.name}</th>)}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map(c => (
+            <tr key={c.id}>
+              <td>{c.name}</td>
+              {envs.map(env => {
+                const e = envEntry(c, env.id);
+                if (!e) return <td key={env.id}>{T.dash}</td>;
+                return (
+                  <td key={env.id}>
+                    {e.url && <span className="paper-envurl">{e.url}</span>}
+                    {(e.version || e.note) && (
+                      <span className="paper-envmeta">
+                        {[e.version, e.note].filter(Boolean).join(' · ')}
+                      </span>
+                    )}
+                    {!e.url && !e.version && !e.note && T.dash}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {/* The environment's own note, once under the table rather than repeated
+          in every cell of its column. */}
+      {envs.some(e => e.note) && (
+        <ul className="paper-envnotes">
+          {envs.filter(e => e.note).map(e => (
+            <li key={e.id}><b>{e.name}</b> — {e.note}</li>
+          ))}
+        </ul>
+      )}
+    </>
+  );
+}
+
 /* ---------------------------------------------------------------- inventory */
 
 function Inventory({ doc, T }: { doc: Architecture; T: Strings }) {
@@ -533,7 +593,10 @@ function Inventory({ doc, T }: { doc: Architecture; T: Strings }) {
         <>
           <h3 className="paper-h3">{T.detail}</h3>
           <div className="paper-sheets">
-            {detailed.map(c => <Sheet key={c.id} comp={c} named={named} colour={colour} T={T} lang={lang} />)}
+            {detailed.map(c => (
+              <Sheet key={c.id} comp={c} named={named} colour={colour}
+                environments={doc.environments} T={T} lang={lang} />
+            ))}
           </div>
         </>
       )}
@@ -541,8 +604,9 @@ function Inventory({ doc, T }: { doc: Architecture; T: Strings }) {
   );
 }
 
-function Sheet({ comp, named, colour, T, lang }: {
+function Sheet({ comp, named, colour, environments, T, lang }: {
   comp: Component; named: (id: string) => string; colour: (id: string) => string;
+  environments: Environment[];
   T: Strings; lang: 'en' | 'fr';
 }) {
   return (
@@ -561,6 +625,24 @@ function Sheet({ comp, named, colour, T, lang }: {
           in a meeting, and "OpenShift" on its own line is not a sentence. */}
       {comp.deployedOn && (
         <p className="paper-deployed">{T.deployedOn} — {comp.deployedOn}</p>
+      )}
+      {/* The same rows the environments table holds, repeated here because a
+          detail sheet is read on its own — someone who turned to this page for
+          one component should not have to find the table again. */}
+      {!!envsOf(comp, environments).length && (
+        <dl className="paper-envlist">
+          {envsOf(comp, environments).map(e => (
+            <div key={e.env}>
+              <dt>{environmentName(environments, e.env)}</dt>
+              <dd>
+                {e.url && <span className="paper-envurl">{e.url}</span>}
+                {(e.version || e.note) && (
+                  <span className="paper-envmeta">{[e.version, e.note].filter(Boolean).join(' · ')}</span>
+                )}
+              </dd>
+            </div>
+          ))}
+        </dl>
       )}
       {comp.role && <p {...rich(comp.role)} />}
       {!!comp.features?.length && (

--- a/src/app/projects/[id]/document/document.css
+++ b/src/app/projects/[id]/document/document.css
@@ -386,6 +386,32 @@ a.paper-btn { border-bottom-width: 1px; }
 /* On a detail sheet the marks are words, not glyphs: this is the page someone
    quotes in a meeting, and "lock" is not a sentence. */
 .paper-marks { font-family: var(--mono); font-size: 9.5px; color: var(--ink-2); margin: 0 0 6px; }
+/* Where it runs, on the detail sheet. Monospace like the marks above it: both
+   are things the machine knows rather than prose about the component (rule 3). */
+.paper-deployed { font-family: var(--mono); font-size: 9.5px; color: var(--ink-2); margin: 0 0 6px; }
+
+/* --------------------------------------------------------- environments
+   A component's addresses, repeated on its own detail sheet — someone who
+   turned to this page for one component should not have to find the table in
+   part 4 again. The environment name is a monospace rail, the address is the
+   line that matters, and the version and note ride under it a step lighter. */
+.paper-envlist { margin: 0 0 8px; }
+.paper-envlist > div { display: grid; grid-template-columns: 62px 1fr; gap: 8px; margin-bottom: 3px; }
+.paper-envlist dt {
+  font-family: var(--mono); font-size: 9px; text-transform: uppercase; letter-spacing: .1em;
+  color: var(--ink-3); padding-top: 1px;
+}
+.paper-envlist dd { margin: 0; }
+.paper-envurl { display: block; font-family: var(--mono); font-size: 9.5px; color: var(--ink-2); }
+/* The version is the one field here that goes stale on its own, so it is set
+   quieter than the address rather than louder — see `src/lib/environments.ts`. */
+.paper-envmeta { display: block; font-family: var(--mono); font-size: 8.5px; color: var(--ink-3); }
+/* The table in part 4: addresses first, and the per-environment note collected
+   once underneath rather than repeated down a column. */
+.paper-envs td { font-size: 10px; }
+.paper-envnotes {
+  margin: 8px 0 0; padding-left: 16px; font-size: 10px; color: var(--ink-3); line-height: 1.5;
+}
 .paper-tick {
   margin-left: 6px; font-family: var(--mono); font-size: 7.5px; letter-spacing: .1em;
   padding: 2px 4px; background: var(--ink); color: var(--panel); vertical-align: middle;

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -29,6 +29,7 @@ import {
   edgeOpacity, edgeStroke, STATE_LABELS, STATE_SIGN, stateTick, statesInUse
 } from '@/lib/lifecycle';
 import { deploymentsInUse } from '@/lib/deployment';
+import { canMoveEnvironment, moveEnvironment } from '@/lib/environments';
 import { MARK_BLURBS, MARK_ICON, MARK_LABELS, marksInUse } from '@/lib/marks';
 import {
   bandPlan, canMoveZone, describeZone, inflatedUnion, layerRuns, layerSlots, moveZone,
@@ -831,7 +832,7 @@ function Finder({ doc, onClose, onPick }: {
  * One component for the three because the frame is the same and only the middle
  * differs; splitting it would mean three copies of the focus, the Escape and the
  * Enter handling, which is the part that has to be identical. */
-type RailKind = 'layer' | 'scope' | 'zone';
+type RailKind = 'layer' | 'scope' | 'zone' | 'environment';
 
 const RAIL_COPY: Record<RailKind, { title: string; blurb: string; placeholder: string }> = {
   layer: {
@@ -848,6 +849,11 @@ const RAIL_COPY: Record<RailKind, { title: string; blurb: string; placeholder: s
     title: 'New zone',
     blurb: 'A boundary that crosses the layers — a platform, a network zone, the perimeter of a migration.',
     placeholder: 'OpenShift'
+  },
+  environment: {
+    title: 'New environment',
+    blurb: 'One of the places this whole architecture runs — dev, SA, production. Declare them in pipeline order; every table reads its columns from it.',
+    placeholder: 'Production'
   }
 };
 
@@ -2033,6 +2039,14 @@ function Palette({ doc, patch, catalog, notify, onOpenPlacement }: {
         });
         return d;
       });
+    } else if (creating === 'environment') {
+      /* Appended, never sorted: the order is the pipeline, and the author is the
+       * only one who knows whether SA comes before or after the integration
+       * platform they call "int". */
+      patch(d => {
+        d.environments.push({ id: slugify(v.name, d.environments.map(e => e.id)), name: v.name });
+        return d;
+      });
     }
     setCreating(null);
   };
@@ -2121,6 +2135,9 @@ function Palette({ doc, patch, catalog, notify, onOpenPlacement }: {
 
       <ZonesPanel doc={doc} patch={patch} notify={notify} fold={fold}
         onAdd={() => setCreating('zone')} />
+
+      <EnvironmentsPanel doc={doc} patch={patch} notify={notify} fold={fold}
+        onAdd={() => setCreating('environment')} />
 
       <EdgeLegend doc={doc} fold={fold} />
 
@@ -2252,6 +2269,88 @@ function ZonesPanel({ doc, patch, notify, fold, onAdd }: {
       ))}
       </RailSection>
     </>
+  );
+}
+
+/* The environments this architecture runs in — dev, SA, production.
+ *
+ * In the rail with the layers, the scopes and the zones because it is structure
+ * rather than content, and like the zones nothing prunes it: an environment
+ * nobody has filled in yet is one someone is about to.
+ *
+ * Up and down rather than left and right, and this is the whole reason the
+ * buttons are here: the order is the *pipeline*, and every table downstream
+ * reads its columns from it. A list that sorted itself would put dev after SA
+ * and production first. */
+function EnvironmentsPanel({ doc, patch, notify, fold, onAdd }: {
+  doc: Architecture; patch: (fn: (d: Architecture) => Architecture) => void;
+  notify: Notify;
+  fold: RailFolds;
+  onAdd: () => void;
+}) {
+  const counts = new Map(doc.environments.map(e => [
+    e.id,
+    doc.components.filter(c => (c.envs || []).some(x => x.env === e.id)).length
+  ]));
+
+  return (
+    <RailSection id="environments" label={`Environments (${doc.environments.length})`}
+      open={fold.isOpen('environments')} onToggle={() => fold.toggle('environments')}
+      action={
+        <button className="iconbtn" style={{ width: 20, height: 20 }} title="Add environment"
+          onClick={onAdd}><Icon name="plus" size={13} /></button>
+      }>
+      {!doc.environments.length && (
+        <div className="hint" style={{ padding: '2px 6px' }}>
+          Where this runs — dev, SA, production. Declare them here in pipeline
+          order, then give each component its address in the inspector.
+        </div>
+      )}
+      {doc.environments.map(e => (
+        <div className="grouprow" key={e.id}>
+          <input value={e.name}
+            onChange={ev => patch(d => {
+              const x = d.environments.find(y => y.id === e.id);
+              if (x) x.name = ev.target.value;
+              return d;
+            })} />
+          <span className="count">{counts.get(e.id) ?? 0}</span>
+          <button className="iconbtn" style={{ width: 22, height: 22 }} title="Move earlier"
+            disabled={!canMoveEnvironment(doc.environments, e.id, -1)}
+            onClick={() => patch(d => {
+              d.environments = moveEnvironment(d.environments, e.id, -1); return d;
+            })}>
+            <Icon name="chevron" size={12} style={{ transform: 'rotate(-90deg)' }} />
+          </button>
+          <button className="iconbtn" style={{ width: 22, height: 22 }} title="Move later"
+            disabled={!canMoveEnvironment(doc.environments, e.id, 1)}
+            onClick={() => patch(d => {
+              d.environments = moveEnvironment(d.environments, e.id, 1); return d;
+            })}>
+            <Icon name="chevron" size={12} style={{ transform: 'rotate(90deg)' }} />
+          </button>
+          <button className="iconbtn" style={{ width: 22, height: 22 }} title="Delete environment"
+            onClick={() => {
+              const held = counts.get(e.id) ?? 0;
+              notify(held
+                ? `Environment "${e.name}" deleted — ${held} component(s) lost their address for it`
+                : `Environment "${e.name}" deleted`);
+              patch(d => {
+                d.environments = d.environments.filter(y => y.id !== e.id);
+                /* The entries go with it. Leaving them would make the document
+                 * carry addresses for a place it no longer says exists, and the
+                 * normaliser would drop them on the next read anyway — silently,
+                 * which is the worse of the two. */
+                d.components.forEach(c => {
+                  const kept = (c.envs || []).filter(x => x.env !== e.id);
+                  c.envs = kept.length ? kept : undefined;
+                });
+                return d;
+              });
+            }}><Icon name="trash" size={13} /></button>
+        </div>
+      ))}
+    </RailSection>
   );
 }
 

--- a/src/components/Inspector.tsx
+++ b/src/components/Inspector.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import { Icon, ICONS } from './Icon';
 import { ICON_KEYS, deleteComponent, slugify } from '@/lib/defaults';
 import { deploymentsInUse } from '@/lib/deployment';
+import { envEntry, setEnvField } from '@/lib/environments';
 import { displayLayerLabel } from '@/lib/layers';
 import {
   LINK_KINDS, LINK_KIND_BLURBS, LINK_KIND_LABELS, linkIsEmpty, linkOf, shortLink
@@ -143,6 +144,40 @@ function ComponentForm({ doc, patch, comp, notify, openLink, onClose, onSelect }
           {places.map(p => <option key={p} value={p} />)}
         </datalist>
       </label>
+
+      {/* One row per environment the document declares, in pipeline order.
+          Rows for every environment rather than an "add" button: the list is
+          already closed and already short, and a form you have to open before
+          you can type into it is a form people stop filling in.
+
+          `setEnvField` creates the entry on the first keystroke and drops it
+          when the last field empties, so nothing here has to know whether an
+          entry exists — and the document never carries a row that says only
+          "this component has an environment". */}
+      {!!doc.environments.length && (
+        <>
+          <div className="sect-label" style={{ marginTop: 14 }}>Environments</div>
+          <div className="envrows">
+            {doc.environments.map(env => {
+              const entry = envEntry(comp, env.id);
+              const field = (key: 'url' | 'version' | 'note', placeholder: string) => (
+                <input className="input" placeholder={placeholder} value={entry?.[key] || ''}
+                  onChange={e => set(c => setEnvField(c, env.id, key, e.target.value))} />
+              );
+              return (
+                <div className="envrow" key={env.id}>
+                  <span className="envname" title={env.note || undefined}>{env.name}</span>
+                  {/* Address and version on one line, the note under it: the
+                      first two are what a reader scans down a column, and the
+                      third is the one that is usually empty. */}
+                  <div className="envline">{field('url', 'api-dev.example.com')}{field('version', 'v2.4.1')}</div>
+                  {field('note', 'anonymised data, VPN only…')}
+                </div>
+              );
+            })}
+          </div>
+        </>
+      )}
 
       {/* A closed set, so the diagram can carry a key and a reader can search
           for "no authentication". Multi-select: SSO in front of a service that

--- a/src/components/howto/HowItWorks.tsx
+++ b/src/components/howto/HowItWorks.tsx
@@ -410,9 +410,6 @@ function Cta() {
       </p>
       <div className="h-ctabtns">
         <a className="btn primary" href="/"><Icon name="grid" size={15} />Open the workspace</a>
-        <a className="btn" href="https://tonuxcorp.com" target="_blank" rel="noreferrer">
-          <Icon name="external" size={15} />tonuxcorp.com
-        </a>
       </div>
     </section>
   );

--- a/src/lib/defaults.ts
+++ b/src/lib/defaults.ts
@@ -1,10 +1,13 @@
 import { canonicalise, cleanDeployedOn } from './deployment';
+import { envEntryIsEmpty } from './environments';
 import { isLifecycle } from './lifecycle';
 import { normalizeMarks } from './marks';
 import { isZoneKind } from './zones';
 import { LINK_KINDS, PROTOCOL_LABEL_MODES, linkIsEmpty } from './links';
 import { displayLayerLabel } from './layers';
-import type { Architecture, Flow, Group, Link, Section, SectionType, Ui, Zone } from './types';
+import type {
+  Architecture, EnvEntry, Environment, Flow, Group, Link, Section, SectionType, Ui, Zone
+} from './types';
 
 /* The Atelier scope palette: five cool hues, `oklch(0.62 0.11 h)` for
  * h = 200, 250, 290, 340, 150, lifted to L .72 / C .12 on a marine ground.
@@ -166,6 +169,7 @@ export function blankArchitecture(name = 'New architecture'): Architecture {
     groups: [],
     layers: [],
     zones: [],
+    environments: [],
     components: [],
     technologies: [],
     flows: [],
@@ -215,6 +219,7 @@ export function normalizeArchitecture(input: Partial<Architecture>): Architectur
       };
     }),
     zones: normalizeZones(input.zones),
+    environments: normalizeEnvironments(input.environments),
     components: input.components || [],
     technologies: input.technologies || [],
     flows: input.flows || [],
@@ -224,6 +229,7 @@ export function normalizeArchitecture(input: Partial<Architecture>): Architectur
   const groupIds = new Set(doc.groups.map(g => g.id));
   const layerIds = new Set(doc.layers.map(l => l.id));
   const zoneIds = new Set(doc.zones.map(z => z.id));
+  const envIds = new Set(doc.environments.map(e => e.id));
   const compIds = new Set(doc.components.map(c => c.id));
 
   doc.components = doc.components.map(c => {
@@ -237,6 +243,7 @@ export function normalizeArchitecture(input: Partial<Architecture>): Architectur
        * only honest one for a pointer to a zone that is gone. */
       zone: c.zone && zoneIds.has(c.zone) ? c.zone : undefined,
       deployedOn: cleanDeployedOn(c.deployedOn),
+      envs: normalizeEnvs(c.envs, envIds),
       tech: c.tech || [],
       features: c.features || [],
       notes: c.notes || [],
@@ -276,6 +283,49 @@ export function normalizeArchitecture(input: Partial<Architecture>): Architectur
  *  also stops on a repeat, so this is the second of two guards, not the only
  *  one — but it is the one that makes the stored document sane, which is what
  *  the editor and the export both read back. */
+/** The declared environments: an id and a name, once each, in the order they
+ *  were written. That order is the pipeline — dev, SA, prod — and every table
+ *  downstream reads its columns from it, so it is never re-sorted here. */
+function normalizeEnvironments(input: Environment[] | undefined): Environment[] {
+  if (!Array.isArray(input)) return [];
+  const seen = new Set<string>();
+  const out: Environment[] = [];
+  for (const e of input) {
+    if (!e || typeof e.id !== 'string' || !e.id || seen.has(e.id)) continue;
+    seen.add(e.id);
+    const clean: Environment = { id: e.id, name: e.name?.trim() || e.id };
+    if (e.note?.trim()) clean.note = e.note.trim();
+    out.push(clean);
+  }
+  return out;
+}
+
+/** A component's entries: one per declared environment, none blank, no pointers
+ *  at an environment that is gone.
+ *
+ *  An entry naming an environment and saying nothing else *is* dropped here even
+ *  though it would be a real answer, because there is no way to have authored it
+ *  on purpose — the editor writes an entry only when a field is filled in, and
+ *  clears it when the last one empties. Returns `undefined` when nothing
+ *  survives, so a document that names no environment exports exactly as it did
+ *  before the field existed. */
+function normalizeEnvs(input: EnvEntry[] | undefined, envIds: Set<string>): EnvEntry[] | undefined {
+  if (!Array.isArray(input)) return undefined;
+  const seen = new Set<string>();
+  const out: EnvEntry[] = [];
+  for (const e of input) {
+    if (!e || typeof e.env !== 'string' || !envIds.has(e.env) || seen.has(e.env)) continue;
+    const clean: EnvEntry = { env: e.env };
+    if (e.url?.trim()) clean.url = e.url.trim();
+    if (e.version?.trim()) clean.version = e.version.trim();
+    if (e.note?.trim()) clean.note = e.note.trim();
+    if (envEntryIsEmpty(clean)) continue;
+    seen.add(e.env);
+    out.push(clean);
+  }
+  return out.length ? out : undefined;
+}
+
 function normalizeZones(input: Zone[] | undefined): Zone[] {
   if (!Array.isArray(input)) return [];
   const seen = new Set<string>();

--- a/src/lib/diff.ts
+++ b/src/lib/diff.ts
@@ -83,6 +83,7 @@ const COMPONENT_FIELDS: { key: keyof Component; label: string; list?: true }[] =
   { key: 'badge', label: 'badge' },
   { key: 'url', label: 'URL' },
   { key: 'deployedOn', label: 'deployment' },
+  { key: 'envs', label: 'environments', list: true },
   { key: 'role', label: 'role' },
   { key: 'marks', label: 'security marks', list: true },
   { key: 'tech', label: 'technologies', list: true },

--- a/src/lib/document/document.test.ts
+++ b/src/lib/document/document.test.ts
@@ -81,6 +81,30 @@ test('the diagram leads part 2 and the inventory is its first chapter', () => {
   assert.equal(part.entries[0].number, '2.1');
 });
 
+test('the environments table is a chapter of DevOps & delivery, and only when filled', () => {
+  const base = () => {
+    const doc = blankArchitecture('Test');
+    doc.layers = [{ id: 'services', name: 'Services' }];
+    doc.groups = [{ id: 'core', name: 'Core' }];
+    doc.environments = [{ id: 'dev', name: 'Dev' }, { id: 'prod', name: 'Production' }];
+    doc.components = [{
+      id: 'api', name: 'API', group: 'core', layer: 'services', tech: [], features: [], notes: [], deps: []
+    }];
+    return doc;
+  };
+
+  /* Declared but never filled in: the chapter would be a grid of dashes. */
+  const empty = buildOutline(normalizeArchitecture(base()));
+  assert.ok(!empty.parts.some(p => p.entries.some(e => e.body.kind === 'environments')));
+
+  const filled = base();
+  filled.components[0].envs = [{ env: 'prod', url: 'api.acme.test' }];
+  const outline = buildOutline(normalizeArchitecture(filled));
+  const part = outline.parts.find(p => p.entries.some(e => e.body.kind === 'environments'));
+  assert.ok(part, 'the environments table should earn a chapter');
+  assert.equal(part!.title, 'DevOps & delivery');
+});
+
 test('flows and the stack table close the appendices', () => {
   const doc = instantiate(getTemplate('multi-service')!, {
     target: 'aws', lang: 'fr', projectName: 'Demo', today: '2026-08-14'

--- a/src/lib/document/plan.ts
+++ b/src/lib/document/plan.ts
@@ -10,6 +10,7 @@
  * recovery one becomes 2.4 — no holes, no renumbering by hand.
  */
 
+import { componentsWithEnvs, environmentsInUse } from '../environments';
 import type { Architecture, Flow, Section } from '../types';
 import { t, type L10n, type Lang } from '../templates/types';
 
@@ -21,6 +22,8 @@ export type DocBody =
   | { kind: 'diagram' }
   /** Every component, by layer — the reference table for the diagram. */
   | { kind: 'inventory' }
+  /** Where to reach each component in each environment. */
+  | { kind: 'environments' }
   | { kind: 'section'; section: Section }
   | { kind: 'flow'; flow: Flow }
   | { kind: 'stack' };
@@ -68,6 +71,11 @@ const GENERATED: Record<string, L10n> = {
   inventorySub: {
     en: 'Every component on the diagram above, with the scope that owns it and the technologies it runs on.',
     fr: 'Chaque composant du schéma ci-dessus, avec le périmètre qui le porte et les technologies employées.'
+  },
+  environments: { en: 'Environments', fr: 'Environnements' },
+  environmentsSub: {
+    en: 'Where to reach each component in each environment, and what is running there.',
+    fr: 'Où joindre chaque composant dans chaque environnement, et ce qui y tourne.'
   },
   flow: { en: 'Flow — {name}', fr: 'Parcours — {name}' },
   stack: { en: 'Technology stack', fr: 'Pile technologique' },
@@ -143,6 +151,18 @@ export function buildOutline(doc: Architecture): Outline {
       entries.push({
         number: '', title: s(GENERATED.inventory), subtitle: s(GENERATED.inventorySub),
         body: { kind: 'inventory' }
+      });
+    }
+
+    /* Part 4 is DevOps & delivery, and a table of addresses per environment is
+     * the page someone prints before a release. Drawn only when a component
+     * actually fills one in: a document that declared three environments and
+     * filled none would otherwise print a grid of dashes. */
+    if (part === '4' && componentsWithEnvs(doc.components).length
+      && environmentsInUse(doc.components, doc.environments).length) {
+      entries.push({
+        number: '', title: s(GENERATED.environments), subtitle: s(GENERATED.environmentsSub),
+        body: { kind: 'environments' }
       });
     }
 

--- a/src/lib/environments.test.ts
+++ b/src/lib/environments.test.ts
@@ -1,0 +1,143 @@
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+
+import { blankArchitecture, normalizeArchitecture } from './defaults';
+import {
+  canMoveEnvironment, componentsWithEnvs, envEntry, envEntryIsEmpty, environmentName,
+  environmentsInUse, envsOf, moveEnvironment, setEnvField
+} from './environments';
+import type { Architecture, Component, Environment } from './types';
+
+const comp = (id: string, over: Partial<Component> = {}): Component => ({
+  id, name: id, group: 'core', layer: 'services', icon: 'box',
+  tech: [], features: [], notes: [], deps: [], ...over
+});
+
+/* Declared out of alphabetical order on purpose: the order is the pipeline, and
+ * every test below leans on the fact that nothing re-sorts it. */
+const ENVS: Environment[] = [
+  { id: 'dev', name: 'Dev' },
+  { id: 'sa', name: 'SA', note: 'anonymised data' },
+  { id: 'prod', name: 'Production' }
+];
+
+const build = (environments: Environment[], components: Component[]): Architecture =>
+  normalizeArchitecture({ ...blankArchitecture('Test'), environments, components });
+
+/* ------------------------------------------------------------- the entries */
+
+test('an entry that says nothing is empty, and one that says anything is not', () => {
+  assert.equal(envEntryIsEmpty({ env: 'dev' }), true);
+  assert.equal(envEntryIsEmpty({ env: 'dev', url: '   ' }), true);
+  assert.equal(envEntryIsEmpty({ env: 'dev', url: 'x.test' }), false);
+  assert.equal(envEntryIsEmpty({ env: 'dev', version: '2.4.1' }), false);
+  assert.equal(envEntryIsEmpty({ env: 'dev', note: 'VPN only' }), false);
+});
+
+test('a component reads its entries in the document order, not the typing order', () => {
+  /* Every table downstream reads across a row, so the columns have to line up
+   * without each one sorting for itself. */
+  const c = comp('api', {
+    envs: [{ env: 'prod', url: 'a' }, { env: 'dev', url: 'b' }, { env: 'sa', url: 'c' }]
+  });
+  assert.deepEqual(envsOf(c, ENVS).map(e => e.env), ['dev', 'sa', 'prod']);
+});
+
+test('an entry pointing at an environment the document does not declare is not read', () => {
+  const c = comp('api', { envs: [{ env: 'dev', url: 'a' }, { env: 'gone', url: 'b' }] });
+  assert.deepEqual(envsOf(c, ENVS).map(e => e.env), ['dev']);
+});
+
+/* --------------------------------------------------------------- the editor */
+
+test('typing into a blank environment creates the entry, one field at a time', () => {
+  const c = comp('api');
+  setEnvField(c, 'sa', 'url', 'api-sa.test');
+  assert.deepEqual(c.envs, [{ env: 'sa', url: 'api-sa.test' }]);
+  setEnvField(c, 'sa', 'version', '2.5.0-rc2');
+  assert.deepEqual(c.envs, [{ env: 'sa', url: 'api-sa.test', version: '2.5.0-rc2' }]);
+});
+
+test('clearing the last field drops the entry rather than leaving a husk', () => {
+  /* Otherwise the document would carry a row saying only "this component has an
+   * environment", which no table can render and no author meant to write. */
+  const c = comp('api', { envs: [{ env: 'sa', url: 'api-sa.test' }] });
+  setEnvField(c, 'sa', 'url', '');
+  assert.equal(c.envs, undefined);
+});
+
+test('clearing one field of several leaves the entry standing', () => {
+  const c = comp('api', { envs: [{ env: 'sa', url: 'api-sa.test', version: '2.4.1' }] });
+  setEnvField(c, 'sa', 'url', '');
+  assert.deepEqual(c.envs, [{ env: 'sa', version: '2.4.1' }]);
+});
+
+/* ----------------------------------------------------------------- in use */
+
+test('a table only draws the environments something was written into', () => {
+  /* A document that declared five and filled two should print two columns, not
+   * five and three columns of dashes — the restraint `marksInUse` keeps. */
+  const items = [
+    comp('a', { envs: [{ env: 'prod', url: 'x' }] }),
+    comp('b', { envs: [{ env: 'dev', url: 'y' }] }),
+    comp('c')
+  ];
+  assert.deepEqual(environmentsInUse(items, ENVS).map(e => e.id), ['dev', 'prod']);
+  assert.deepEqual(componentsWithEnvs(items).map(c => c.id), ['a', 'b']);
+});
+
+test('an environment nobody filled in draws no column even when declared', () => {
+  assert.deepEqual(environmentsInUse([comp('a')], ENVS), []);
+});
+
+test('an environment is named in the reader’s words, and falls back to its id', () => {
+  assert.equal(environmentName(ENVS, 'sa'), 'SA');
+  assert.equal(environmentName(ENVS, 'nope'), 'nope');
+});
+
+/* ---------------------------------------------------------------- the order */
+
+test('an environment moves one place, and refuses by identity at either end', () => {
+  assert.deepEqual(moveEnvironment(ENVS, 'prod', -1).map(e => e.id), ['dev', 'prod', 'sa']);
+  assert.equal(moveEnvironment(ENVS, 'dev', -1), ENVS);
+  assert.equal(moveEnvironment(ENVS, 'prod', 1), ENVS);
+  assert.equal(moveEnvironment(ENVS, 'nope', 1), ENVS);
+  assert.equal(canMoveEnvironment(ENVS, 'dev', -1), false);
+  assert.equal(canMoveEnvironment(ENVS, 'dev', 1), true);
+});
+
+/* ------------------------------------------------- through the normaliser */
+
+test('the declared order survives the normaliser — it is the pipeline, not a set', () => {
+  const doc = build(ENVS, []);
+  assert.deepEqual(doc.environments.map(e => e.id), ['dev', 'sa', 'prod']);
+  assert.equal(doc.environments[1].note, 'anonymised data');
+});
+
+test('an address for an environment that is gone is dropped on read', () => {
+  const doc = build([{ id: 'dev', name: 'Dev' }], [
+    comp('api', { envs: [{ env: 'dev', url: 'a.test' }, { env: 'gone', url: 'b.test' }] })
+  ]);
+  assert.deepEqual(doc.components[0].envs, [{ env: 'dev', url: 'a.test' }]);
+});
+
+test('blank entries and duplicates do not survive, and nothing left means nothing stored', () => {
+  const doc = build(ENVS, [
+    comp('a', { envs: [{ env: 'dev', url: '  ' }] }),
+    comp('b', { envs: [{ env: 'sa', url: 'x' }, { env: 'sa', url: 'y' }] })
+  ]);
+  assert.equal(doc.components[0].envs, undefined);
+  assert.deepEqual(doc.components[1].envs, [{ env: 'sa', url: 'x' }]);
+});
+
+test('a document that names no environment reads exactly as it did before the field', () => {
+  const doc = build([], [comp('a'), comp('b')]);
+  assert.deepEqual(doc.environments, []);
+  assert.ok(doc.components.every(c => c.envs === undefined));
+});
+
+test('envEntry finds one entry without caring about order', () => {
+  const c = comp('api', { envs: [{ env: 'prod', url: 'p' }, { env: 'dev', url: 'd' }] });
+  assert.equal(envEntry(c, 'dev')?.url, 'd');
+  assert.equal(envEntry(c, 'sa'), undefined);
+});

--- a/src/lib/environments.ts
+++ b/src/lib/environments.ts
@@ -1,0 +1,119 @@
+/* The environments an architecture runs in — dev, SA, production.
+ *
+ * ------------------------------------------------------- why a document list
+ *
+ * A component could carry its own list of `{ name, url }` pairs and that would
+ * be less plumbing. It would also be useless within a week: one component says
+ * "SA", the next says "recette", the third says "staging", and the question
+ * anyone actually asks — *give me every SA address* — has no answer that a table
+ * can hold. So the environments are declared once on the document, the way
+ * scopes and layers are, and a component fills in the ones it lives in.
+ *
+ * Declaration order is reading order, because it is the pipeline. A table with
+ * production in the middle is one nobody trusts, and sorting alphabetically
+ * would put dev after SA and prod first — which is exactly backwards.
+ *
+ * ------------------------------------------------------ what an entry holds
+ *
+ * An address, a version, and a line of prose. The version is the field to be
+ * careful with: it is the only thing here that goes stale on its own, and a
+ * document that says "prod = 2.4.1" three releases later is worse than one that
+ * never said. So nothing derives from it, nothing warns on it, and it is left
+ * blank by default — it earns its place during a migration, when "SA is two
+ * versions ahead" is the whole conversation, and should be cleared after.
+ *
+ * ------------------------------------------------------- not `deployedOn`
+ *
+ * `deployedOn` says which platform a component runs on — OpenShift, AWS. This
+ * says which *instance* of the architecture you are looking at. They are
+ * orthogonal: the same component on OpenShift has a dev, an SA and a prod URL.
+ */
+
+import type { Component, EnvEntry, Environment } from './types';
+
+/** An entry that names an environment and says nothing else is still an answer
+ *  — "it is deployed there" — so only a fully blank one is dropped. */
+export const envEntryIsEmpty = (e: EnvEntry): boolean =>
+  !e.url?.trim() && !e.version?.trim() && !e.note?.trim();
+
+export const environmentOf = (
+  environments: Environment[], id: string | undefined
+): Environment | undefined => (id ? environments.find(e => e.id === id) : undefined);
+
+export const environmentName = (environments: Environment[], id: string): string =>
+  environmentOf(environments, id)?.name || id;
+
+/** A component's entries, in the document's environment order rather than
+ *  whatever order they were typed in. Every table downstream reads across a row,
+ *  so the columns have to line up without each one re-sorting. */
+export function envsOf(component: Component, environments: Environment[]): EnvEntry[] {
+  const at = new Map(environments.map((e, i) => [e.id, i]));
+  return [...(component.envs || [])]
+    .filter(e => at.has(e.env))
+    .sort((a, b) => at.get(a.env)! - at.get(b.env)!);
+}
+
+/** Read one field out of one environment, for a table cell. */
+export const envEntry = (component: Component, env: string): EnvEntry | undefined =>
+  (component.envs || []).find(e => e.env === env);
+
+/** The environments at least one component fills in.
+ *
+ *  Every table asks before drawing a column: a document that declared five
+ *  environments and filled two should print two columns, not five and three
+ *  columns of dashes. The same restraint `marksInUse` keeps for its legend. */
+export function environmentsInUse(
+  components: Component[], environments: Environment[]
+): Environment[] {
+  const held = new Set<string>();
+  components.forEach(c => (c.envs || []).forEach(e => {
+    if (!envEntryIsEmpty(e)) held.add(e.env);
+  }));
+  return environments.filter(e => held.has(e.id));
+}
+
+/** Components with something to say about at least one environment, in document
+ *  order — the rows of the environments table. */
+export const componentsWithEnvs = (components: Component[]): Component[] =>
+  components.filter(c => (c.envs || []).some(e => !envEntryIsEmpty(e)));
+
+/** Set or clear one field of one entry, creating or dropping the entry as
+ *  needed. The editor calls nothing else: a form that has to decide whether an
+ *  entry already exists before it can type into it is a form with a bug in it. */
+export function setEnvField(
+  component: Component, env: string, field: 'url' | 'version' | 'note', value: string
+): void {
+  const out = [...(component.envs || [])];
+  const at = out.findIndex(e => e.env === env);
+  const next: EnvEntry = at >= 0 ? { ...out[at] } : { env };
+  const clean = value.trim();
+  if (clean) next[field] = value; else delete next[field];
+
+  if (envEntryIsEmpty(next)) {
+    if (at >= 0) out.splice(at, 1);
+  } else if (at >= 0) out[at] = next;
+  else out.push(next);
+
+  component.envs = out.length ? out : undefined;
+}
+
+/** Move an environment one place earlier or later. Order is the pipeline, so
+ *  this is the only thing that decides what a table's columns read like.
+ *
+ *  Returns the list unchanged when there is nowhere to go, so the caller can
+ *  compare identity to decide whether the button is live — the contract
+ *  `moveZone` keeps. */
+export function moveEnvironment(
+  environments: Environment[], id: string, delta: -1 | 1
+): Environment[] {
+  const at = environments.findIndex(e => e.id === id);
+  const to = at + delta;
+  if (at < 0 || to < 0 || to >= environments.length) return environments;
+  const out = [...environments];
+  [out[at], out[to]] = [out[to], out[at]];
+  return out;
+}
+
+export const canMoveEnvironment = (
+  environments: Environment[], id: string, delta: -1 | 1
+): boolean => moveEnvironment(environments, id, delta) !== environments;

--- a/src/lib/export/drawio.test.ts
+++ b/src/lib/export/drawio.test.ts
@@ -116,6 +116,23 @@ test('what the picture cannot carry travels as cell data', () => {
 /* The bug this file exists to prevent. A cell's value is HTML inside an XML
  * attribute, so authored text is escaped twice; getting either half wrong is
  * either a card reading "R&amp;D" or a file draw.io will not open at all. */
+test('a component\u2019s addresses ride as one data field per environment', () => {
+  /* Named by the environment rather than by its id: draw.io shows these to
+   * someone who never opened this document, and "sa" is not a word. */
+  const xml = buildDrawioXml(doc({
+    environments: [{ id: 'dev', name: 'Dev' }, { id: 'prod', name: 'Production' }],
+    components: [{
+      id: 'api', name: 'API', group: 'core', layer: 'services',
+      envs: [
+        { env: 'prod', url: 'api.acme.test', version: '2.4.1' },
+        { env: 'dev', url: 'api-dev.acme.test' }
+      ]
+    }]
+  }));
+  assert.ok(xml.includes('Dev="api-dev.acme.test"'));
+  assert.ok(xml.includes('Production="api.acme.test \u00b7 2.4.1"'));
+});
+
 test('an ampersand in a name survives both parsers', () => {
   const xml = buildDrawioXml(doc({
     groups: [{ id: 'core', name: 'R&D <ops>', color: '#0099A0' }],

--- a/src/lib/export/drawio.ts
+++ b/src/lib/export/drawio.ts
@@ -41,6 +41,7 @@
  */
 
 import type { Architecture } from '../types';
+import { environmentName, envsOf } from '../environments';
 import { MARK_LABELS } from '../marks';
 import { STATE_LABELS } from '../lifecycle';
 import {
@@ -196,6 +197,15 @@ function nodeCell(n: NodePlacement, sheet: Sheet): string {
   if (c.marks?.length) data.security = c.marks.map(m => MARK_LABELS[m][sheet.lang]).join(', ');
   if (c.state) data.state = STATE_LABELS[c.state][sheet.lang];
   if (c.url) data.link = c.url;
+  /* One entry per environment, keyed by the environment's own name so the field
+   * reads as "SA" rather than as an id nobody outside this document knows. The
+   * version and the note ride in the same value: draw.io's Edit Data is a flat
+   * string map, and three keys per environment would bury the addresses. */
+  envsOf(c, sheet.environments).forEach(e => {
+    const env = environmentName(sheet.environments, e.env);
+    const value = [e.url, e.version, e.note].filter(Boolean).join(' · ');
+    if (value) data[env] = value;
+  });
 
   return object(`n-${slug(c.id)}`, lines.join("<br>"), data,
     `<mxCell style="${attr(style)}" vertex="1" parent="1">`

--- a/src/lib/export/layout.ts
+++ b/src/lib/export/layout.ts
@@ -31,7 +31,7 @@
  * calque, and the two agree everywhere it matters — the ink itself is the same.
  */
 
-import type { Architecture, Component, Layer, Zone } from '../types';
+import type { Architecture, Component, Environment, Layer, Zone } from '../types';
 import {
   BAND_GUTTER, SHELF_GAP, bandPlan, describeZone, inflatedUnion, layerRuns, layerSlots, withDescendants,
   zoneDepth, zoneIsPhysical, zonePad, zonesInUse, type Band, type Box, type ZoneRun
@@ -174,6 +174,10 @@ export interface Sheet {
   /** The scopes in use, in declaration order. Colour carries scope on every
    *  surface, so an export that drops the key drops half the drawing. */
   legend: { id: string; label: string; color: string }[];
+  /** The declared environments, in pipeline order. Nothing is drawn from them —
+   *  they ride along so the draw.io export can name a component's addresses in
+   *  the reader's words rather than by id. */
+  environments: Environment[];
   /** Where the legend row's baseline sits. */
   legendY: number;
   noteY: number;
@@ -338,6 +342,7 @@ export function layoutSheet(doc: Architecture): Sheet {
     layers: placedLayers,
     zones: placedZones,
     nodes, edges, legend, legendY, noteY,
+    environments: doc.environments || [],
     lang
   };
 }

--- a/src/lib/templates/index.ts
+++ b/src/lib/templates/index.ts
@@ -245,6 +245,10 @@ export function instantiate(tpl: Template, opts: InstantiateOptions): Architectu
      * carry — "OpenShift" is an answer to a question the template deliberately
      * leaves to whoever instantiates it. */
     zones: [],
+    /* Nor an environment, and for the same reason: how many stages sit between
+     * a laptop and production is a fact about an organisation, not about an
+     * architecture. */
+    environments: [],
     components,
     technologies,
     flows,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -122,6 +122,31 @@ export interface Link {
   state?: import('./lifecycle').Lifecycle;
 }
 
+/** One of the places the whole architecture runs — dev, SA, production.
+ *
+ *  Declaration order is reading order, because it is the pipeline: a table with
+ *  production in the middle is a table nobody trusts. `src/lib/environments.ts`
+ *  is where the rest of the reasoning lives. */
+export interface Environment {
+  id: string;
+  name: string;
+  /** One line about the environment itself — "anonymised data", "VPN only". */
+  note?: string;
+}
+
+/** One component, in one environment. Every field but `env` is optional: naming
+ *  an environment for a component and leaving it blank is a real answer — it
+ *  says the thing is deployed there and its address is not written down. */
+export interface EnvEntry {
+  /** The environment's id. Unknown ids are dropped on read. */
+  env: string;
+  url?: string;
+  /** What is running there — "2.4.1", "2.5.0-rc2". */
+  version?: string;
+  /** Anything the two above cannot say — "read-only replica", "nightly reset". */
+  note?: string;
+}
+
 export interface Component {
   id: string;
   name: string;
@@ -147,6 +172,11 @@ export interface Component {
    *  sheet. See `src/lib/deployment.ts`. */
   deployedOn?: string;
   url?: string;
+  /** Where to reach it in each environment, plus what is running there. One
+   *  entry per environment at most, in the document's own environment order —
+   *  see `src/lib/environments.ts`. `url` above stays the one address the
+   *  component is known by, whatever the pipeline is doing. */
+  envs?: EnvEntry[];
   role?: string;
   /** Stable Lego catalog identity; `role` remains human-readable prose. */
   brick?: import('./lego/bricks').BrickId;
@@ -231,6 +261,9 @@ export interface Architecture {
   /** Optional throughout: a document with no zones draws exactly as it did
    *  before the field existed, and normalisation leaves the key at `[]`. */
   zones: Zone[];
+  /** Optional throughout, like `zones`: a document that names none reads and
+   *  exports exactly as it did before the field existed. */
+  environments: Environment[];
   components: Component[];
   technologies: Technology[];
   flows: Flow[];

--- a/src/lib/undo.ts
+++ b/src/lib/undo.ts
@@ -46,6 +46,11 @@ export function docShape(doc: Architecture): string {
   return [
     doc.layers.map(l => l.id).join(','),
     doc.groups.map(g => g.id).join(','),
+    /* Order is the pipeline here, so reordering the environments is a move and
+     * a move is undoable on its own — the same reason the layers are in this
+     * list. What a component's address *is* stays out: that arrives one
+     * keystroke at a time and should merge. */
+    (doc.environments ?? []).map(e => e.id).join(','),
     (doc.zones ?? []).map(z => `${z.id}>${z.parent ?? ''}${z.stack ? '^' : ''}`).join(','),
     doc.components
       .map(c => `${c.id}@${c.layer}/${c.group}/${c.zone ?? ''}:${(c.deps ?? []).join('+')}`)

--- a/viewer/engine.js
+++ b/viewer/engine.js
@@ -61,7 +61,8 @@ const LABELS = {
     role: 'Role', technologies: 'Technologies', responsibilities: 'Responsibilities',
     notes: 'Notes', dependsOn: 'Depends on', usedBy: 'Used by', outgoing: 'outgoing',
     incoming: 'incoming', components: 'Components', distribution: 'Component distribution',
-    endpoints: 'Endpoints', prev: 'Previous', next: 'Next', play: 'Play', pause: 'Pause',
+    endpoints: 'Endpoints', environments: 'Environments',
+    prev: 'Previous', next: 'Next', play: 'Play', pause: 'Pause',
     involved: 'Components involved', allCategories: 'All categories', results: 'result',
     resultsPlural: 'results', empty: 'Nothing matches this filter.',
     infraNote: 'The bottom layer is not wired with arrows: it supports every component above it.',
@@ -83,6 +84,7 @@ const LABELS = {
     notes: 'Chantiers identifiés', dependsOn: 'Dépend de', usedBy: 'Sollicité par',
     outgoing: 'sortant', incoming: 'entrant', components: 'Composants',
     distribution: 'Répartition des composants', endpoints: 'Domaines & endpoints',
+    environments: 'Environnements',
     prev: 'Précédent', next: 'Suivant', play: 'Lecture', pause: 'Pause',
     involved: 'Composants mobilisés', allCategories: 'Toutes les catégories',
     results: 'résultat', resultsPlural: 'résultats', empty: 'Aucun résultat pour ce filtre.',
@@ -180,6 +182,9 @@ function normalize(raw) {
    * its rectangle holds, so a cycle is a hang rather than a wrong drawing —
    * `zoneAncestry` guards it a second time, but a document that arrives here
    * broken should not stay broken in the tree the rest of the file reads. */
+  d.environments = d.environments || [];
+  const eById = Object.fromEntries(d.environments.map(e => [e.id, e]));
+
   const zById = Object.fromEntries(d.zones.map(z => [z.id, z]));
   d.zones.forEach(z => {
     if (!z.parent) return;
@@ -208,6 +213,16 @@ function normalize(raw) {
     c.features = c.features || [];
     c.notes = c.notes || [];
     c.deps = c.deps || [];
+    /* An address for an environment the document no longer declares is a claim
+     * about a place that does not exist here — dropped, and said out loud. */
+    if (c.envs) {
+      c.envs = c.envs.filter(e => {
+        if (eById[e.env]) return true;
+        warn(`component "${c.id}": unknown environment "${e.env}" — its address is dropped`);
+        return false;
+      });
+      if (!c.envs.length) c.envs = undefined;
+    }
     /* Unzoned is a real answer, so a pointer at a zone that is not in the list
      * falls back to it rather than to the first zone — unlike a group or a
      * layer, where the component has to be *somewhere*. */
@@ -467,6 +482,17 @@ const SHELF_MAX = 3;
 
 /** Zones in tree order, so a subtree's bands are contiguous and a parent's box
  *  is one range of columns rather than two with a hole in the middle. */
+/* The environments a component actually fills in, and the components that fill
+ * one — both asked before a table draws a column or a row. MIRROR of
+ * `environmentsInUse` / `componentsWithEnvs` in src/lib/environments.ts. */
+const envEntryIsEmpty = e => !(e.url || '').trim() && !(e.version || '').trim() && !(e.note || '').trim();
+const ENV_ROWS = DATA.components.filter(c => (c.envs || []).some(e => !envEntryIsEmpty(e)));
+const ENVS_IN_USE = (() => {
+  const held = new Set();
+  DATA.components.forEach(c => (c.envs || []).forEach(e => { if (!envEntryIsEmpty(e)) held.add(e.env); }));
+  return DATA.environments.filter(e => held.has(e.id));
+})();
+
 const ZONES_TREE_ORDER = (() => {
   const key = id => zoneAncestry(id)
     .map(x => String(ZONE_ORDER[x] ?? 999).padStart(3, '0')).join('.');
@@ -795,13 +821,34 @@ function renderOverview() {
       ${m.principle ? `<div class="divider"></div><div class="note">${rich(m.principle)}</div>` : ''}
     </div>`;
 
-  const endpointsCard = endpoints.length ? `
+  /* The environments in use become columns, so "give me every SA address" is one
+   * glance rather than a hunt. Only the ones a component actually fills in: a
+   * document that declared five and filled two would otherwise print three
+   * columns of dashes. */
+  const envCols = ENVS_IN_USE;
+  const endpointsCard = (endpoints.length || ENV_ROWS.length) ? `
     <div class="card pad">
-      <div class="sec-title"><h2>${T.endpoints}</h2></div>
+      <div class="sec-title"><h2>${envCols.length ? T.environments : T.endpoints}</h2></div>
       <div style="height:12px"></div>
+      ${envCols.length ? `
+      <div class="tablewrap">
+      <table class="cmp envtable">
+        <thead><tr><th></th>${envCols.map(e =>
+          `<th${e.note ? ` title="${esc(e.note)}"` : ''}>${esc(e.name)}</th>`).join('')}</tr></thead>
+        <tbody>${ENV_ROWS.map(c =>
+          `<tr><td style="color:var(--ink-2)"><span class="dot" style="background:${gvar(c.group)}"></span>${esc(c.name)}</td>${
+            envCols.map(env => {
+              const e = (c.envs || []).find(x => x.env === env.id);
+              if (!e) return `<td class="mono envcell">—</td>`;
+              const meta = [e.version, e.note].filter(Boolean).join(' · ');
+              return `<td class="mono envcell">${e.url ? `<span>${esc(e.url)}</span>` : ''}${
+                meta ? `<em>${esc(meta)}</em>` : ''}${!e.url && !meta ? '—' : ''}</td>`;
+            }).join('')}</tr>`).join('')}</tbody>
+      </table>
+      </div>` : `
       <table class="cmp"><tbody>${endpoints.map(c =>
         `<tr><td class="mono" style="font-size:12px"><span class="dot" style="background:${gvar(c.group)}"></span>${esc(c.url)}</td>
-             <td style="color:var(--ink-2)">${esc(c.name)}</td></tr>`).join('')}</tbody></table>
+             <td style="color:var(--ink-2)">${esc(c.name)}</td></tr>`).join('')}</tbody></table>`}
     </div>` : '';
 
   const groupCards = DATA.groups.map(g => {
@@ -1670,6 +1717,14 @@ function openDrawer(id) {
   $('#db').innerHTML = `
     ${c.role ? `<h4>${T.role}</h4><p>${rich(c.role)}</p>` : ''}
     ${c.deployedOn ? `<h4>${T.deployedOn}</h4><p>${esc(c.deployedOn)}</p>` : ''}
+    ${(c.envs || []).length ? `<h4>${T.environments}</h4><dl class="envlist">${
+      DATA.environments.filter(env => (c.envs || []).some(x => x.env === env.id)).map(env => {
+        const e = c.envs.find(x => x.env === env.id);
+        const meta = [e.version, e.note].filter(Boolean).join(' · ');
+        return `<div><dt>${esc(env.name)}</dt><dd>${
+          e.url ? `<a href="${esc(/^https?:/.test(e.url) ? e.url : 'https://' + e.url)}" target="_blank" rel="noopener">${esc(e.url)}</a>` : ''
+        }${meta ? `<em>${esc(meta)}</em>` : ''}</dd></div>`;
+      }).join('')}</dl>` : ''}
     ${c.tech.length ? `<h4>${T.technologies}</h4><div class="taglist">${c.tech.map(t => `<span class="tag k">${esc(t)}</span>`).join('')}</div>` : ''}
     ${c.features.length ? `<h4>${T.responsibilities}</h4><ul>${c.features.map(f => `<li>${rich(f)}</li>`).join('')}</ul>` : ''}
     ${c.notes.length ? `<h4>${T.notes}</h4><ul>${c.notes.map(f => `<li>${rich(f)}</li>`).join('')}</ul>` : ''}

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -458,6 +458,31 @@ table.cmp tbody tr:hover{background:var(--panel-2)}
 table.cmp td:first-child{font-weight:600;color:var(--ink)}
 .dot{width:9px;height:9px;border-radius:0;display:inline-block;margin-right:8px;vertical-align:-1px}
 
+/* ------------------------------------------------------------ environments
+   One column per environment the document fills in. Wide by nature — three
+   environments of domain names past a component name — so it scrolls inside its
+   own box rather than pushing the card off the page. */
+.tablewrap{overflow-x:auto}
+.envtable{min-width:520px}
+.envtable td:first-child{white-space:nowrap}
+.envcell{font-size:11.5px;color:var(--ink-2)}
+/* An address is one token — broken across two lines at its hyphens it stops
+   being copyable and starts being a puzzle. So it never wraps, and the table
+   scrolls inside `.tablewrap` instead. */
+.envcell span{display:block;white-space:nowrap}
+/* The version and the note are the fields that go stale on their own, so they
+   are set quieter than the address rather than louder. */
+.envcell em{display:block;font-style:normal;font-size:10px;color:var(--ink-3);margin-top:2px}
+
+/* The same rows in the detail drawer, where there is one component and room to
+   put the environment's name beside its address rather than above it. */
+.envlist>div{display:grid;grid-template-columns:70px 1fr;gap:10px;margin-bottom:6px}
+.envlist dt{font-family:var(--mono);font-size:10px;text-transform:uppercase;letter-spacing:.1em;color:var(--ink-3);padding-top:2px}
+.envlist dd{margin:0;font-family:var(--mono);font-size:11.5px}
+.envlist dd a{color:var(--brand);text-decoration:none}
+.envlist dd a:hover{text-decoration:underline}
+.envlist dd em{display:block;font-style:normal;font-size:10px;color:var(--ink-3);margin-top:2px}
+
 /* ---------- Flows ---------- */
 .flowpick{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:16px}
 .flowgrid{display:grid;grid-template-columns:1fr 330px;gap:18px;align-items:start}


### PR DESCRIPTION
- Introduced Environment and EnvEntry types to manage environments for components.
- Updated Architecture to include environments, ensuring documents can declare and utilize multiple environments.
- Implemented normalization functions for environments and their entries, ensuring data integrity and proper handling of empty or duplicate entries.
- Enhanced component functionality to support environment-specific addresses, including URL, version, and notes.
- Updated UI components to display environment information in tables and detail views.
- Added tests to validate the new environment features and ensure existing functionality remains intact.
- Modified export functions to include environment data in draw.io exports.

## Summary by Sourcery

Add ordered environment support throughout architecture modeling, component details, generated documentation, and exports.

New Features:
- Add document-level environments with ordered declarations and component-specific URLs, versions, and notes.
- Expose environment information across the editor, generated documents, viewer details and overview tables, and draw.io exports.

Enhancements:
- Normalize environment declarations and component entries by removing invalid, duplicate, empty, and undeclared data while preserving pipeline order.
- Support environment reordering, editing, cleanup, and undo tracking in the architecture workspace.

Documentation:
- Document the distinction between deployment platforms and architecture environments and describe how environment data is presented across outputs.

Tests:
- Add coverage for environment normalization, ordering, editing, filtering, generated document sections, and draw.io export fields.

Chores:
- Remove outdated TonuxCorp branding links and update the project wording.