### PR TITLE
refactor: transform history panel into versions panel with enhanced f…

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,19 @@ scheduled. It is the *stroke* and not the colour because colour already means sc
 survives a monochrome print. All of it is optional, and an edge nobody has annotated draws
 exactly as it always did.
 
-**History** — every save older than five minutes since the last one writes a snapshot. The
-**History** button lists them and, for each, what changed *since* it: components added and
-removed, renames, moves between layers, edges gained and lost, sections and chapters. Name a
-version (“sent to the client”) and it is kept for good — the 30-snapshot cap only ever prunes
-automatic ones. Restoring writes a *Before restore* snapshot first, so a restore is itself
+**Versions** — a diagram that is worth drawing is one that keeps changing, so the **Versions**
+button holds the series it went through. **Freeze** the document under a number and a title
+(“v1.2 — sent to the client”) and it is kept for good; the live document sits at the head of the
+list as **Current**, with how far it has drifted since the last one. A frozen version is a place
+you can go rather than a point to subtract from: **view** it in the Preview tab, **export** it to
+HTML, SVG, PNG or draw.io, and **print** it — each one carries its own number on its cover and in
+the viewer's subtitle, because freezing writes the number into the document itself.
+
+Any two versions can be **compared**, not just each one against now: what changed between the
+September board and the October one is a question you can ask. Under the series are the automatic
+**snapshots** — one every five minutes while you edit, capped at 30, plus the ones the app writes
+before a restore or an enrichment. They are still there and still restorable; naming one promotes
+it into the series. Restoring writes a *Before restore* snapshot first, so a restore is itself
 undoable.
 
 **Preview** — the preview tab is not a re-implementation. It renders, in an iframe, byte-for-byte
@@ -535,6 +543,7 @@ src/lib/lifecycle.ts   the three transition marks and what each commits you to
 src/lib/marks.ts       the closed security set, its icons and its key
 src/lib/deployment.ts  where a component runs, and why it is not a zone
 src/lib/environments.ts dev / SA / prod, and one address per component per stage
+src/lib/versions.ts    what makes a snapshot a version, and the next number
 src/lib/zones.ts       the zone tree, the run ordering, and the measured union
 ```
 
@@ -658,13 +667,28 @@ first import with `No such built-in module: node:sqlite`. CI runs the suite on 2
 on current, so that floor is a tested number rather than a remembered one.
 
 **Revisions.** Every save older than five minutes since the last snapshot writes one. The cap of
-30 per project applies to automatic snapshots only: a named checkpoint is never pruned, and the
+30 per project applies to automatic snapshots only: a named row is never pruned, and the
 *Before restore* snapshots a restore leaves behind keep their own ceiling of five. Snapshots are
 ordered `created_at DESC, rowid DESC` — `datetime('now')` has one-second granularity, so naming a
 checkpoint during an autosave otherwise leaves two rows in the same second with no defined order.
-The full surface is `GET/POST/PATCH/DELETE /api/projects/:id/revisions`, driven by the **History**
+The full surface is `GET/POST/PATCH/DELETE /api/projects/:id/revisions`, driven by the **Versions**
 button in the editor. What that panel shows is computed by `src/lib/diff.ts`, which turns two
 documents into sentences rather than a JSON diff.
+
+**A version stores no more than a snapshot does.** The schema is `CREATE TABLE IF NOT EXISTS`
+re-exec'd on every connection and there is no `ALTER TABLE` anywhere, so a column added to
+`revisions` would land on fresh databases and never on an installed one. It is not needed: a
+version's *title* is the row's `label`, which is what a label already was, and its *number* is the
+`meta.version` of the document inside the snapshot — read back in the same `JSON.parse` that
+already counted the components. Freezing therefore *edits the document* before snapshotting it,
+which is why an exported version prints its own number without anything downstream being told
+which revision it came from. The three kinds a row can be — a version, one of the app's own
+checkpoints, an automatic save — are derived from the label in `src/lib/versions.ts`; the machine
+labels live there too, so the prune SQL and the panel cannot drift apart on them.
+
+`?revisionId=` on the export route and `?revision=` on the document page are what make a stored
+version viewable, exportable and printable. Both fall back to the live document, so nothing about
+the normal path changed.
 
 ---
 

--- a/src/app/api/projects/[id]/export/route.ts
+++ b/src/app/api/projects/[id]/export/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getProject } from '@/lib/store';
+import { getProject, getRevisionData } from '@/lib/store';
 import { buildStandaloneHtml, buildDataFile, inlineFontCss, safeFilename } from '@/lib/exportHtml';
 import { buildDrawioXml } from '@/lib/export/drawio';
 import { buildDiagramSvg } from '@/lib/export/svg';
@@ -18,6 +18,17 @@ export async function GET(req: Request, { params }: Ctx) {
   const format = url.searchParams.get('format') || 'html';
   const inline = url.searchParams.get('inline') === '1';
 
+  /* A stored version, if one is asked for. Every format below reads `doc` rather
+   * than `project.data`, so exporting the September drawing is the same code
+   * path as exporting today's — including the PNG, which rasterises the SVG.
+   *
+   * `project.name` still names the file: it is the project's name, not the
+   * version's, and a download called "architecture.svg" is what the reader is
+   * looking for whichever version it holds. */
+  const revisionId = url.searchParams.get('revisionId');
+  const doc = revisionId ? getRevisionData(id, revisionId) : project.data;
+  if (!doc) return NextResponse.json({ error: 'not found' }, { status: 404 });
+
   /* One shape for every format: a body, a type, and the name the browser should
    * save it under. `inline` drops the disposition — the preview iframe and the
    * PNG builder both read these over `fetch` and neither wants a download. */
@@ -30,16 +41,16 @@ export async function GET(req: Request, { params }: Ctx) {
     });
 
   if (format === 'json') {
-    return send(JSON.stringify(project.data, null, 2), 'application/json',
+    return send(JSON.stringify(doc, null, 2), 'application/json',
       safeFilename(project.name, 'json'));
   }
 
   if (format === 'datafile') {
-    return send(buildDataFile(project.data), 'application/javascript', 'architecture.js');
+    return send(buildDataFile(doc), 'application/javascript', 'architecture.js');
   }
 
   if (format === 'drawio') {
-    return send(buildDrawioXml(project.data), 'application/xml',
+    return send(buildDrawioXml(doc), 'application/xml',
       safeFilename(project.name, 'drawio'));
   }
 
@@ -47,9 +58,9 @@ export async function GET(req: Request, { params }: Ctx) {
     /* The faces travel with the drawing. Without them an SVG opened anywhere
      * else falls back to the reader's Helvetica, and the PNG built from it in an
      * `<img>` cannot request a font at all. */
-    return send(buildDiagramSvg(project.data, { fontCss: inlineFontCss() }), 'image/svg+xml',
+    return send(buildDiagramSvg(doc, { fontCss: inlineFontCss() }), 'image/svg+xml',
       safeFilename(project.name, 'svg'));
   }
 
-  return send(buildStandaloneHtml(project.data), 'text/html', safeFilename(project.name, 'html'));
+  return send(buildStandaloneHtml(doc), 'text/html', safeFilename(project.name, 'html'));
 }

--- a/src/app/api/projects/[id]/revisions/route.ts
+++ b/src/app/api/projects/[id]/revisions/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import {
-  createRevision, deleteRevision, getRevisionData, labelRevision, listRevisions, restoreRevision
+  createRevision, deleteRevision, freezeVersion, getRevisionData, labelRevision, listRevisions,
+  restoreRevision
 } from '@/lib/store';
 
 export const runtime = 'nodejs';
@@ -21,18 +22,28 @@ export async function GET(req: Request, { params }: Ctx) {
   return data ? NextResponse.json({ id: revisionId, data }) : missing();
 }
 
-/** With `revisionId`, restore it. Without, snapshot the project as it stands —
- *  that is how a named checkpoint is created. */
+/** Three operations on one verb, told apart by what the body carries.
+ *
+ *  `revisionId`  restore it.
+ *  `version`     freeze the current document as a numbered version — this also
+ *                writes the number into the document, so it is a save as well.
+ *  neither       snapshot the project as it stands, unnamed or named. */
 export async function POST(req: Request, { params }: Ctx) {
   const { id } = await params;
-  const { revisionId, label } = await req.json().catch(() => ({}));
+  const { revisionId, version, label } = await req.json().catch(() => ({}));
+  const title = typeof label === 'string' ? label : undefined;
 
   if (revisionId) {
     const restored = restoreRevision(id, String(revisionId));
     return restored ? NextResponse.json(restored) : missing();
   }
 
-  const created = createRevision(id, typeof label === 'string' ? label : undefined);
+  if (typeof version === 'string' && version.trim()) {
+    const frozen = freezeVersion(id, version, title);
+    return frozen ? NextResponse.json(frozen) : missing();
+  }
+
+  const created = createRevision(id, title);
   return created ? NextResponse.json(created) : missing();
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -858,6 +858,21 @@ input.input[type="color"] { height: 34px; padding: 3px; cursor: pointer; }
 
 .previewframe { flex: 1; border: 0; width: 100%; background: var(--bg); }
 
+/* ------------------------------------------------- reading an older version
+   The frame below holds a complete, valid drawing with nothing on it saying how
+   old it is — so this bar is the only thing between reading September's diagram
+   and believing it is today's. Teal because it is the thing you can act on
+   (rule 2): the way back out is a button on it. */
+.previewwrap { flex: 1; display: flex; flex-direction: column; min-height: 0; }
+.viewingbar {
+  display: flex; align-items: center; gap: 10px; padding: 8px 12px;
+  background: color-mix(in srgb, var(--brand) 10%, var(--panel));
+  border-bottom: 1px solid color-mix(in srgb, var(--brand) 40%, transparent);
+  color: var(--ink); font-size: 12.5px;
+}
+.viewingbar .spacer { flex: 1; }
+.viewingbar .mono { font-family: var(--mono); font-size: 10.5px; color: var(--ink-3); }
+
 /* ------------------------------------------------------- content editors */
 /* The wide surface behind the Content tab: everything the canvas cannot say. */
 
@@ -1241,6 +1256,32 @@ input.input[type="color"] { height: 34px; padding: 3px; cursor: pointer; }
 .histrow .when { font-size: 12.5px; font-weight: 600; letter-spacing: -.01em; }
 .histrow b { font-size: 12px; font-weight: 600; color: var(--brand-ink); }
 .histrow .at { font-family: var(--mono); font-size: 10px; color: var(--ink-3); font-variant-numeric: tabular-nums; }
+
+/* ------------------------------------------------------------ the series
+   The live document at the head of the list. A row rather than a header,
+   because it is a point on the same line as the frozen ones — but not a button:
+   there is nothing to compare it against but itself and nothing to restore it
+   to. The teal dot is the only place in this panel that says "you are here". */
+.histrow.current { cursor: default; background: var(--panel-2); border-left-color: var(--brand); }
+.histrow.current:hover { background: var(--panel-2); }
+.histrow.current .when { display: flex; align-items: center; gap: 7px; color: var(--ink); }
+.histrow.current .dot {
+  width: 7px; height: 7px; border-radius: 0; background: var(--brand); flex: none;
+}
+/* The number carries the version, so it is set in the machine's own face
+   (rule 3) — a version number is not prose. */
+.vnum { font-family: var(--mono); font-size: 11.5px; letter-spacing: .02em; }
+
+/* The automatic snapshots, folded away. They are still the safety net and still
+   restorable; they are just no longer the first thing the panel is about. */
+.snapshead {
+  display: flex; align-items: center; gap: 7px; width: 100%; font: inherit;
+  font-family: var(--mono); font-size: 10px; text-transform: uppercase; letter-spacing: .12em;
+  color: var(--ink-3); background: transparent; border: 0;
+  border-bottom: 1px solid var(--line); padding: 10px 12px; cursor: pointer;
+}
+.snapshead:hover { color: var(--ink); background: var(--panel-3); }
+.snapshead .spacer { flex: 1; }
 
 .hist-pane { display: flex; flex-direction: column; min-width: 0; min-height: 0; }
 .hist-paneh {

--- a/src/app/projects/[id]/document/PaperDocument.tsx
+++ b/src/app/projects/[id]/document/PaperDocument.tsx
@@ -52,6 +52,7 @@ const STRINGS = {
     back: 'Back to the editor', print: 'Print · Save as PDF', contents: 'Contents',
     hint: 'Print to “Save as PDF”. Keep background graphics on, or the scope colours disappear.',
     version: 'Version', updated: 'Last edited', figure: 'Figure — component diagram',
+    aVersion: 'An earlier version', backToCurrent: 'Back to the current version',
     component: 'Component', scope: 'Scope', deployedOn: 'Deployed on',
     tech: 'Technologies', role: 'Role',
     dependsOn: 'Depends on', detail: 'Component detail', notes: 'Notes',
@@ -62,6 +63,7 @@ const STRINGS = {
     back: "Retour à l'éditeur", print: 'Imprimer · Enregistrer en PDF', contents: 'Sommaire',
     hint: 'Imprime vers « Enregistrer au format PDF ». Garde les graphiques d’arrière-plan activés, sinon les couleurs de périmètre disparaissent.',
     version: 'Version', updated: 'Dernière modification', figure: 'Figure — schéma des composants',
+    aVersion: 'Une version antérieure', backToCurrent: 'Revenir à la version courante',
     component: 'Composant', scope: 'Périmètre', deployedOn: 'Déployé sur',
     tech: 'Technologies', role: 'Rôle',
     dependsOn: 'Dépend de', detail: 'Détail des composants', notes: 'Notes',
@@ -75,7 +77,12 @@ type Strings = Record<keyof typeof STRINGS['en'], string>;
 /** Inline `<b>`, `<i>`, `<code>` render as markup — same contract as the viewer. */
 const rich = (html: string) => ({ dangerouslySetInnerHTML: { __html: html } });
 
-export default function PaperDocument({ project }: { project: ProjectWithData }) {
+export default function PaperDocument({ project, viewing = null }: {
+  project: ProjectWithData;
+  /** Set when `?revision=` asked for a stored version rather than the live
+   *  document. Nothing about the sheet changes — the banner above it does. */
+  viewing?: { label: string | null; version: string | null; createdAt: string } | null;
+}) {
   const doc = project.data;
   const outline = useMemo(() => buildOutline(doc), [doc]);
   const contents = useMemo(() => toc(outline), [outline]);
@@ -88,7 +95,21 @@ export default function PaperDocument({ project }: { project: ProjectWithData })
           <Icon name="back" size={15} />{T.back}
         </Link>
         <b className="paper-bar-name">{project.name}</b>
-        <span className="paper-bar-hint">{T.hint}</span>
+        {/* Which version this is, on the bar and not on the page: the sheet
+            below is the version's own document and already prints its number on
+            the cover. This is here so nobody prints an old drawing thinking it
+            is today's. Not printed — `.paper-bar` is `display:none` on paper. */}
+        {viewing
+          ? (
+            <span className="paper-bar-version">
+              <Icon name="clock" size={13} />
+              {[viewing.version, viewing.label].filter(Boolean).join(' — ') || T.aVersion}
+              <Link className="paper-btn sm" href={`/projects/${project.id}/document`}>
+                {T.backToCurrent}
+              </Link>
+            </span>
+          )
+          : <span className="paper-bar-hint">{T.hint}</span>}
         <button className="paper-btn primary" onClick={() => window.print()}>
           <Icon name="download" size={15} />{T.print}
         </button>

--- a/src/app/projects/[id]/document/document.css
+++ b/src/app/projects/[id]/document/document.css
@@ -72,6 +72,19 @@
 a.paper-btn { border-bottom-width: 1px; }
 .paper-btn:hover { background: var(--panel-3); border-color: var(--ink); }
 .paper-btn.primary { background: var(--brand); border-color: var(--brand); color: #FFFFFF; }
+.paper-btn.sm { height: 24px; padding: 0 9px; font-size: 11px; }
+
+/* Reading a stored version rather than the live document. Loud, because the one
+   mistake this page can cause is printing September's drawing believing it is
+   today's — and the sheet itself gives no clue, since it *is* a valid document
+   with its own cover. It never prints: `.paper-bar` is hidden on paper. */
+.paper-bar-version {
+  flex: 1; min-width: 0; display: flex; align-items: center; gap: 9px;
+  font-family: var(--mono); font-size: 10.5px; color: var(--ink);
+  background: color-mix(in srgb, var(--brand) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--brand) 35%, transparent);
+  padding: 4px 8px 4px 10px;
+}
 
 /* --------------------------------------------------------------------- page */
 

--- a/src/app/projects/[id]/document/page.tsx
+++ b/src/app/projects/[id]/document/page.tsx
@@ -1,12 +1,33 @@
 import { notFound } from 'next/navigation';
-import { getProject } from '@/lib/store';
+import { getProject, getRevisionData, listRevisions } from '@/lib/store';
 import PaperDocument from './PaperDocument';
 
 export const dynamic = 'force-dynamic';
 
-export default async function DocumentPage({ params }: { params: Promise<{ id: string }> }) {
+export default async function DocumentPage({ params, searchParams }: {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<{ revision?: string }>;
+}) {
   const { id } = await params;
+  const { revision } = await searchParams;
   const project = getProject(id);
   if (!project) notFound();
-  return <PaperDocument project={project} />;
+
+  /* `?revision=` prints a stored version instead of the live document — the way
+   * to get a PDF of what was sent in September. The project is swapped rather
+   * than the document alone so the cover's "last edited" reads the version's own
+   * date: printing an old drawing under today's date is the one thing this page
+   * must not do. */
+  if (!revision) return <PaperDocument project={project} />;
+
+  const data = getRevisionData(id, revision);
+  if (!data) notFound();
+  const row = listRevisions(id).find(r => r.id === revision);
+
+  return (
+    <PaperDocument
+      project={{ ...project, data, updatedAt: row?.createdAt ?? project.updatedAt }}
+      viewing={row ? { label: row.label, version: row.version, createdAt: row.createdAt } : null}
+    />
+  );
 }

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -49,7 +49,7 @@ import { isArrowKey, searchComponents, stepSelection } from '@/lib/navigate';
 import {
   bandDropId, DEPTH, dropChangesAnything, layerDropId, PALETTE_NEW, railZoneDropId, resolveDrop
 } from '@/lib/dnd';
-import type { Architecture, Component, ProjectWithData, Zone } from '@/lib/types';
+import type { Architecture, Component, ProjectWithData, RevisionRecord, Zone } from '@/lib/types';
 
 /* Which of the boxes under the pointer is meant.
  *
@@ -108,6 +108,10 @@ export default function Editor({ project }: { project: ProjectWithData }) {
   const [sheetZoom, setSheetZoom] = useState(1);
   const [hoverTarget, setHoverTarget] = useState<string | null>(null);
   const [history, setHistory] = useState(false);
+  /* A stored version being read in the Preview tab. Editor state rather than the
+   * panel's, because it outlives the panel — you close the versions list and
+   * keep reading the version. */
+  const [viewing, setViewing] = useState<RevisionRecord | null>(null);
   const [enrich, setEnrich] = useState(false);
   const [catalog, setCatalog] = useState<LegoCatalogSnapshot | null>(null);
   const [placementRequest, setPlacementRequest] = useState<{ callerId?: string; suggestion?: LegoDependencySuggestion } | null>(null);
@@ -531,15 +535,16 @@ export default function Editor({ project }: { project: ProjectWithData }) {
             )}
 
             <button className="btn" onClick={() => setHistory(true)}
-              title="Earlier versions, and what changed since each one">
-              <Icon name="clock" size={15} />History
+              title="The versions of this architecture, and what changed between them">
+              <Icon name="clock" size={15} />Versions
             </button>
 
             <ExportMenu projectId={project.id} name={project.name} notify={notify} />
           </div>
 
           {mode === 'preview' ? (
-            <PreviewPane projectId={project.id} version={doc} saveState={save} />
+            <PreviewPane projectId={project.id} version={doc} saveState={save}
+              viewing={viewing} onBackToCurrent={() => setViewing(null)} />
           ) : mode === 'content' ? (
             <ContentEditor doc={doc} patch={patch} catalog={catalog} notify={notify} />
           ) : (
@@ -638,6 +643,8 @@ export default function Editor({ project }: { project: ProjectWithData }) {
       {history && (
         <History projectId={project.id} doc={doc} dirty={save !== 'saved'}
           onClose={() => setHistory(false)}
+          onView={row => { setViewing(row); setMode('preview'); setHistory(false); }}
+          onFroze={data => { adopt(data); notify(`Frozen as ${data.meta.version}`); }}
           onRestore={data => {
             /* The restore already wrote the document server-side. Adopting it
              * here keeps the canvas, the inspector and the preview in step —
@@ -2452,24 +2459,58 @@ function EdgeLegend({ doc, fold }: { doc: Architecture; fold: RailFolds }) {
 
 /* ------------------------------------------------------------------ preview */
 
-function PreviewPane({ projectId, version, saveState }: {
+function PreviewPane({ projectId, version, saveState, viewing, onBackToCurrent }: {
   projectId: string; version: Architecture; saveState: SaveState;
+  /** A stored version being read instead of the live document, or null. */
+  viewing: RevisionRecord | null;
+  onBackToCurrent: () => void;
 }) {
   const [src, setSrc] = useState('');
-  const key = useMemo(() => JSON.stringify(version).length + ':' + saveState, [version, saveState]);
+  const key = useMemo(
+    () => (viewing ? `r:${viewing.id}` : JSON.stringify(version).length + ':' + saveState),
+    [version, saveState, viewing]
+  );
 
   useEffect(() => {
-    /* wait for the autosave to land, then render the real export */
-    if (saveState !== 'saved') return;
+    /* A stored version is already saved by definition, so it renders straight
+     * away; the live document waits for the autosave to land first, or the
+     * preview would be one keystroke behind the sheet it claims to be. */
+    if (!viewing && saveState !== 'saved') return;
     let alive = true;
-    fetch(`/api/projects/${projectId}/export?format=html&inline=1`)
+    const at = `/api/projects/${projectId}/export?format=html&inline=1`
+      + (viewing ? `&revisionId=${encodeURIComponent(viewing.id)}` : '');
+    fetch(at)
       .then(r => r.text())
       .then(html => { if (alive) setSrc(html); });
     return () => { alive = false; };
-  }, [projectId, key, saveState]);
+  }, [projectId, key, saveState, viewing]);
 
-  if (saveState !== 'saved' && !src) {
-    return <div className="empty">Saving your last change…</div>;
-  }
-  return <iframe className="previewframe" srcDoc={src} title="Preview" sandbox="allow-scripts allow-popups" />;
+  const frame = saveState !== 'saved' && !src && !viewing
+    ? <div className="empty">Saving your last change…</div>
+    : <iframe className="previewframe" srcDoc={src} title="Preview" sandbox="allow-scripts allow-popups" />;
+
+  if (!viewing) return frame;
+
+  /* The banner is the whole safety of this feature. What is in the frame is a
+     complete, valid drawing with no mark on it saying how old it is — so the
+     only thing standing between reading September's diagram and believing it is
+     today's is this line. */
+  return (
+    <div className="previewwrap">
+      <div className="viewingbar">
+        <Icon name="clock" size={14} />
+        <b>{[viewing.version, viewing.label].filter(Boolean).join(' — ') || 'An earlier version'}</b>
+        <span className="mono">{viewing.componentCount} comp.</span>
+        <span className="spacer" />
+        <a className="btn sm" href={`/api/projects/${projectId}/export?format=html&revisionId=${viewing.id}`}>
+          <Icon name="download" size={13} />Export this version
+        </a>
+        <a className="btn sm" href={`/projects/${projectId}/document?revision=${viewing.id}`} target="_blank" rel="noopener">
+          <Icon name="file" size={13} />Document
+        </a>
+        <button className="btn sm primary" onClick={onBackToCurrent}>Back to current</button>
+      </div>
+      {frame}
+    </div>
+  );
 }

--- a/src/components/History.tsx
+++ b/src/components/History.tsx
@@ -1,21 +1,30 @@
 'use client';
 
-/* The history panel.
+/* The versions panel.
  *
- * The snapshots were always being written; what was missing is the only
- * question anyone actually asks of them — "what did I have then that I do not
- * have now". So the list is the index and the diff is the page: selecting a
- * version never shows the version, it shows what changed since it.
+ * It was a history: a rolling log of snapshots where selecting a row never
+ * showed the row, it showed what changed since it. That answers the question you
+ * ask after a misdrop, and it stays answered — the snapshots are still here,
+ * still restorable, folded away at the bottom.
  *
- * The comparison is against the document held in the editor, not against what
- * is on disk. If there are unsaved edits in front of you, they are part of
- * "now", and pretending otherwise would make the panel lie for 700 ms.
+ * What it could not answer is the question you ask of a drawing that has been
+ * evolving for months: *show me the version we sent in September*. So the named
+ * rows are lifted out into a series with the live document at the top of it, and
+ * a version is now something you can open, export and print rather than only
+ * something to subtract from.
+ *
+ * Two things kept from the old panel because they were right. The comparison is
+ * against the document held in the editor, not what is on disk — unsaved edits
+ * are part of "now", and pretending otherwise would make the panel lie for
+ * 700 ms. And the list still does not carry the documents: thirty snapshots are
+ * thirty full architectures, fetched one at a time when a row is picked.
  */
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Icon } from './Icon';
 import { useAsk } from './Ask';
 import { byArea, diffArchitecture, summarise, type ChangeKind } from '@/lib/diff';
+import { nextVersionNumber, snapshotsOf, versionsOf } from '@/lib/versions';
 import type { Architecture, RevisionRecord } from '@/lib/types';
 
 /** SQLite stores `YYYY-MM-DD HH:MM:SS` in UTC, with no zone marker on it. */
@@ -42,16 +51,30 @@ const stamp = (iso: string) =>
  * someone who cannot separate the two colours. */
 const KIND_GLYPH: Record<ChangeKind, string> = { added: '+', removed: '−', changed: '~' };
 
-export default function History({ projectId, doc, dirty, onClose, onRestore }: {
+/** The live document, given the same shape as a row so the list can hold both
+ *  without every renderer asking which it has. `id` is the sentinel the two
+ *  fetches below check for. */
+const CURRENT = '@current';
+
+export default function History({ projectId, doc, dirty, onClose, onRestore, onView, onFroze }: {
   projectId: string;
   doc: Architecture;
   dirty: boolean;
   onClose: () => void;
   onRestore: (data: Architecture) => void;
+  /** Open a stored version in the Preview tab. */
+  onView: (row: RevisionRecord) => void;
+  /** A freeze wrote `meta.version` into the document — adopt it here so the
+   *  canvas and the undo stack see the edit that just happened server-side. */
+  onFroze: (data: Architecture) => void;
 }) {
   const [list, setList] = useState<RevisionRecord[] | null>(null);
   const [picked, setPicked] = useState<string | null>(null);
+  /** What `picked` is compared against. `CURRENT` is the live document. */
+  const [against, setAgainst] = useState<string>(CURRENT);
   const [past, setPast] = useState<Architecture | null>(null);
+  const [other, setOther] = useState<Architecture | null>(null);
+  const [openSnaps, setOpenSnaps] = useState(false);
   const [busy, setBusy] = useState(false);
   const ask = useAsk();
   const [error, setError] = useState('');
@@ -63,48 +86,108 @@ export default function History({ projectId, doc, dirty, onClose, onRestore }: {
     setPicked(p => select ?? (p && rows.some(r => r.id === p) ? p : rows[0]?.id ?? null));
   }, [projectId]);
 
-  useEffect(() => { load().catch(() => setError('Could not read the history.')); }, [load]);
+  useEffect(() => { load().catch(() => setError('Could not read the versions.')); }, [load]);
 
-  /* The chosen snapshot's document, fetched on demand — the list deliberately
-   * does not carry 30 full documents just to render 30 rows. */
+  const fetchDoc = useCallback((id: string): Promise<Architecture | null> =>
+    fetch(`/api/projects/${projectId}/revisions?revisionId=${encodeURIComponent(id)}`)
+      .then(r => r.json()).then(r => r.data ?? null), [projectId]);
+
   useEffect(() => {
     if (!picked) { setPast(null); return; }
     let alive = true;
     setPast(null);
-    fetch(`/api/projects/${projectId}/revisions?revisionId=${encodeURIComponent(picked)}`)
-      .then(r => r.json())
-      .then(r => { if (alive) setPast(r.data ?? null); })
+    fetchDoc(picked)
+      .then(d => { if (alive) setPast(d); })
       .catch(() => { if (alive) setError('Could not read that version.'); });
     return () => { alive = false; };
-  }, [projectId, picked]);
+  }, [fetchDoc, picked]);
 
-  const diff = useMemo(() => (past ? diffArchitecture(past, doc) : null), [past, doc]);
-  const groups = useMemo(() => (diff ? byArea(diff) : []), [diff]);
+  useEffect(() => {
+    if (against === CURRENT) { setOther(null); return; }
+    let alive = true;
+    setOther(null);
+    fetchDoc(against).then(d => { if (alive) setOther(d); }).catch(() => {});
+    return () => { alive = false; };
+  }, [fetchDoc, against]);
+
+  const versions = useMemo(() => versionsOf(list ?? []), [list]);
+  const snapshots = useMemo(() => snapshotsOf(list ?? []), [list]);
   const current = list?.find(r => r.id === picked) ?? null;
+  const compared = against === CURRENT ? null : list?.find(r => r.id === against) ?? null;
 
-  async function checkpoint() {
+  /* Always oldest → newest, whichever way round the two were picked. Reversing
+   * them silently swaps every `+` for a `−`, which is the kind of wrong a reader
+   * has no way to notice.
+   *
+   * Which is older comes from the list's own order, not from the timestamps.
+   * `created_at` is `datetime('now')` at one-second granularity — three versions
+   * frozen in the same minute can share a second, and comparing those strings
+   * ties and falls whichever way the ternary happens to point. The store already
+   * settled this with `created_at DESC, rowid DESC`, so the row further down the
+   * list is the older one, full stop. */
+  const [from, to, older] = useMemo(() => {
+    const right = against === CURRENT ? doc : other;
+    if (!past || !right || !current) return [null, null, null] as const;
+    if (!compared) return [past, right, current] as const;
+
+    const rows = list ?? [];
+    const pickedIsOlder = rows.indexOf(current) > rows.indexOf(compared);
+    return pickedIsOlder
+      ? [past, right, current] as const
+      : [right, past, compared] as const;
+  }, [past, other, against, doc, compared, current, list]);
+
+  const diff = useMemo(() => (from && to ? diffArchitecture(from, to) : null), [from, to]);
+  const groups = useMemo(() => (diff ? byArea(diff) : []), [diff]);
+
+  /** The number to offer next: whatever the newest version carried, bumped. */
+  const proposed = nextVersionNumber(versions[0]?.version ?? doc.meta.version);
+
+  /* How far the live document has drifted from the newest version — the one
+   * number that makes the Current row mean something. */
+  const [drift, setDrift] = useState<number | null>(null);
+  useEffect(() => {
+    const newest = versionsOf(list ?? [])[0];
+    if (!newest) { setDrift(null); return; }
+    let alive = true;
+    fetchDoc(newest.id)
+      .then(d => { if (alive && d) setDrift(diffArchitecture(d, doc).total); })
+      .catch(() => {});
+    return () => { alive = false; };
+  }, [fetchDoc, list, doc]);
+
+  async function freeze() {
+    const version = await ask.text({
+      title: 'Freeze this version',
+      body: 'The number is written into the document, so every export of this version prints it on the cover and in the viewer. A frozen version is never pruned.',
+      label: 'Number', value: proposed, confirmLabel: 'Next'
+    });
+    if (version === null || !version.trim()) return;
     const label = await ask.text({
-      title: 'Save a checkpoint',
-      body: 'A named version is never pruned — the thirty-snapshot cap only ever removes automatic ones.',
-      label: 'Name', value: 'Sent to the client', confirmLabel: 'Save'
+      title: `Freeze ${version.trim()}`,
+      body: 'A title for what this version is — what it was sent for, or what it settled.',
+      label: 'Title', value: '', placeholder: 'Sent to the client', allowEmpty: true
     });
     if (label === null) return;
+
     setBusy(true); setError('');
     try {
       const r: RevisionRecord = await fetch(`/api/projects/${projectId}/revisions`, {
         method: 'POST', headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ label })
+        body: JSON.stringify({ version, label })
       }).then(x => x.json());
+      /* The freeze edited the document server-side; bring that edit home. */
+      onFroze({ ...doc, meta: { ...doc.meta, version: version.trim() } });
       await load(r.id);
-    } catch { setError('Could not save a checkpoint.'); }
+    } catch { setError('Could not freeze this version.'); }
     setBusy(false);
   }
 
   async function rename(rev: RevisionRecord) {
     const label = await ask.text({
-      title: 'Name this version',
-      body: 'A named version is kept for good. Clearing the name makes it an ordinary snapshot again, and it can then be pruned.',
-      label: 'Name', value: rev.label ?? '', placeholder: 'Sent to the client',
+      title: rev.kind === 'version' ? 'Rename this version' : 'Make this a version',
+      body: 'A named version is kept for good and shows in the series above. Clearing the name makes it an ordinary snapshot again, and it can then be pruned.',
+      label: 'Title', value: rev.label ?? '', placeholder: 'Sent to the client',
       allowEmpty: true
     });
     if (label === null) return;
@@ -128,6 +211,7 @@ export default function History({ projectId, doc, dirty, onClose, onRestore }: {
     await fetch(`/api/projects/${projectId}/revisions?revisionId=${encodeURIComponent(rev.id)}`,
       { method: 'DELETE' }).catch(() => setError('Could not delete it.'));
     setPicked(null);
+    if (against === rev.id) setAgainst(CURRENT);
     await load();
     setBusy(false);
   }
@@ -157,21 +241,30 @@ export default function History({ projectId, doc, dirty, onClose, onRestore }: {
     } catch { setError('Could not restore that version.'); setBusy(false); }
   }
 
+  const row = (r: RevisionRecord) => (
+    <button key={r.id} className={`histrow${picked === r.id ? ' on' : ''}`}
+      onClick={() => setPicked(r.id)}>
+      <span className="when">{r.version ? <b className="vnum">{r.version}</b> : since(r.createdAt)}</span>
+      {r.label && <b>{r.label}</b>}
+      <span className="at">{stamp(r.createdAt)} · {r.componentCount} comp.</span>
+    </button>
+  );
+
   return (
     <>
     <div className="modal-scrim" onClick={onClose}>
       <div className="modal wide" onClick={e => e.stopPropagation()}>
         <div className="modal-head">
           <div>
-            <h2>History</h2>
+            <h2>Versions</h2>
             <p className="lede">
-              A snapshot is kept at most every five minutes while you edit. Pick one to see what
-              changed since — the comparison is against what is in front of you right now.
+              Freeze a version to keep it for good — it can be opened, exported and printed on its
+              own. Under them are the automatic snapshots, one every five minutes while you edit.
             </p>
           </div>
-          <button className="btn" onClick={checkpoint} disabled={busy}
-            title="Snapshot the document as it stands, under a name of your choosing">
-            <Icon name="flag" size={15} />Save a checkpoint
+          <button className="btn" onClick={freeze} disabled={busy}
+            title="Keep the document as it stands, under a number and a title">
+            <Icon name="flag" size={15} />Freeze this version
           </button>
         </div>
 
@@ -185,39 +278,78 @@ export default function History({ projectId, doc, dirty, onClose, onRestore }: {
         {error && <div className="err">{error}</div>}
 
         {list === null ? (
-          <div className="empty">Reading the history…</div>
-        ) : list.length === 0 ? (
-          <div className="empty">
-            Nothing here yet. The first snapshot is written five minutes into your next edit —
-            or right now, if you name a checkpoint.
-          </div>
+          <div className="empty">Reading the versions…</div>
         ) : (
           <div className="hist">
             <div className="hist-list">
-              {list.map(r => (
-                <button key={r.id} className={`histrow${picked === r.id ? ' on' : ''}`}
-                  onClick={() => setPicked(r.id)}>
-                  <span className="when">{since(r.createdAt)}</span>
-                  {r.label && <b>{r.label}</b>}
-                  <span className="at">{stamp(r.createdAt)} · {r.componentCount} comp.</span>
-                </button>
-              ))}
+              {/* The live document, at the head of the series. Not selectable:
+                  there is nothing to compare it against but itself, and nothing
+                  to restore it to. */}
+              <div className="histrow current">
+                <span className="when"><i className="dot" />Current</span>
+                {doc.meta.version && <b className="vnum">{doc.meta.version}</b>}
+                <span className="at">
+                  {doc.components.length} comp.
+                  {drift !== null && ` · ${drift} change${drift === 1 ? '' : 's'} since ${versions[0]?.version || 'the last version'}`}
+                </span>
+              </div>
+
+              {versions.map(row)}
+
+              {versions.length === 0 && (
+                <p className="muted" style={{ padding: '8px 10px' }}>
+                  No frozen version yet. Freezing one is how this diagram keeps a past you can
+                  go back and look at.
+                </p>
+              )}
+
+              {snapshots.length > 0 && (
+                <>
+                  <button className="snapshead" onClick={() => setOpenSnaps(o => !o)}>
+                    <Icon name="chevron" size={12}
+                      style={{ transform: openSnaps ? 'rotate(90deg)' : 'none' }} />
+                    Snapshots<span className="spacer" />
+                    <span className="count">{snapshots.length}</span>
+                  </button>
+                  {openSnaps && snapshots.map(row)}
+                </>
+              )}
             </div>
 
             <div className="hist-pane">
               {!current ? (
                 <div className="empty">Pick a version on the left.</div>
-              ) : !past ? (
+              ) : !from || !to ? (
                 <div className="empty">Comparing…</div>
               ) : (
                 <>
                   <div className="hist-paneh">
                     <div>
-                      <b>Changed since {since(current.createdAt)}</b>
-                      <span>{summarise(diff!) ?? 'Nothing — this version is identical to the current one.'}</span>
+                      {/* Named after the *older* of the two, because that is
+                          what "changed since" means — and the older one is not
+                          always the row you clicked. */}
+                      <b>Changed since {older?.version || since((older ?? current).createdAt)}</b>
+                      <span>{summarise(diff!) ?? 'Nothing — the two documents match.'}</span>
                     </div>
                     <div className="hist-acts">
-                      <button className="iconbtn" title="Name this version" disabled={busy}
+                      {/* The comparison target. "Current" is the default because
+                          it is the question asked nine times in ten; the rest is
+                          what makes "between the September and October boards" a
+                          question you can ask at all. */}
+                      <select className="select sm" value={against}
+                        onChange={e => setAgainst(e.target.value)} title="Compare against">
+                        <option value={CURRENT}>vs Current</option>
+                        {versions.filter(v => v.id !== picked).map(v => (
+                          <option key={v.id} value={v.id}>
+                            vs {v.version || stamp(v.createdAt)}{v.label ? ` — ${v.label}` : ''}
+                          </option>
+                        ))}
+                      </select>
+                      <button className="iconbtn" title="View this version" disabled={busy}
+                        onClick={() => onView(current)}><Icon name="eye" size={15} /></button>
+                      <button className="iconbtn"
+                        title={current.kind === 'version' ? 'Rename this version' : 'Make this a version'}
+                        disabled={busy}
                         onClick={() => rename(current)}><Icon name="flag" size={15} /></button>
                       <button className="iconbtn danger" title="Delete this version" disabled={busy}
                         onClick={() => remove(current)}><Icon name="trash" size={15} /></button>

--- a/src/lib/diff.test.ts
+++ b/src/lib/diff.test.ts
@@ -78,6 +78,23 @@ test('moving a component to another platform is reported, and named as a deploym
   assert.equal(find(diffArchitecture(before, after).changes, 'api')?.detail, 'deployment');
 });
 
+test('comparing two versions is directional — A to B is the mirror of B to A', () => {
+  /* The panel lets you pick any two versions, so it has to order them itself.
+     Handing them over the wrong way round swaps every `+` for a `−`, which is a
+     kind of wrong the reader has no way to notice. */
+  const older = doc({ components: [comp('api')] });
+  const newer = doc({ components: [comp('api'), comp('worker')] });
+
+  const forward = diffArchitecture(older, newer);
+  const back = diffArchitecture(newer, older);
+
+  assert.equal(forward.added, 1);
+  assert.equal(forward.removed, 0);
+  assert.equal(back.added, 0);
+  assert.equal(back.removed, 1);
+  assert.equal(forward.total, back.total);
+});
+
 test('absent and empty are the same document, not an edit', () => {
   /* The left side is what an imported or pre-normalisation revision looks like:
    * the list keys are simply missing. Normalising fills them with `[]`, and

--- a/src/lib/store.test.ts
+++ b/src/lib/store.test.ts
@@ -1,0 +1,165 @@
+/* The first test in this repo that touches SQLite.
+ *
+ * Everything else under `src/lib` is a pure function over a document, which is
+ * why the snapshot policy had no coverage at all: the five-minute gate, the
+ * thirty-row cap that only ever catches unlabelled rows, the restore ceiling.
+ * Versions are built on all three, so they get tested now.
+ *
+ * `DATABASE_PATH` is read at import time in db.ts, so the environment has to be
+ * set before the module graph is pulled in — hence the dynamic import below
+ * rather than a static one at the top of the file. Each run gets its own file
+ * under `os.tmpdir()` and deletes it afterwards.
+ */
+
+import { strict as assert } from 'node:assert';
+import { after, before, describe, test } from 'node:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { blankArchitecture } from './defaults';
+import type { Architecture } from './types';
+
+const DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'archstudio-store-'));
+process.env.DATABASE_PATH = path.join(DIR, 'test.db');
+
+type Store = typeof import('./store');
+let store: Store;
+
+before(async () => { store = await import('./store'); });
+after(() => { fs.rmSync(DIR, { recursive: true, force: true }); });
+
+/** A document with `n` components, so a snapshot's size is legible in a test. */
+const docOf = (n: number, version?: string): Architecture => {
+  const doc = blankArchitecture('Test');
+  if (version) doc.meta.version = version;
+  doc.layers = [{ id: 'services', name: 'Services' }];
+  doc.groups = [{ id: 'core', name: 'Core' }];
+  doc.components = Array.from({ length: n }, (_, i) => ({
+    id: `c${i}`, name: `C${i}`, group: 'core', layer: 'services',
+    tech: [], features: [], notes: [], deps: []
+  }));
+  return doc;
+};
+
+const project = (n = 1) => store.createProject({ name: 'Test', data: docOf(n) });
+
+describe('revisions', () => {
+  test('a new project starts with no history at all', () => {
+    const p = project();
+    assert.deepEqual(store.listRevisions(p.id), []);
+  });
+
+  test('a snapshot carries the component count and the document’s own version', () => {
+    const p = store.createProject({ name: 'T', data: docOf(3, 'v2.1') });
+    store.createRevision(p.id, 'Kickoff');
+    const [row] = store.listRevisions(p.id);
+    assert.equal(row.componentCount, 3);
+    assert.equal(row.version, 'v2.1');
+    assert.equal(row.label, 'Kickoff');
+    assert.equal(row.kind, 'version');
+  });
+
+  test('a document with no version of its own reports none', () => {
+    const p = project();
+    store.createRevision(p.id);
+    assert.equal(store.listRevisions(p.id)[0].version, null);
+    assert.equal(store.listRevisions(p.id)[0].kind, 'auto');
+  });
+
+  test('the five-minute gate stops a second automatic snapshot', () => {
+    /* Two saves in a row must not leave two rows. The first `updateProject`
+     * writes nothing either — there is no earlier document to keep. */
+    const p = project(1);
+    store.updateProject(p.id, { data: docOf(2) });
+    const afterFirst = store.listRevisions(p.id).length;
+    store.updateProject(p.id, { data: docOf(3) });
+    assert.equal(store.listRevisions(p.id).length, afterFirst,
+      'the second save inside the window should have been suppressed');
+  });
+
+  test('the cap only ever prunes rows nobody named', () => {
+    /* The whole promise of naming a version: forty automatic rows cannot push it
+     * out. `createRevision` bypasses the interval, so this fills the table
+     * without waiting five minutes forty times. */
+    const p = project();
+    store.createRevision(p.id, 'Kept for good');
+    for (let i = 0; i < 40; i++) store.createRevision(p.id);
+
+    const rows = store.listRevisions(p.id);
+    const named = rows.filter(r => r.label === 'Kept for good');
+    assert.equal(named.length, 1, 'the named version should have survived');
+    assert.ok(rows.filter(r => r.label === null).length <= 30,
+      'automatic snapshots should be capped at thirty');
+  });
+
+  test('restoring keeps the document it replaced, and says what it is', () => {
+    const p = store.createProject({ name: 'T', data: docOf(2) });
+    const old = store.createRevision(p.id, 'Kickoff')!;
+    store.updateProject(p.id, { data: docOf(7) });
+
+    const restored = store.restoreRevision(p.id, old.id);
+    assert.equal(restored?.data.components.length, 2, 'the old document should be live again');
+
+    const before = store.listRevisions(p.id).find(r => r.label === 'Before restore');
+    assert.ok(before, 'the pre-restore document should have been kept');
+    assert.equal(before!.componentCount, 7);
+    assert.equal(before!.kind, 'checkpoint', 'a safety net is not a version');
+  });
+
+  test('the pre-restore rows have a ceiling of their own', () => {
+    const p = project();
+    const target = store.createRevision(p.id, 'Kickoff')!;
+    for (let i = 0; i < 8; i++) store.restoreRevision(p.id, target.id);
+    const kept = store.listRevisions(p.id).filter(r => r.label === 'Before restore');
+    assert.ok(kept.length <= 5, `expected at most 5 pre-restore rows, found ${kept.length}`);
+  });
+
+  test('naming a snapshot promotes it, and clearing the name demotes it', () => {
+    const p = project();
+    const r = store.createRevision(p.id)!;
+    assert.equal(r.kind, 'auto');
+    assert.equal(store.labelRevision(p.id, r.id, 'Comité archi')?.kind, 'version');
+    assert.equal(store.labelRevision(p.id, r.id, '')?.kind, 'auto');
+  });
+});
+
+describe('freezing a version', () => {
+  test('the number lands in the document and in the snapshot at once', () => {
+    /* This is the whole design: a frozen version is a document that knows what
+     * it is called, so exporting it prints the number on its own cover without
+     * anything downstream being told which revision it came from. */
+    const p = store.createProject({ name: 'T', data: docOf(4) });
+    const frozen = store.freezeVersion(p.id, 'v1.0', 'Kickoff')!;
+
+    assert.equal(frozen.version, 'v1.0');
+    assert.equal(frozen.label, 'Kickoff');
+    assert.equal(frozen.kind, 'version');
+    assert.equal(store.getProject(p.id)?.data.meta.version, 'v1.0',
+      'the live document should carry the number too');
+    assert.equal(store.getRevisionData(p.id, frozen.id)?.meta.version, 'v1.0',
+      'and so should the snapshot');
+  });
+
+  test('a frozen version holds the drawing as it was, not as it becomes', () => {
+    const p = store.createProject({ name: 'T', data: docOf(2) });
+    const v1 = store.freezeVersion(p.id, 'v1.0')!;
+    store.updateProject(p.id, { data: docOf(9) });
+
+    assert.equal(store.getRevisionData(p.id, v1.id)?.components.length, 2);
+    assert.equal(store.getProject(p.id)?.data.components.length, 9);
+  });
+
+  test('a version can be frozen without a title', () => {
+    const p = project();
+    const frozen = store.freezeVersion(p.id, 'v3.0')!;
+    /* No title means no label, which means the row reads as an automatic
+     * snapshot — the number alone is not what keeps it. Worth knowing. */
+    assert.equal(frozen.version, 'v3.0');
+    assert.equal(frozen.label, null);
+  });
+
+  test('freezing an unknown project returns null rather than throwing', () => {
+    assert.equal(store.freezeVersion('p_nope', 'v1.0'), null);
+  });
+});

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,5 +1,6 @@
 import { db, uid, now, plain, plainAll } from './db';
 import { blankArchitecture, normalizeArchitecture } from './defaults';
+import { RESTORE_LABEL, revisionKind } from './versions';
 import type {
   Architecture, FolderRecord, ProjectRecord, ProjectSummary, ProjectWithData, RevisionRecord
 } from './types';
@@ -14,8 +15,9 @@ const REVISION_INTERVAL_MS = 5 * 60_000;
  * the way a reader expects: last written, first shown. */
 const NEWEST_FIRST = 'created_at DESC, rowid DESC';
 
-/** The label a restore leaves behind, so the restore itself can be undone. */
-const RESTORE_LABEL = 'Before restore';
+/* `RESTORE_LABEL` is imported rather than declared: it is one of the two strings
+ * that decide what kind of row a revision is, and both live in versions.ts so
+ * the panel and the prune SQL can never drift apart on it. */
 /** How many of those to keep. They are machine-written, so they get a ceiling
  *  of their own rather than the exemption a hand-named checkpoint gets. */
 const RESTORE_CAP = 5;
@@ -241,6 +243,37 @@ export function createRevision(projectId: string, label?: string): RevisionRecor
   return listRevisions(projectId).find(r => r.id === id) ?? null;
 }
 
+/** Freeze the current document as a numbered version.
+ *
+ *  The number goes *into the document* before the snapshot is taken, not beside
+ *  it. That is the whole design: a frozen version is a document that knows what
+ *  it is called, so exporting it prints the right number on the cover and in the
+ *  viewer's subtitle without anything downstream having to be told which
+ *  revision it came from. It also means freezing is a real edit — undoable, and
+ *  reported in the history as a "Version" change like any other field.
+ *
+ *  Order matters. `updateProject` may write its own five-minute snapshot of the
+ *  *previous* document on the way through, which is the state just before the
+ *  freeze and worth keeping; the version's own snapshot is written after it, so
+ *  it is the newest row and the one the panel opens on. */
+export function freezeVersion(
+  projectId: string, version: string, label?: string
+): RevisionRecord | null {
+  const current = getProject(projectId);
+  if (!current) return null;
+
+  const number = version.trim();
+  const data: Architecture = number
+    ? { ...current.data, meta: { ...current.data.meta, version: number } }
+    : current.data;
+
+  const saved = updateProject(projectId, { data });
+  if (!saved) return null;
+
+  const id = writeSnapshot(projectId, saved.data, label?.trim() || null);
+  return listRevisions(projectId).find(r => r.id === id) ?? null;
+}
+
 export function listRevisions(projectId: string): RevisionRecord[] {
   const rows = db.prepare(
     `SELECT id, project_id, label, created_at, data FROM revisions WHERE project_id = ? ORDER BY ${NEWEST_FIRST}`
@@ -248,12 +281,20 @@ export function listRevisions(projectId: string): RevisionRecord[] {
   return plainAll<Record<string, unknown>>(rows)
     .map(o => {
       let componentCount = 0;
-      try { componentCount = (JSON.parse(o.data as string) as Architecture).components?.length ?? 0; }
-      catch { /* a corrupt snapshot should still be listed, and restorable */ }
+      let version: string | null = null;
+      try {
+        /* One parse, two answers. The number a version carries is the document's
+         * own `meta.version` — there is no column for it and there does not need
+         * to be, because this row was already being read to count components. */
+        const doc = JSON.parse(o.data as string) as Architecture;
+        componentCount = doc.components?.length ?? 0;
+        version = doc.meta?.version?.trim() || null;
+      } catch { /* a corrupt snapshot should still be listed, and restorable */ }
+      const label = (o.label ?? null) as string | null;
       return {
         id: o.id as string, projectId: o.project_id as string,
-        label: (o.label ?? null) as string | null, createdAt: o.created_at as string,
-        componentCount
+        label, createdAt: o.created_at as string,
+        componentCount, version, kind: revisionKind(label)
       };
     });
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -304,12 +304,21 @@ export interface ProjectSummary extends ProjectRecord {
 
 /** A snapshot of a project's document.
  *
- * `label` is what separates the two kinds: an automatic snapshot has none, a
- * checkpoint the user named has one — and a named checkpoint is never pruned. */
+ * `label` is what separates the kinds: an automatic snapshot has none, a version
+ * someone froze has a title — and a named row is never pruned. `kind` is that
+ * reading, made explicit, plus the third case the app writes for itself. See
+ * `src/lib/versions.ts`.
+ *
+ * `version` and `kind` are *derived*, not stored: the schema has no column for
+ * either, and could not gain one. The number is read out of the snapshot's own
+ * `meta.version` in the same parse that counts the components. */
 export interface RevisionRecord {
   id: string;
   projectId: string;
   label: string | null;
   createdAt: string;
   componentCount: number;
+  /** The number the document carried when it was frozen. */
+  version: string | null;
+  kind: import('./versions').RevisionKind;
 }

--- a/src/lib/versions.test.ts
+++ b/src/lib/versions.test.ts
@@ -1,0 +1,87 @@
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+
+import {
+  FIRST_VERSION, MACHINE_LABELS, RESTORE_LABEL, nextVersionNumber, revisionKind,
+  snapshotsOf, versionsOf, type RevisionKind
+} from './versions';
+
+/* ------------------------------------------------------------- the kinds */
+
+test('a row with no label is an automatic snapshot', () => {
+  assert.equal(revisionKind(null), 'auto');
+  assert.equal(revisionKind(undefined), 'auto');
+  assert.equal(revisionKind(''), 'auto');
+});
+
+test('a row the app labelled for itself is a checkpoint, not a version', () => {
+  /* These are safety nets the app wrote without being asked. Listing them among
+   * the versions someone decided to keep would bury the ones that mean
+   * something. */
+  assert.equal(revisionKind('Before restore'), 'checkpoint');
+  assert.equal(revisionKind('Before enrichment'), 'checkpoint');
+});
+
+test('a row somebody named is a version', () => {
+  assert.equal(revisionKind('Sent to the client'), 'version');
+  assert.equal(revisionKind('Comité archi'), 'version');
+});
+
+test('the restore label is one of the machine labels, not a second list', () => {
+  /* The prune SQL in store.ts compares this string literally. If it ever drifts
+   * from the set the panel classifies by, restore checkpoints start showing up
+   * as versions. */
+  assert.ok(MACHINE_LABELS.has(RESTORE_LABEL));
+});
+
+/* --------------------------------------------------------- the next number */
+
+test('the last integer is what gets bumped, wherever it sits', () => {
+  assert.equal(nextVersionNumber('v1.3'), 'v1.4');
+  assert.equal(nextVersionNumber('v0.1'), 'v0.2');
+  assert.equal(nextVersionNumber('2.4.1'), '2.4.2');
+  assert.equal(nextVersionNumber('v2'), 'v3');
+  assert.equal(nextVersionNumber('v9'), 'v10');
+});
+
+test('it works on the version numbers that are not version numbers', () => {
+  /* The field is free text and always was — a document is as likely to be on a
+   * sprint or a date as on a semver triple, and refusing those would mean
+   * refusing an answer the author already gave. */
+  assert.equal(nextVersionNumber('Sprint 4'), 'Sprint 5');
+  assert.equal(nextVersionNumber('v1.0-rc1'), 'v1.0-rc2');
+});
+
+test('leading zeros survive, because a date is not a decimal', () => {
+  assert.equal(nextVersionNumber('2026.09'), '2026.10');
+  assert.equal(nextVersionNumber('v1.09'), 'v1.10');
+});
+
+test('nothing to read from means the series starts at the beginning', () => {
+  assert.equal(nextVersionNumber(undefined), FIRST_VERSION);
+  assert.equal(nextVersionNumber(null), FIRST_VERSION);
+  assert.equal(nextVersionNumber('   '), FIRST_VERSION);
+  assert.equal(nextVersionNumber('draft'), FIRST_VERSION);
+});
+
+test('bumping twice from the same start walks the series', () => {
+  assert.equal(nextVersionNumber(nextVersionNumber('v1.0')), 'v1.2');
+});
+
+/* ------------------------------------------------------------- the panel */
+
+const rows = [
+  { id: 'a', kind: 'version' as RevisionKind },
+  { id: 'b', kind: 'auto' as RevisionKind },
+  { id: 'c', kind: 'checkpoint' as RevisionKind },
+  { id: 'd', kind: 'version' as RevisionKind }
+];
+
+test('the series is the named rows, and everything else folds away together', () => {
+  assert.deepEqual(versionsOf(rows).map(r => r.id), ['a', 'd']);
+  assert.deepEqual(snapshotsOf(rows).map(r => r.id), ['b', 'c']);
+});
+
+test('the two halves partition the list — nothing is shown twice or lost', () => {
+  assert.equal(versionsOf(rows).length + snapshotsOf(rows).length, rows.length);
+});

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -1,0 +1,107 @@
+/* Versions — the history, read as the architecture's own evolution.
+ *
+ * ------------------------------------------------------------ what was there
+ *
+ * The snapshots were always being written. They were framed as insurance: a
+ * rolling log you open after a misdrop, where the only question asked of a row
+ * is "what did I have then that I do not have now". That is a real question and
+ * it stays answered. It is just not the one someone asks of a diagram that has
+ * been evolving for six months — which is "show me the version we sent in
+ * September", and that one needs the row to be a *thing you can open* rather
+ * than a point to subtract from.
+ *
+ * ------------------------------------------------------------ what a version is
+ *
+ * A row of `revisions` with a name on it. Nothing more: no column was added and
+ * none could be — the schema is `CREATE TABLE IF NOT EXISTS` re-exec'd on every
+ * connection and there is no `ALTER TABLE` anywhere, so a new column would land
+ * on fresh databases and never on an installed one.
+ *
+ * It does not need one. The *title* is the row's `label`, which is what a label
+ * already was. The *number* is the `meta.version` of the document inside the
+ * snapshot — which is where a document's version belongs, is already printed on
+ * the paper cover and in the viewer's subtitle, and comes back for free because
+ * `listRevisions` already parses that JSON to count components.
+ *
+ * The consequence worth stating: freezing a version *edits the document*. It
+ * writes the number into `meta.version` and then snapshots. So a version is not
+ * a label stuck on the side of the history — it is a document that knows what it
+ * is called, and every export of it says so on its own.
+ *
+ * -------------------------------------------------------------- three kinds
+ *
+ * `version`     someone froze it, with a number and a title. Never pruned.
+ * `checkpoint`  the app protected an operation — a restore, an enrichment.
+ * `auto`        the five-minute save.
+ *
+ * The discriminant is the label, and that is not new: the prune SQL in store.ts
+ * already compares `'Before restore'` literally. What is new is that the machine
+ * labels live in one place instead of two. Someone who titles a version "Before
+ * restore" gets a checkpoint — a real edge, and the honest price of not being
+ * able to add a column.
+ */
+
+/** Labels the app writes for itself. A row carrying one is a safety net rather
+ *  than a version someone decided to keep. */
+export const MACHINE_LABELS: ReadonlySet<string> = new Set([
+  'Before restore',
+  'Before enrichment'
+]);
+
+/** The label a restore leaves behind, so the restore itself can be undone.
+ *  Exported from here rather than declared in the store: it is one of the two
+ *  strings that decide what a row *is*, and both belong together. */
+export const RESTORE_LABEL = 'Before restore';
+
+export type RevisionKind = 'version' | 'checkpoint' | 'auto';
+
+export const revisionKind = (label: string | null | undefined): RevisionKind => {
+  if (!label) return 'auto';
+  return MACHINE_LABELS.has(label) ? 'checkpoint' : 'version';
+};
+
+/** Where a version series starts when nothing before it can be read. */
+export const FIRST_VERSION = 'v1.0';
+
+/** The number to offer for the next freeze: the last integer in the current one,
+ *  plus one.
+ *
+ *  Bumping the *last* integer rather than parsing semver on purpose. This field
+ *  is free text and always was — templates seed `v0.1`, and a document is just
+ *  as likely to be on "Sprint 4" or "2026.09" as on a version triple. Taking the
+ *  last run of digits and incrementing it does the right thing for all of those
+ *  and never has to reject an answer the author already gave.
+ *
+ *    v1.3 → v1.4      v0.1 → v0.2      2.4.1 → 2.4.2
+ *    v2   → v3        Sprint 4 → Sprint 5      (nothing) → v1.0
+ *
+ *  Leading zeros survive, because "2026.09" incrementing to "2026.10" is what
+ *  someone writing dates means, and "2026.1" is not. */
+export function nextVersionNumber(current: string | null | undefined): string {
+  const from = (current || '').trim();
+  if (!from) return FIRST_VERSION;
+
+  /* The last run of digits, wherever it is — `v1.3` and `Sprint 4` both end on
+   * one, and a trailing `-rc2` would too, which is the right answer for it. */
+  const match = from.match(/(\d+)(\D*)$/);
+  if (!match) return FIRST_VERSION;
+
+  const [whole, digits, tail] = match;
+  const next = String(Number(digits) + 1).padStart(digits.length, '0');
+  return from.slice(0, from.length - whole.length) + next + tail;
+}
+
+/* --------------------------------------------------------------- the panel */
+
+/** Anything with a `kind`. Keeps these two usable from the store, from the
+ *  panel, and from a test, without any of them importing the others' types. */
+interface Kinded { kind: RevisionKind }
+
+/** The named series — what the panel lists as the architecture's evolution. */
+export const versionsOf = <T extends Kinded>(rows: T[]): T[] =>
+  rows.filter(r => r.kind === 'version');
+
+/** Everything else, folded away: the five-minute saves and the app's own safety
+ *  nets. Still restorable, still nameable — naming one promotes it. */
+export const snapshotsOf = <T extends Kinded>(rows: T[]): T[] =>
+  rows.filter(r => r.kind !== 'version');


### PR DESCRIPTION
…unctionality

- Renamed the History component to Versions and updated related terminology.
- Improved the logic for comparing versions, allowing users to view changes between selected versions.
- Introduced functionality to freeze versions, which saves the current document state with a version number and title.
- Enhanced the UI to display current document state alongside frozen versions and automatic snapshots.
- Added tests for version comparison and freezing functionality, ensuring correct behavior and data integrity.
- Updated data structures to include version information in revision records, facilitating better tracking of document evolution.

## Summary by Sourcery

Transform document history into a durable versions workflow with numbered freezes, historical viewing, comparisons, and revision-aware exports.

New Features:
- Add a Versions panel that separates durable numbered versions from automatic snapshots and displays the live document alongside them.
- Allow users to freeze, compare, restore, rename, view, export, and print stored document versions.
- Support rendering stored revisions in the preview and document views through revision-aware export and printing routes.

Bug Fixes:
- Ensure comparisons between arbitrary versions are ordered chronologically so additions and removals are reported in the correct direction.

Enhancements:
- Derive revision metadata and version numbering from document data and centralized revision classification rules.
- Show document drift from the newest frozen version and provide clear navigation between historical and current documents.

Documentation:
- Update user and developer documentation to describe version freezing, comparison, viewing, exporting, printing, and snapshot retention.

Tests:
- Add coverage for directional version diffs, revision classification, version numbering, snapshot retention, restore safeguards, promotion of snapshots, and freezing behavior.

Chores:
- Rename the editor's History terminology to Versions across the interface and data model.