### PR TITLE
feat(admin): local-first content CMS with publish and F-REG

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,9 +180,32 @@ Functions became Cloud Run functions, Azure AI Foundry became Microsoft Foundry,
 closing in favour of Entra External ID. Re-read that file once a year.
 
 ```bash
-npm test                        # the 60 instantiations and their invariants
-UPDATE_SNAPSHOTS=1 npm test     # accept a deliberate change
+npm test                        # full suite (templates + admin + lego)
+npm run test:admin              # admin CMS regression slice (F-REG)
+UPDATE_SNAPSHOTS=1 npm test     # accept a deliberate template snapshot change
 ```
+
+---
+
+## Admin CMS (content without a code PR)
+
+Open **`/admin`** on a local or private deploy. The shell uses the same Atelier chrome as the
+editor (teal, square corners, `Fields` / `Icon`). There is **no auth** — same threat model as the
+rest of the app ([SECURITY.md](SECURITY.md)): VPN / reverse-proxy / Tailscale only.
+
+| Area | What you edit | Notes |
+|---|---|---|
+| Catalogue Lego | Bricks, scopes, intents, variants, dependencies, technologies | Create / update / delete; locked seed ids reappear after `ensure` |
+| Templates | Project + architecture templates, cloud services | Diagram = same surface as the project editor |
+| ADD / Flows | Document section presets, journey patterns | Publish blocked on placeholder markers (`[…]`, « À estimer ») |
+| Locale / Import | System copy + layer labels; content bundle export/import | Bundle version `1` |
+| Publish | Wizard across all content domains | Validates before write; issues link into editors |
+
+Runtime flag **`CONTENT_FROM_ADMIN=1`**: published admin content feeds project creation, flow
+plates, and ADD presets. Flag off keeps the previous code/seed paths.
+
+Docs for reviewers: [`docs/add/README.md`](docs/add/README.md) · regression
+[`docs/add/REGRESSION-admin.md`](docs/add/REGRESSION-admin.md).
 
 ---
 
@@ -469,7 +492,8 @@ npm run build && npm start          # a VPS, a Raspberry Pi, a container with a 
 
 There is no authentication. Put it behind your VPN, a reverse-proxy basic-auth, or a Tailscale
 network — do not expose it to the open internet as is. Adding auth means one middleware and a
-session check in the API routes; the data model does not need to change.
+session check in the API routes; the data model does not need to change. The **`/admin`** CMS
+shares that model: anyone who can reach the port can publish or wipe content domains.
 
 ---
 
@@ -477,7 +501,8 @@ session check in the API routes; the data model does not need to change.
 
 - Diagram placeholders for the document chapters that have none — network topology, CI/CD pipeline
 - Keyboard navigation on the canvas, and undo/redo
-- Optional auth for shared installs
+- Optional auth for shared installs (covers `/admin` too)
+- Hydrate gated ADD cards to Acme density (no « Composants concernés » dump — CONTRAT B2)
 - Multi-select and bulk move on the canvas
 
 ## Community

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,8 +29,9 @@ follows from that.
 ### Not vulnerabilities
 
 **There is no authentication, and no authorisation.** Anyone who can reach the port can read,
-edit, export and delete every project. This is documented in the README, and the fix is a reverse
-proxy, a VPN, or the middleware the README describes — not a report.
+edit, export and delete every project — and, with the Admin CMS, publish or replace content
+domains under `/admin` and `/api/admin/**`. This is documented in the README, and the fix is a
+reverse proxy, a VPN, or the middleware the README describes — not a report.
 
 **An instance exposed to the open internet is compromised by design.** Reporting that a
 public instance can be edited by anyone is reporting the documented behaviour.

--- a/docs/add/ADMIN-CMS.md
+++ b/docs/add/ADMIN-CMS.md
@@ -1,0 +1,433 @@
+# Admin CMS — tout le contenu système éditable sans code
+
+- Date : 2026-08-18 · updated 2026-08-20
+- Session LifeOS : `082ba078-2ccd-4291-b2d2-a5cf77b7b769`
+- Statut : **SHIPPED** — ISA parent + UX **complete** ([`ISA-archstudio-admin-cms.md`](./ISA-archstudio-admin-cms.md), [`ISA-archstudio-admin-cms-ux.md`](./ISA-archstudio-admin-cms-ux.md)). Index PR : [`README.md`](./README.md).
+- Amont :
+  - [`RESEARCH.md`](./RESEARCH.md) — kit ADD slim, gating, zéro `[…]`
+  - [`RESEARCH-brick-metadata.md`](./RESEARCH-brick-metadata.md) — métadonnées catalogue → slots ADD
+  - [`CONTRAT-qualite-acme.md`](./CONTRAT-qualite-acme.md) — barre qualité ; templates Acme = levier principal
+  - [`../lego/GAPS.md`](../lego/GAPS.md) — admin CMS marked shipped
+
+**Décision produit (principal, 2026-08-18) :** *« Tout le contenu doit être éditable dans admin »* — plus de PR pour une brique, une section, un flow pattern ou un template Acme.
+
+---
+
+## Problem
+
+Aujourd’hui ArchStudio mélange **moteur** (placement, gating, PDF, canvas) et **contenu** (briques, templates, sections ADD, flow patterns, technos) dans le même repo TypeScript.
+
+| Contenu | Fichier(s) actuel(s) | Conséquence |
+|---------|----------------------|-------------|
+| Catalogue Lego (26 briques, 154 variants, deps…) | `seed-data.ts` → SQLite (seed one-shot) | `concernTags` encore relus depuis le seed TS, pas SQLite |
+| Templates architecture (6 hyperscaler) | `templates/*.ts` + registry | Nouveau template = dev + deploy |
+| Template démo Acme | `seed/demo.json` + `seed.ts` | Qualité cible, mais pas extensible sans commit |
+| Sections ADD preset (13 CAF) | `document/preset.ts` | Chapitre = diff code |
+| Flow patterns (8 ids) | `flows/catalog.ts` | Pattern = diff code |
+| Descriptions technos | SQLite + seed | Partiellement en base, authoring code-first |
+| Icônes, protocoles, layers packs | docs locked + constantes | Changement = ISA + code |
+
+Le fondateur non-tech **ne doit jamais** passer par l’admin. L’admin sert **l’équipe produit / contenu** : shipper un template « Deux plateformes », ajouter Auth0, corriger une section operations, publier un flow checkout — **sans redeploy applicatif** pour le contenu seul.
+
+---
+
+## Vision
+
+Un **panneau Admin** local-first (`/admin`) : CMS du produit ArchStudio.
+
+- **Une vérité** par entité, versionnée, brouillon → publié.
+- **Tout** ce qui alimente le picker, le wizard Lego, les flow patterns, le preset ADD et les seeds exemples y est CRUD.
+- Le runtime **lit** la version publiée (SQLite ou export JSON signé) ; il n’importe plus de `.ts` pour le contenu.
+- Un template Acme ne se « devine » plus : on le **crée une fois** dans l’admin, le fondateur le choisit.
+
+Euphorie : ajouter « Template marketplace B2B » un mardi après-midi, avec canvas + 4 sections + 2 flows + qualité PDF, **sans ouvrir l’IDE**.
+
+---
+
+## Out of Scope (admin ≠ app user)
+
+| Hors admin | Pourquoi |
+|------------|----------|
+| Éditer les projets users (`projects.data`) | C’est le canvas client ; reste l’éditeur normal |
+| Réécrire le moteur (gating, hydrate, `buildOutline`, placement) | Code ; consomme le contenu admin |
+| Changer les **ids verrouillés** du moteur (`ConcernTag`, `TAG_TO_PRESET`, types de section) | Contrat code ; l’admin choisit *dans* l’enum |
+| Billing, multi-tenant cloud, sync remote | Local-first ; export/import fichier suffit en v1 |
+| Wizard besoins fondateur (ISA #4) | Produit séparé ; consomme les gates, ne les définit pas |
+| Mode audit Azure complet | Overlay futur |
+
+---
+
+## Principles
+
+1. **Content vs engine** — l’admin ne shippe que des données ; la logique de résolution reste typée en code.
+2. **Stable ids** — renommer l’affichage OK ; `identity`, `auth-login`, `add-data` ne changent pas sans migration explicite.
+3. **Absent > vide** — une section sans corps publiable n’apparaît pas (aligné [`CONTRAT-qualite-acme.md`](./CONTRAT-qualite-acme.md)).
+4. **i18n obligatoire** — tout texte user-facing : `en` + `fr` (même règle que `L10n` / catalogue).
+5. **Publish explicite** — brouillon éditable ; runtime ne voit que `published`.
+6. **Acme-first templates** — les templates **projet** (snapshot complet) priment sur l’inférence pour le non-tech.
+
+---
+
+## Boundary — trois couches
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  ADMIN CMS (brouillon / publié)                         │
+│  templates · catalogue · sections · flows · technos · …  │
+└───────────────────────────┬─────────────────────────────┘
+                            │ read published
+┌───────────────────────────▼─────────────────────────────┐
+│  MOTEUR (code)                                          │
+│  instantiate · placeVariant · insertPlate · deriveGates   │
+│  hydratePresetSection · buildOutline · PaperDocument    │
+└───────────────────────────┬─────────────────────────────┘
+                            │ read/write
+┌───────────────────────────▼─────────────────────────────┐
+│  INSTANCE PROJET (Architecture JSON par user)           │
+│  components · flows · sections auteur · meta · …        │
+└─────────────────────────────────────────────────────────┘
+```
+
+L’admin **ne touche jamais** les instances projet sauf action explicite « Dupliquer comme exemple seed » (outil interne).
+
+---
+
+## Inventaire — tout ce qui devient éditable
+
+### 1. Templates projet (priorité #1 — Acme)
+
+Snapshot **complet** prêt à instancier : équivalent de `seed/demo.json`.
+
+| Champ admin | Source actuelle | Notes |
+|-------------|-----------------|-------|
+| `id`, `name`, `tagline`, `description` | meta + seed | Picker « Nouveau projet » |
+| `accent`, `theme`, `icon` | theme / UI | Carte projet |
+| `meta` (intro, principle, facts, kicker, title…) | demo.json | Qualité non-tech |
+| `groups`, `layers` | demo.json | |
+| `components[]` | demo.json | role, features, notes, tech — **sans** obligation `brick` |
+| `flows[]` | demo.json | Parcours déjà liés |
+| `sections[]` | demo.json | compare, operations, roadmap, risks |
+| `technologies[]` | demo.json | Stack annexe |
+| `ui.tabs`, `ui.views` | demo.json | Onglets viewer |
+| `supportedTargets` | optionnel | Si déploiement multi-cloud plus tard |
+| `whenToUse` / `whenNotToUse` | picker | Bullets marketing |
+| `sortOrder`, `published`, `featured` | — | Ordre picker ; Acme en tête |
+
+**Instanciation user :** `createProject({ templateId })` → copie profonde du snapshot publié → projet éditable normal.
+
+**Anti-régression :** le template publié « Acme — two platforms » doit produire un PDF indiscernable du seed actuel (cf. falsifiers [`CONTRAT-qualite-acme.md`](./CONTRAT-qualite-acme.md)).
+
+---
+
+### 2. Templates architecture (hyperscaler — priorité #2)
+
+Les 6 templates actuels (`serverless-mvp`, `saas-multitenant`, `rag`, …) : structure abstraite + table `cloud` par cible.
+
+| Entité | Éditable dans admin |
+|--------|---------------------|
+| Métadonnée picker | id, name, tagline, intro, icon, accent, whenToUse, whenNotToUse, supportedTargets |
+| `groups`, `layers` | CRUD |
+| `components[]` | id, role, features, notes, tech, deps, **cloud overrides** (aws/gcp/azure/selfhosted) |
+| `flows[]`, `sections[]` | idem templates projet |
+| `technologies[]` | optionnel |
+
+**Résolution à l’instanciation :** le moteur `instantiate(template, target, lang)` reste en code ; il lit le JSON admin au lieu de `import './saas-multitenant'`.
+
+---
+
+### 3. Catalogue Lego (priorité #2 — déjà SQLite)
+
+Étendre le schéma existant (`src/lib/db.ts`) pour **100 % authoring admin** — fin de `seed-data.ts` comme source de vérité.
+
+#### Déjà en SQLite (à éditer via admin)
+
+| Table | Contenu |
+|-------|---------|
+| `lego_catalog_versions` | Version + statut draft/published |
+| `lego_scopes` | 18 scopes EN/FR |
+| `lego_scope_aliases` | core → product, etc. |
+| `lego_bricks` | id, icon, layer_id, default_scope, capabilities_json |
+| `lego_brick_texts` | role, responsibilities, notes (EN/FR) |
+| `lego_capability_phrases` | phrase EN/FR |
+| `lego_brick_scope_affinities` | brick ↔ scope |
+| `lego_intents` | 12 intents + label |
+| `lego_intent_modes` / `lego_intent_shapes` | modes et shapes |
+| `lego_variants` | 154 variants → maps_to brick |
+| `lego_technology_descriptions` | clé → description EN/FR |
+| `lego_dependencies` | from, to, strength, why, protocol, kind |
+
+#### À ajouter en SQLite (aujourd’hui seulement dans TS)
+
+| Champ / table | Usage |
+|---------------|-------|
+| `lego_brick_texts.purpose` | DISTINCT de `role` si besoin ; ADD contexte / glossaire |
+| `lego_brick_concern_tags` | `(catalog_version, brick_id, tag)` — **sortir** de `CATALOG_SEED.concernTags` |
+| `lego_brick_metadata.when_use` / `when_not` | JSON EN/FR, max 2 bullets |
+| `lego_protocols` | id, label, kind (sync/async/batch) — aujourd’hui `protocols.ts` |
+| `lego_layers` | id, label EN/FR, pack (default/rag/event) — packs éditables |
+| `lego_icons` | clé validée contre `Icon.tsx` — picker admin |
+
+#### Écrans admin catalogue
+
+1. **Versions** — liste, dupliquer, publier, rollback
+2. **Scopes & aliases**
+3. **Briques** — fiche : icon, layer, scope, capabilities, purpose, role, features, notes, **concernTags**, whenUse/whenNot, affinités
+4. **Intents** — modes, shapes
+5. **Variants** — label, intent, mode, maps_to (autocomplete briques)
+6. **Dependencies** — graphe + formulaire ; validation acyclic optional
+7. **Technologies** — clé normalisée + description EN/FR
+
+---
+
+### 4. Sections ADD (priorité #3)
+
+Bibliothèque de chapitres réutilisables — aujourd’hui `SECTIONS[]` dans `preset.ts`.
+
+| Champ | Description |
+|-------|-------------|
+| `id` | ex. `add-data`, `add-iam`, ou custom `platforms-compare` |
+| `type` | `cards` \| `timeline` \| `table` \| `compare` \| `text` |
+| `doc.chapter` | ex. `2.2` — ordre papier |
+| `doc.gated_default` | bool — ouvre-t-on via concernTags seulement ? |
+| `concern_tags[]` | tags qui **ouvrent** ce chapitre (miroir `TAG_TO_PRESET` côté contenu) |
+| `title`, `subtitle`, `note` | L10n EN/FR |
+| Payload typé | `items`, `rows`, `columns`, `blocks`, … selon `type` |
+| `hydrator_id` | optionnel — `add-iam`, `add-data`, ou `generic-cards` |
+
+**Deux usages :**
+
+- **Preset pack** — les 13 CAF + sections auteur type Acme, assignables à un template projet
+- **À la carte** — bouton « Ajouter section depuis bibliothèque » (Sections editor) — comportement actuel `applyDesignDocumentPreset`, alimenté par admin
+
+**Règle qualité :** une section publiée pour gating ne doit pas contenir de `[…]` dans le corps par défaut ; sinon marquée `template_only: true` et adoptée/hydratée au gate ON (cf. ISA brick-metadata).
+
+---
+
+### 5. Flow patterns (priorité #4)
+
+Aujourd’hui 8 ids locked dans [`FLOWS.md`](../lego/FLOWS.md) — l’admin les **édite**, n’en ajoute pas en v1 sans décision (extension v2).
+
+| Champ | Description |
+|-------|-------------|
+| `id` | `auth-login`, `checkout`, … |
+| `icon`, `name`, `tagline` | L10n |
+| `steps[]` | key, title, description, **hint** (name/tech/layers/icons/avoid[]) |
+| `default_protocol_suggestions` | par step pair |
+| `mappable_brick` | rôle Lego attendu pour create-missing |
+
+**Écran :** éditeur de steps ordonnés ; preview « bind sur demo Acme » ; test `countMappableSteps`.
+
+API existante : `/api/flow-templates` — lire depuis SQLite publié au lieu de `FLOW_CATALOG` import.
+
+---
+
+### 6. Technologies & stack (priorité #5)
+
+| Source | Admin |
+|--------|-------|
+| `lego_technology_descriptions` | CRUD clé → prose EN/FR |
+| Catégories stack (`ui.stack` defaults) | Texte section stack EN/FR |
+| Synonymes matching | ex. `postgres` ↔ `PostgreSQL` pour inférence future |
+
+Les `tech[]` sur les composants restent **instance** ; l’admin propose un **vocabulaire** autocomplete.
+
+---
+
+### 7. Vocabulaires système (priorité #5)
+
+| Vocabulaire | Aujourd’hui | Admin v1 |
+|-------------|-------------|----------|
+| `ConcernTag` | `concerns.ts` enum | **Lecture seule** ; admin assigne tags existants aux briques |
+| `TAG_TO_PRESET` | code | **Lecture seule** v1 ; mapping tag → section_id en v2 |
+| Icônes | `ICONS.md` + `Icon.tsx` | Picker liste blanche |
+| Protocoles | `PROTOCOLS.md` | CRUD si table `lego_protocols` |
+| Capabilities | `CAPABILITIES.md` | Tags libres sur brique, suggérés depuis liste |
+| Cloud services | `templates/services.ts` | CRUD table `cloud_services` (role → aws/gcp/azure/selfhosted label) |
+
+**Règle :** élargir l’enum `ConcernTag` ou ajouter un flow pattern #9 reste une **ISA + release moteur** ; l’admin configure *dans* le contrat.
+
+---
+
+### 8. Copy & defaults système (priorité #6)
+
+| Clé | Usage |
+|-----|-------|
+| `DEFAULT_FLOW_COPY` | Premier flow manuel EN/FR |
+| `STARTER_LAYERS` / groupes vides | Nouveau projet blank |
+| Labels layers (`displayLayerLabel`) | Traduction id → label |
+| Meta document vides | tagline placeholder |
+
+Objet clé/valeur L10n en table `system_copy`.
+
+---
+
+### 9. Seeds & exemples (outil admin)
+
+- **Publier comme template** — exporter un projet user → brouillon template projet
+- **Réinitialiser exemples** — dossier « Examples » recréé depuis templates `featured`
+- Pas d’édition directe du JSON projet dans l’admin (hors export/import template)
+
+---
+
+## Modèle de publication
+
+```
+draft (catalog_version | content_version)
+  ↓ validate
+  ↓ publish (atomic transaction)
+published ← seul lu par API runtime / seed au boot
+  ↓ optional export
+content-bundle.json (backup, PR, autre machine)
+```
+
+| Règle | Détail |
+|-------|--------|
+| Un seul `published` actif | Par domaine : catalogue, templates, sections, flows |
+| Brouillon | Copie COW du publié ; edits isolés |
+| Validation publish | Schéma JSON + refs integrity + i18n complete + pas d’id orphelin |
+| Rollback | Réactiver version précédente publiée |
+| Projets existants | **Non migrés** — snapshot au create ; catalogue ne retro-change pas les tags déjà posés |
+
+---
+
+## Admin UI — structure proposée
+
+Route racine : **`/admin`** (local-only v1 ; auth basique ou flag dev).
+
+| Nav | Écrans |
+|-----|--------|
+| **Dashboard** | versions, dernier publish, compteurs, liens « test picker » |
+| **Templates projet** | liste, éditeur (meta / canvas / sections / flows), preview PDF, publish |
+| **Templates architecture** | idem + onglet cloud overrides |
+| **Catalogue** | version, scopes, briques, intents, variants, deps, technos |
+| **Sections ADD** | bibliothèque, éditeur typé par `type`, preview papier |
+| **Flow patterns** | liste 8, éditeur steps + hints, test mapping |
+| **Vocabulaires** | icônes, protocoles, cloud services, system copy |
+| **Import / Export** | bundle JSON, diff brouillon vs publié |
+
+**Éditeurs structurés** — pas de textarea JSON nu pour l’usage courant :
+
+- Compare / timeline / cards / table / text = formulaires par type
+- Canvas template = grille composants (nom, layer, group, role, features, tech)
+- Brique = fiche unique avec onglets EN/FR
+
+### Chrome UI — réutilisation stricte
+
+`/admin` **n'a pas son propre design system**. Il compose les mêmes briques visuelles que l'app principale :
+
+| Réutiliser | Fichier |
+|------------|---------|
+| Tokens Atelier (teal, carré, Archivo/Space Mono) | `src/app/globals.css` |
+| Icônes stroke SVG | `src/components/Icon.tsx` |
+| Champs formulaire | `src/components/editors/Fields.tsx` |
+| Lockup + sous-titre « Content » | `src/components/Brand.tsx` |
+| Shell sidebar / topbar / inspector | mêmes classes que `Editor.tsx` |
+
+**Interdit :** emoji dans l'UI admin, bibliothèques UI externes (shadcn, Lucide), esthétique « AI dashboard » (gradients, glass, coins arrondis génériques, empty states illustrés). Détail et DoD visuel : [`RESEARCH-admin-cms-ux.md`](./RESEARCH-admin-cms-ux.md) § Identité visuelle.
+
+---
+
+## API runtime (remplacement progressif)
+
+| Endpoint actuel | Source future |
+|-----------------|---------------|
+| `/api/lego/catalog` | SQLite `published` |
+| `/api/templates` | `project_templates` + `architecture_templates` |
+| `/api/flow-templates` | `flow_patterns` published |
+| (interne) `presetSectionForId` | `add_sections` published |
+| `ensureSeed()` | template projet `featured` published |
+
+Feature flag `CONTENT_FROM_ADMIN=1` pour basculer source par source lors de la migration.
+
+---
+
+## Validation (bloquante au publish)
+
+| Check | Exemple d’échec |
+|-------|------------------|
+| i18n | `title.fr` manquant |
+| Ref integrity | variant `maps_to` → brique inexistante |
+| Section type | compare sans `columns` |
+| Flow step | `key` dupliqué |
+| Icon | clé absente de `Icon.tsx` |
+| Concern tag | valeur hors enum |
+| Template | `components[].group` ∉ `groups` |
+| Qualité gated | section `gated_default` avec `[…]` sans hydrator |
+| Acme parity | template acme-v1 : 22 composants, 4 sections auteur |
+
+---
+
+## Migration depuis le code (ordre d’exécution)
+
+| Phase | Action | DoD |
+|-------|--------|-----|
+| **M0** | Schéma SQLite étendu + import one-shot depuis TS/JSON actuels | Parité byte runtime avec flag off |
+| **M1** | Admin CRUD catalogue + publish ; API catalogue ← admin | Fin `seed-data.ts` authoring ; concernTags en DB |
+| **M2** | Admin templates **projet** ; Acme importé ; picker ← admin ; `ensureSeed` ← admin | Nouveau template sans code |
+| **M3** | Admin sections ADD ; `preset.ts` ← admin | Chapitre CAF éditable |
+| **M4** | Admin flow patterns ; catalog.ts ← admin | Hint editable |
+| **M5** | Admin templates architecture + cloud_services | 6 templates migrés |
+| **M6** | system_copy, vocabulaires, export bundle | Zéro contenu système dans `src/lib/**` sauf enums moteur |
+
+---
+
+## Lien stratégie non-tech
+
+| Besoin fondateur | Mécanisme admin |
+|------------------|-----------------|
+| « Je veux un doc comme Acme » | Template projet publié |
+| « J’ajoute Auth0 » | Brique/variant admin déjà à jour → wizard |
+| « Mon PDF a une section operations » | Section bibliothèque incluse dans template |
+| Pas de formulaire CAF | Sections gated sans `[…]` ; absent si pas de signal |
+
+L’inférence tech → tags devient **fallback** pour projets custom sans template — pas le chemin principal.
+
+---
+
+## Sécurité & déploiement
+
+| Topic | v1 |
+|-------|-----|
+| Auth admin | Route cachée + token local / env `ADMIN_TOKEN` |
+| Multi-user | Non — single operator |
+| Audit trail | `admin_audit_log` : who, what, version, timestamp |
+| Remote | Export bundle ; pas de sync cloud obligatoire |
+
+---
+
+## ISCs candidats (à formaliser en ISA dédiée)
+
+| ID | Probe |
+|----|-------|
+| ISC-A1 | Publier brouillon brique `identity` avec nouveau `purpose.fr` → API catalogue renvoie la valeur sans redeploy |
+| ISC-A2 | Créer template projet depuis admin → picker affiche → `createProject` produit 22 composants |
+| ISC-A3 | Éditer section `add-iam` dans admin → PDF gated Auth0 utilise le nouveau titre |
+| ISC-A4 | Éditer hint step `auth` du flow `auth-login` → `countMappableSteps` mis à jour |
+| ISC-A5 | Publish invalidé si variant pointe vers brique absente |
+| ISC-A6 | Template Acme admin vs seed : outline slim + 4 sections auteur équivalentes |
+| Anti | Admin n’expose pas `projects.data` en CRUD |
+| Anti | Publish ne modifie pas rétroactivement les tags snapshottés sur composants existants |
+
+---
+
+## Décisions proposées
+
+| ID | Décision |
+|----|----------|
+| AD1 | **Tout contenu système** passe par admin publish — objectif M6 |
+| AD2 | **Templates projet** avant templates architecture (Acme first) |
+| AD3 | Catalogue Lego : étendre SQLite, ne plus relire `CATALOG_SEED.concernTags` depuis TS |
+| AD4 | Flow patterns : 8 ids v1 locked ; contenu éditable, pas d’ajout id sans ISA |
+| AD5 | Enums moteur (`ConcernTag`, section types) restent code ; admin configure dans l’enum |
+| AD6 | Un bundle export/import = unité de backup et de transfert entre machines |
+
+---
+
+## Suite
+
+1. ~~**Figer** ce doc en ISA `archstudio-admin-cms` (E3).~~ **Done** → [`ISA-archstudio-admin-cms.md`](./ISA-archstudio-admin-cms.md).
+2. **UX/UI** — spec écrans, flows, anti-patterns : [`RESEARCH-admin-cms-ux.md`](./RESEARCH-admin-cms-ux.md) (Standard Research, 2026-08-18).
+3. **M0** — schéma + import script — seulement après ISA LOCKED.
+4. Premier contenu admin = **template Acme** ([`CONTRAT-qualite-acme.md`](./CONTRAT-qualite-acme.md)).
+
+Ce document est le contrat CMS. Le code admin vient après.

--- a/docs/add/CONTRAT-qualite-acme.md
+++ b/docs/add/CONTRAT-qualite-acme.md
@@ -1,0 +1,178 @@
+# Contrat qualité ADD — barre Acme
+
+- Date : 2026-08-18
+- Session LifeOS : `082ba078-2ccd-4291-b2d2-a5cf77b7b769`
+- Statut : **LOCKED** — qualité publish référencée par [`ISA-archstudio-admin-cms.md`](./ISA-archstudio-admin-cms.md) ISC-Q1–Q3
+- Amont : [`RESEARCH.md`](./RESEARCH.md) (kit slim, zéro théâtre `[…]`) · [`RESEARCH-brick-metadata.md`](./RESEARCH-brick-metadata.md) (gating par `concernTags`) · ISA `20260817-archstudio-brick-metadata` **complete**
+- Objectif principal (verbatim) : *« Même si c'est écrit j'aimerai que l'objectif qu'on [ait] quelque chose de cette qualité tout soit remplit »*
+
+Acme (`src/lib/seed/demo.json`, projet seed « Acme — two platforms ») n’est **pas** un cas à ignorer parce qu’il est déjà rédigé. C’est la **barre de qualité** : un ADD qu’on peut imprimer et lire. Tout chemin (catalogue Lego, import, architecture tapée à la main) doit viser cette densité, pas un classeur CAF troué.
+
+---
+
+## Ce que « qualité Acme » veut dire
+
+Acme n’est pas « 13 chapitres CAF + une intro ». C’est un dossier **lu en une heure**, dont chaque page ouverte contient des faits du canvas.
+
+### Anatomie du seed (vérité mesurée)
+
+| Couche | Ce qu’Acme a vraiment | Qualité |
+|--------|------------------------|---------|
+| Méta | `intro`, `principle`, facts, kicker, title | Phrase de thèse, pas un titre vide |
+| Canvas | 22 composants, chacun avec `role` + `features[]` (+ parfois `notes`) + `tech[]` | Carte produit, pas un cube anonyme |
+| Slim généré | Contexte, inventaire, 2 flux, glossaire, stack | Déjà là via le toolkit |
+| Éditorial auteur | 4 sections : compare plateformes, operations (cartes), roadmap 12 semaines, risques | Prose réelle, puces concrètes, noms de technos en gras |
+| CAF gated | **0** — aucun `brick` / `concernTags` | Le seed n’emprunte pas le chemin Lego |
+
+Exemple densité (operations) — c’est le plancher, pas le plafond :
+
+- **Hosting & containers** — VMs dédiées, Docker sur chaque service applicatif, volumes persistants pour bases et cache.
+- **Authentication & API** — OAuth2 / JWT, rotation des clés, MFA optionnel, rate limit, signatures webhook, CORS strict.
+- **Data & compliance** — chiffrement repos/transit, masquage PII dans les logs, secrets via env, audit logs.
+- **Observability & SRE** — logs centralisés, `traceId`, latence / error rate / profondeur de file, alerting SLA.
+
+Une carte Acme = **titre métier + 2–4 puces qui citent le canvas**. Pas « Composants concernés » suivi d’une liste à plat. Pas `[…]`. Pas « À estimer ».
+
+### Ce que « tout soit rempli » veut dire
+
+**Rempli** = chaque chapitre **présent** dans le PDF a un corps utilisable, composé depuis des faits déjà sur le canvas (nom, rôle/purpose, features, notes, tech, liens, groupes).
+
+**Rempli n’est pas** :
+
+- ouvrir les 13 tiroirs CAF par défaut ;
+- inventer une roadmap 12 semaines, une équipe N2, ou des risques RH que le diagramme ne porte pas ;
+- coller le template CAF et laisser des trous « à compléter plus tard » ;
+- écraser une section déjà écrite (les 4 chapitres Acme restent l’œuvre de l’auteur).
+
+Aligné sur [`RESEARCH.md`](./RESEARCH.md) : *section absente > section vide* (arc42 FAQ B-1). Le théâtre de complétude est un échec, pas un objectif.
+
+---
+
+## Écart actuel (pourquoi Acme « écrit » ne prouve pas le produit)
+
+Le chemin Lego (ISA brick-metadata) marche **seulement** si le composant a `brick` ou `concernTags`. Acme n’en a aucun : `role` est de la prose (« Transactional store of the consumer platform. »), `tech` est du produit (`PostgreSQL`, `Traefik`, `GitHub Actions`).
+
+Conséquence :
+
+| Chemin | PDF aujourd’hui |
+|--------|-----------------|
+| Acme seed, tel quel | Slim + 4 sections auteur. Qualité haute. **0** chapitre CAF, alors que le canvas *justifie* data, IAM/OAuth, réseau, obs, CI/CD. |
+| Pose Lego (Auth0, Postgres) | Chapitres gated hydratés. Souvent une carte fourre-tout « Composants concernés », ou un tableau Data avec « À estimer ». En-dessous de la barre. |
+| Projet tapé à la main (comme Acme) | Même aveuglement que le seed : pas de tags → pas de gates → CAF absent, même si PostgreSQL et OAuth2 sont écrits sur les cartes. |
+
+Le produit vend « pose le diagramme → le document se remplit ». Tant qu’un Acme écrit ne déclenche pas des chapitres **justifiés et remplis**, l’objectif n’est pas tenu — *même si* le seed est déjà beau.
+
+---
+
+## Barre d’acceptation (à figer en ISC)
+
+Un ADD atteint la barre Acme quand **toutes** les conditions suivantes sont vraies.
+
+### B1 — Pas de trou affiché
+
+Aucun chapitre persisté (gated ou auteur) ne contient `[…]`, « À estimer », « To be estimated », ni un paragraphe template dont le lecteur voit qu’il n’a pas été écrit.
+
+### B2 — Densité carte = Acme operations
+
+Un chapitre gated de type cartes n’est **pas** un dump unique « Composants concernés ». C’est **une carte par composant concerné** (ou par famille clairement nommée), avec :
+
+1. le **nom** du composant comme titre ;
+2. le `role` / `purpose` **auteur** en première puce (la prose Acme gagne sur la phrase catalogue générique) ;
+3. les `features[]` et `notes[]` déjà sur la carte ;
+4. une ligne technologies si `tech[]` n’est pas vide.
+
+S’il n’y a rien de tout ça, le chapitre **n’existe pas** — on n’ouvre pas une coquille.
+
+### B3 — Data = les stores du canvas, pas une famille fantôme
+
+Le chapitre Data, s’il s’ouvre, a **une ligne par store réellement présent** (les deux PostgreSQL Acme restent deux lignes : consumer vs business). La colonne volume/croissance n’invente pas un chiffre : elle reprend une note, sinon les technos. Pas de « À estimer ».
+
+### B4 — L’écrit compte autant que le Lego
+
+Un composant **sans** `brick` ouvre quand même les gates **justifiées** par ce qui est déjà écrit (`tech[]`, nom, éventuellement couche). Exemples Acme attendus après inférence *conservatrice* :
+
+| Composant | Signal | Brique / tags | Ne pas faire |
+|-----------|--------|----------------|--------------|
+| PostgreSQL — consumer/business | tech `PostgreSQL`, layer `data` | `sql` → `data`, `dr` | Fusionner les deux bases |
+| Redis — cache & queues | tech `Redis`, layer `data` | `cache` → `data` | — |
+| Object storage | tech `S3-compatible`, layer `data` | `objects` → `data` | — |
+| Reverse proxy | tech `Traefik` | `apiGateway` → `network`, `security` | En faire un IdP |
+| CI / CD | tech `GitHub Actions` | `cicd` → `ops` | — |
+| Observability | tech `Loki`, `Prometheus` | `observability` | — |
+| Consumer mobile | tech `React Native` | `mobileApp` → `network` | — |
+| Business portal | tech `Next.js` | `webApp` → `network` | — |
+| Headless CMS | tech `Directus` + `PostgreSQL`, layer **services** | **pas** `sql` | Voler la brique « base » à un back-office |
+| Public API | tech `OAuth2` | tag `iam` **sans** changer la brique | Inventer un Auth0 absent du canvas |
+| CRM, payments, maps, warehouse | pas de variant catalogue | aucun tag inventé | Forcer un chapitre |
+
+### B5 — L’auteur reste l’auteur
+
+`normalize` / sync gated :
+
+- n’écrase **jamais** `role`, `features`, `notes` déjà remplis ;
+- ne pose `purpose` catalogue que si `purpose` **et** `role` sont vides (sinon la phrase générique masquerait la prose Acme) ;
+- n’adopte pas une section auteur (`platforms`, `operations`, `roadmap`, `risks`) comme chapitre gated ;
+- au save, ne ré-hydrate pas un chapitre gated que l’humain a édité.
+
+### B6 — Slim toujours là, CAF seulement justifié
+
+Le défaut imprimable reste le kit slim (contexte, schéma, inventaire, parcours, glossaire, stack). Les chapitres CAF s’ajoutent **uniquement** si B4 a un signal **et** B2/B3 peuvent produire un corps. Acme après contrat : 4 sections auteur **plus** data / réseau / IAM (OAuth2 + bordure) / obs / CI-CD **remplis depuis les cartes existantes**, pas un second operations fantôme vide.
+
+---
+
+## Interdit (anti-vision)
+
+| Interdit | Pourquoi |
+|----------|----------|
+| Dump des 13 CAF vides ou semi-vides | [`RESEARCH.md`](./RESEARCH.md) — théâtre de complétude |
+| Inventer roadmap, staffing, risques RH, enveloppe € | Le canvas Acme le fait *parce que c’est un seed démo* ; un projet réel n’a pas ces faits |
+| Inférer `sql` dès que `PostgreSQL` apparaît sur un CMS / API | Fausse brique, faux chapitre, prose catalogue à la place du métier |
+| Inférer `identity` depuis `JWT` sur une API publique | L’API n’est pas l’IdP ; Acme n’a pas de composant Auth0 |
+| Remplacer operations auteur par un `add-iam` template Human/Machine/Secrets | On empile, on n’écrase pas |
+| Remplir un trou par « TBD » localisé | Même échec que `[…]` |
+| Wizard besoins, templates produit, éditeur ADR, € / brique | ISA #3 / #4 / dette — hors de **ce** contrat |
+
+---
+
+## Décisions proposées (à LOCKED en ISA, pas encore code)
+
+| ID | Décision | Défaut raisonné |
+|----|----------|-----------------|
+| D1 | Inférer `brick` + `concernTags` depuis `tech[]` et le nom, via les **labels de variants** du catalogue, seulement si `brick` est absent | Oui — c’est le seul levier pour les architectures « écrites » |
+| D2 | Garde-fou couche : une brique dont le catalogue vit en `data` ne s’infère que si le composant est en layer `data` | Oui — protège le CMS Acme |
+| D3 | Tags extra **sans** changer la brique : `OAuth2` / `OIDC` / `SAML` → `iam` | Oui — Public API Acme ouvre IAM avec *sa* prose |
+| D4 | Corps gated = cartes (ou lignes) **par composant**, densité operations Acme | Oui — abandon du dump « Composants concernés » et des hydrators CAF troués comme chemin par défaut |
+| D5 | Intro / principle : ne pas générer de fiction. Si vides, on peut *au plus* une phrase de constat (N composants, M scopes) — pas une thèse produit | Conservateur — Acme a déjà les siens |
+| D6 | Roadmap / risques / compare plateformes : **jamais** auto-générés dans cette ISA | Hors faits canvas ; restent sections auteur ou templates produit (ISA #3) |
+
+---
+
+## Falsifiers (ce qui prouverait que le contrat a échoué)
+
+1. Après `normalize` du `demo.json`, le PDF **perd** platforms / operations / roadmap / risks, ou leur titre/corps a changé.
+2. Après `normalize` du `demo.json`, un chapitre gated contient `[…]` ou « À estimer ».
+3. Le CMS Acme (`Directus` + `PostgreSQL`, layer services) a `brick === 'sql'`.
+4. Un projet Auth0-only (déjà gated IAM) régresse : trou `[…]` ou carte fourre-tout à la place des faits Auth0.
+5. Un projet sans aucun store / IdP / proxy **gagne** quand même 13 chapitres CAF.
+
+Preuve positive minimale : `normalize(demo.json)` → tags sur Postgres/Redis/Traefik/CI/obs ; chapitres gated **remplis** citant les noms Acme (« PostgreSQL — consumer », « Traefik », « GitHub Actions ») ; les 4 sections auteur intactes.
+
+---
+
+## Hors ce contrat (inchangé)
+
+- ISA #3 — templates produit (site, app) qui *écrivent* un compare / une roadmap quand le template le sait.
+- ISA #4 — wizard besoins (multi-tenant, PII, budget).
+- Éditeur ADR, FinOps montants, sanitization HTML globale de `rich()`.
+- Réécrire le seed Acme pour y coller des `brick` à la main — ça tricherait la preuve B4.
+
+---
+
+## Suite
+
+1. ~~**Figer** ce contrat en ISA (Goal + ISC calqués sur B1–B6 / D1–D6 / falsifiers). Pas de code avant.~~ **Done** — ISC-Q1–Q3 dans ISA admin CMS.
+2. **Admin CMS** — templates Acme et catalogue éditables : [`ADMIN-CMS.md`](./ADMIN-CMS.md).
+3. Ensuite : tests rouges + hydratation **ou** migration admin M2 (templates projet first).
+4. Vérifier sur trois documents : Acme seed, Auth0-only, projet CAF manuel encore plein de `[…]`.
+
+Ce fichier est le cahier des charges qualité. L’admin CMS est le levier de livraison. Le code vient après ISA LOCKED.

--- a/docs/add/DESIGN-admin-shell.md
+++ b/docs/add/DESIGN-admin-shell.md
@@ -1,0 +1,484 @@
+# Design brief — Admin CMS shell (F-UX0)
+
+- **ISA :** [`ISA-archstudio-admin-cms-ux.md`](./ISA-archstudio-admin-cms-ux.md) (LOCKED)
+- **Recherche :** [`RESEARCH-admin-cms-ux.md`](./RESEARCH-admin-cms-ux.md)
+- **Date :** 2026-08-18
+- **Auteur :** Designer (Aditi Sharma)
+- **Handoff :** Engineer / Forge — F-UX1 → F-UX7
+
+---
+
+## Aesthetic direction
+
+**Tone :** Atelier opérateur — même identité que l’éditeur projet, surface orientée contenu système.
+
+| Couche | Valeur |
+|--------|--------|
+| Fond calque | `--bg` `#EEF3F6` |
+| Surfaces | `--panel`, `--panel-2`, `--panel-3` |
+| Action / sélection | `--brand` `#0E7C8A` |
+| Typo prose | Archivo (`--sans`) |
+| Typo machine | Space Mono (`--mono`) — ids, counts, badges, timestamps |
+| Rayon | `--r: 0px` partout |
+| Marque | `Lockup` `sub="Content"` — mono, `--ink-3` |
+
+**Différenciation mémorable :** l’opérateur ne quitte jamais l’Atelier — seule la nav latérale change (entités CMS vs dossiers projets). Split-pane fiche entité = inspecteur projet élargi + preview papier réelle.
+
+**Framework :** Next.js App Router · React · CSS tokens `globals.css` uniquement.
+
+---
+
+## 1. Component map
+
+Réutiliser tel quel — **aucun nouveau design system**, pas de feuille CSS admin >50 lignes hors scoping layout.
+
+### Shell & layout
+
+| Rôle | Classe CSS | Composant / pattern source |
+|------|------------|----------------------------|
+| Racine flex full-height | `.shell` | `Workspace.tsx`, `Editor.tsx` |
+| Colonne nav gauche | `.sidebar`, `.sidebar-head`, `.sidebar-scroll`, `.sidebar-foot` | `Workspace.tsx` |
+| Zone principale (colonne droite) | `.admin-main` *(nouveau wrapper minimal — flex column, flex:1, overflow:hidden)* | dérivé `.editor` |
+| Barre d’actions | `.topbar`, `.topbar .name` | `Editor.tsx` |
+| Corps scrollable liste | `.workspace`, `.ws-head`, `.ws-body` | `Workspace.tsx` |
+| Corps split entité | `.editor-body` | `Editor.tsx` — panneau form + panneau preview |
+| Panneau formulaire (60 %) | `.content-main` + `.cpanel` | `ContentEditor.tsx`, `Fields.tsx` `Panel` |
+| Panneau preview (40 %) | `.inspector` + `.previewframe` | `Editor.tsx` `PreviewPane`, `Inspector.tsx` |
+| Rail secondaire (onglets template) | `.content-rail`, `.railitem` | `ContentEditor.tsx` |
+| Séparateur | `.insp-sep` | `Inspector.tsx` |
+
+### Navigation sidebar
+
+| Rôle | Classe CSS | Composant source |
+|------|------------|------------------|
+| Entrée nav | `.tree-row`, `.tree-row.active`, `.tree-row .ficon`, `.tree-row .label`, `.tree-row .count` | `Workspace.tsx` `ScopeRow` |
+| Groupe nav | `.sect-label`, `.sect-label .spacer` | `Workspace.tsx`, `Editor.tsx` palette |
+| Sous-nav catalogue | `.tree-row` indent `paddingLeft: 8 + depth * 14` | `Workspace.tsx` `FolderBranch` |
+| Lockup | `.sidebar-head` + `Lockup` | `Brand.tsx`, `Workspace.tsx` |
+| Pied sidebar | `.footbtn`, `.iconbtn` (thème) | `Workspace.tsx` |
+
+### Topbar
+
+| Rôle | Classe CSS | Pattern source |
+|------|------------|----------------|
+| Retour workspace | `.iconbtn` + `Icon name="back"` | `Editor.tsx` |
+| Titre entité / breadcrumb | `.topbar .name` (readonly ou éditable) | `Editor.tsx` |
+| État save | `.saveflag`, `.saveflag.dirty`, `.saveflag.error` | `Editor.tsx` `SaveFlag` |
+| Switch locale EN/FR | `.segmented` + `button[aria-pressed]` | `Editor.tsx` mode switch ; `Workspace.tsx` `NewProjectDialog` |
+| Actions primaires | `.btn`, `.btn.primary`, `.btn.sm`, `.btn.ghost` | partout |
+| Spacer flex | `style={{ flex: 1 }}` | `Editor.tsx` |
+
+### Formulaires & listes
+
+| Rôle | Classe / composant | Source |
+|------|-------------------|--------|
+| Champs | `.field`, `.input`, `.textarea`, `.select`, `.hint` | `globals.css`, `Fields.tsx` |
+| Primitives React | `Text`, `Area`, `Choice`, `StringList`, `CellGrid`, `CardList`, `IconPicker`, `Panel`, `Group` | `Fields.tsx` |
+| Grille entités | `.pgrid`, `.pcard` | `Workspace.tsx` |
+| Liste vide (texte seul) | `.empty` | `globals.css` — **pas d’illustration** |
+| Liste expandable | `.elist`, `.elist-head`, `.elist-body`, `.cardlist` | `Fields.tsx` |
+| Tags / concernTags | `.chiprow`, `.tagchip` | `globals.css` |
+| Alerte validation | `.warnbox` | `globals.css` |
+| Drawer blocks | `.modal-scrim`, `.modal.wide` | `Workspace.tsx` dialogs |
+| Stepper wizard | `.flowmap`, `.flowmap-row`, `.flowmap-row > .n` | `globals.css` (vertical) |
+| Diff résumé publish | `.hist`, `.histrow`, `.diffrow`, `.dkind` | `globals.css` |
+| Recherche liste | `.ws-search`, `.ws-search input` | `Workspace.tsx` |
+
+### Icônes & marque
+
+| Rôle | Source |
+|------|--------|
+| Toutes les icônes nav / actions | `Icon.tsx` — stroke SVG 24×24 |
+| Lockup admin | `Brand.tsx` → `<Lockup size={26} sub="Content" />` |
+
+### Badges publish (Draft / Modified / Published)
+
+**`.pill` n’existe pas dans `globals.css`** (présent seulement dans `viewer/style.css`). Deux options Engineer — choisir **B** par défaut :
+
+| Option | Implémentation |
+|--------|----------------|
+| A | Porter `.pill` viewer → `globals.css` (~6 lignes, mêmes tokens) |
+| **B (défaut)** | `<span className="btn sm">` non-cliquable (`role="status"`) avec modificateurs : |
+
+```tsx
+// Draft — neutre
+<span className="btn sm" role="status">Draft</span>
+
+// Modified — teal (aligné saveflag.dirty)
+<span className="btn sm" role="status" style={{ borderColor: 'var(--brand)', color: 'var(--brand-ink)' }}>Modified</span>
+
+// Published — ok
+<span className="btn sm" role="status" style={{ borderColor: 'var(--ok)', color: 'var(--ok)' }}>Published</span>
+```
+
+Alternative compacte listes : classe `.count` existante + couleur inline pour Published/Modified.
+
+---
+
+## 2. Wireframes ASCII
+
+### 2.1 Layout shell
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ .shell (100vh, flex row)                                                    │
+├──────────────┬──────────────────────────────────────────────────────────────┤
+│ .sidebar     │ .admin-main (flex:1, flex-col, overflow:hidden)              │
+│ 268px        │ ┌──────────────────────────────────────────────────────────┐ │
+│ --panel-2    │ │ .topbar 56px — back · titre · saveflag · locale · actions│ │
+│              │ ├──────────────────────────────────────────────────────────┤ │
+│ [Lockup      │ │ .admin-body (flex:1, overflow)                           │ │
+│  Content]    │ │   → liste (.workspace) OU split (.editor-body) OU wizard │ │
+│              │ └──────────────────────────────────────────────────────────┘ │
+│ nav scroll   │                                                              │
+│              │                                                              │
+│ .sidebar-foot│                                                              │
+│ theme·note   │                                                              │
+└──────────────┴──────────────────────────────────────────────────────────────┘
+```
+
+**Diff vs Workspace :** même sidebar ; la zone droite ajoute une `.topbar` permanente (Editor pattern) au lieu d’un seul `.ws-head`.
+
+**Diff vs Editor :** admin **a** une sidebar CMS ; l’éditeur projet n’en a pas.
+
+---
+
+### 2.2 Nav sidebar — 4 piliers + Publish + Import + Locale
+
+```
+┌─ .sidebar-head ─────────────────┐
+│ [Mark] ArchStudio               │
+│        Content          (mono)  │
+└─────────────────────────────────┘
+┌─ .sidebar-scroll ───────────────┐
+│                                 │
+│  .tree-row*     Dashboard       │  → /admin
+│                                 │
+│  ── .sect-label: Content ──     │
+│  .tree-row      Templates       │  → /admin/templates
+│  .tree-row      Catalogue Lego  │  → /admin/catalog  (hub .pgrid .pcard)
+│    └ .tree-row    Briques       │  → /admin/catalog/bricks
+│    └ .tree-row    Scopes        │  → /admin/catalog/scopes
+│    └ .tree-row    Intents       │  → /admin/catalog/intents
+│    └ .tree-row    Variants      │  → /admin/catalog/variants
+│    └ .tree-row    Dependencies  │  → /admin/catalog/dependencies
+│    └ .tree-row    Technologies  │  → /admin/catalog/technologies
+│  .tree-row      Bibliothèque ADD│  → /admin/sections
+│  .tree-row      Flow patterns   │  → /admin/flows
+│                                 │
+│  ── .sect-label: Operations ──  │
+│  .tree-row      Publish         │  → /admin/publish
+│  .tree-row      Import / Export │  → /admin/import
+│  .tree-row      Localisation    │  → /admin/locale
+│                                 │
+└─────────────────────────────────┘
+┌─ .sidebar-foot ─────────────────┐
+│ [moon]  Self-hosted · seed CMS  │
+└─────────────────────────────────┘
+```
+
+**Icônes `Icon` suggérées :**
+
+| Entrée | `Icon` name |
+|--------|-------------|
+| Dashboard | `grid` |
+| Templates | `file` |
+| Catalogue | `cube` |
+| Briques | `box` |
+| Scopes | `map` |
+| Variants | `layers` |
+| Intents | `route` |
+| Dependencies | `link` |
+| Technologies | `terminal` |
+| ADD Sections | `folder` |
+| Flows | `route` |
+| Publish | `upload` |
+| Import | `download` |
+| Locale | `globe` ou `cog` si `globe` absent |
+
+**Active state :** `.tree-row.active` sur route courante ; sous-items catalogue indentés comme `FolderBranch`.
+
+---
+
+### 2.3 Topbar
+
+```
+┌─ .topbar ────────────────────────────────────────────────────────────────────┐
+│ [←]  identity-auth0          [● Editing…]     │ EN │ FR │   [Validate][Publish]│
+│ iconbtn  .name / breadcrumb    .saveflag      .segmented      .btn .primary   │
+└──────────────────────────────────────────────────────────────────────────────┘
+        ↑ flex:1 spacer entre saveflag et locale sur pages liste
+```
+
+**Pages liste** (dashboard, templates index, catalog index) :
+
+```
+┌─ .topbar ────────────────────────────────────────────────────────────────────┐
+│ [←]  Templates               │ EN │ FR │              [+ New] [Import JSON]   │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Règle chrome title (HARD — post-close coherence 2026-08-20) :**
+
+| Couche | Rôle | Ne pas |
+|--------|------|--------|
+| `.topbar .name` | **Seul** titre H1-level de l’écran (nav section ou id entité) | Répéter la même chaîne en `<h1>` / `.ws-head-title` dans le body |
+| `AdminPageHeader` / `AdminWorkspace` | Toolbar body : lede + search + actions (PublishBadge, Create) | Prop `title` / `<h1>` |
+| Fiche split (`CatalogSplitShell`, `TemplateEditorShell` `.cpanel-head h2`) | Titre **entité** local au panneau form (id/label édité) — distinct du chrome section | Dupliquer le label section topbar |
+
+**Choix :** Topbar owns the page title. Body never competes.
+
+**Règles :**
+
+- `[←]` → `/` (workspace fondateur) — **pas** de lien `/admin` depuis Workspace/Editor (ISC-UX4).
+- Locale switcher **toujours** visible — voir §6. Layout topbar écrit `admin-locale` + event `admin-locale` ; `useAdminLocale` écoute storage + event (pas seulement `focus`).
+- Pas de segmented Diagram/Content/Preview — réservé à l’éditeur projet.
+
+---
+
+### 2.4 Split-pane — fiche entité (stub brique)
+
+```
+┌─ .editor-body ───────────────────────────────────────────────────────────────┐
+│ ┌─ .content-main (60%) ─────────────┐ ┌─ .inspector (40%) ────────────────┐ │
+│ │ .cpanel-head                      │ │ .sub mono  identity-auth0         │ │
+│ │  identity-auth0    [Modified]     │ │ h3 Preview                        │ │
+│ │  [Validate][Draft][Publish]       │ │ ┌─────────────────────────────┐   │ │
+│ ├───────────────────────────────────┤ │ │ .previewframe (iframe)      │   │ │
+│ │ .cgroup: Metadata                 │ │ │  tuile wizard + glossaire   │   │ │
+│ │  IconPicker · layer · scope       │ │ └─────────────────────────────┘   │ │
+│ │  concernTags (.tagchip)           │ │                                   │ │
+│ │ .cgroup: Content                  │ │ [EN|FR] segmented (preview only)  │ │
+│ │  tabs EN | FR inline (.segmented) │ │                                   │ │
+│ │  Area purpose · role · features   │ │                                   │ │
+│ │ .insp-sep                         │ │                                   │ │
+│ │ ▾ Avancé (.elist collapsed)       │ │                                   │ │
+│ │  textarea JSON (.textarea mono)   │ │                                   │ │
+│ └───────────────────────────────────┘ └───────────────────────────────────┘ │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Stub v1 :** form champs placeholder + iframe preview vide ou seed statique ; data branchée F-UX3.
+
+**Template editor :** remplacer split par `.content-body` — `.content-rail` onglets Métadonnée · Canvas · Flows · Sections · Preview (RESEARCH UX5b).
+
+---
+
+### 2.5 Publish wizard — 4 étapes
+
+Page pleine `.admin-body` — pas modal. Stepper vertical `.flowmap` :
+
+```
+┌─ Publish ──────────────────────────────────────────────────────────────────────┐
+│                                                                                │
+│  .flowmap                                                                      │
+│  ┌─ .flowmap-row ──────────────────────────────────────────────────────────┐  │
+│  │ 1 │ Scope                          [x] Catalogue  [ ] Templates  [ ] All │  │
+│  └─────────────────────────────────────────────────────────────────────────┘  │
+│  ┌─ .flowmap-row ──────────────────────────────────────────────────────────┐  │
+│  │ 2 │ Validation                     .warnbox if blocked                   │  │
+│  │   │  · purpose.fr missing → identity-auth0  (link → field)              │  │
+│  │   │  · orphan ref → variant-xyz           (link → field)              │  │
+│  └─────────────────────────────────────────────────────────────────────────┘  │
+│  ┌─ .flowmap-row ──────────────────────────────────────────────────────────┐  │
+│  │ 3 │ Summary diff                   .hist (list + diff pane)             │  │
+│  └─────────────────────────────────────────────────────────────────────────┘  │
+│  ┌─ .flowmap-row ──────────────────────────────────────────────────────────┐  │
+│  │ 4 │ Confirm                        [Cancel]  [Publish] (disabled si 2)  │  │
+│  └─────────────────────────────────────────────────────────────────────────┘  │
+│                                                                                │
+└────────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Comportement :** étape 2 **bloque** étape 4 si issues ; clic issue → navigate vers fiche entité + focus champ (query `?field=purpose.fr`).
+
+---
+
+## 3. Route table
+
+| Route | Page | Rôle v1 | Layout |
+|-------|------|---------|--------|
+| `/admin` | Dashboard | Liste issues publish uniquement — `.empty` si OK | shell + ws-head « Issues » |
+| `/admin/templates` | Templates index | Grille `.pgrid` templates seed | shell + liste |
+| `/admin/templates/[id]` | Template editor | Onglets rail + preview iframe | shell + content-body |
+| `/admin/catalog` | Catalogue hub | Hub cards `.pgrid` `.pcard` — counts + dirty badge once | shell + workspace |
+| `/admin/catalog/bricks` | Briques index | Liste `.tree-row` (icon + id + layer/scope) + filter | shell + workspace |
+| `/admin/catalog/bricks/[id]` | Fiche brique | Split 60/40 form + inspector | shell + editor-body |
+| `/admin/catalog/scopes` | Scopes | Liste + inspector `Text` EN/FR | shell + editor-body |
+| `/admin/catalog/intents` | Intents | Liste + inspector modes/shapes | shell + editor-body |
+| `/admin/catalog/intents/[id]` | Fiche intent | Split 60/40 (deep link) | shell + editor-body |
+| `/admin/catalog/variants` | Variants | Liste filtrée + inspector mapping | shell + editor-body |
+| `/admin/catalog/dependencies` | Dependencies | Liste + inspector edge | shell + editor-body |
+| `/admin/catalog/technologies` | Technologies | Liste + inspector copy EN/FR | shell + editor-body |
+| `/admin/sections` | ADD library | Liste sections + link edit | shell + liste |
+| `/admin/sections/[id]` | Section editor | Form + preview + JSON replié | shell + editor-body |
+| `/admin/flows` | Flow patterns | Liste + link edit | shell + liste |
+| `/admin/flows/[id]` | Flow editor | Stepper vertical stub | shell + content-main |
+| `/admin/publish` | Publish wizard | 4 steps | shell + wizard |
+| `/admin/import` | Import / Export | JSON bulk + export buttons | shell + cpanel |
+| `/admin/locale` | Localisation | Filtre champs `*.fr` manquants | shell + liste issues |
+
+**Next.js :** `src/app/admin/layout.tsx` wraps all ; pas de route `/admin` depuis `Workspace` / `Editor` (grep CI ISC-UX4).
+
+---
+
+## 4. File plan
+
+### `src/app/admin/`
+
+| File | Responsibility |
+|------|----------------|
+| `layout.tsx` | Client shell : `.shell` + `AdminSidebar` + `{children}` dans `.admin-main` ; charge locale context ; **pas** de data CMS v1 |
+| `page.tsx` | Dashboard — issues publish stub |
+| `templates/page.tsx` | Index templates — stub `.pgrid` |
+| `templates/[id]/page.tsx` | Template editor shell — tabs rail stub |
+| `catalog/page.tsx` | Hub cards `.pgrid` `.pcard` → listes entités |
+| `catalog/bricks/page.tsx` | Liste briques + filter `.ws-search` |
+| `catalog/bricks/[id]/page.tsx` | Fiche brique split |
+| `catalog/variants/page.tsx` | Stub |
+| `catalog/intents/page.tsx` | Stub |
+| `catalog/deps/page.tsx` | Stub |
+| `sections/page.tsx` | Bibliothèque ADD stub |
+| `sections/[id]/page.tsx` | Section editor stub |
+| `flows/page.tsx` | Flow patterns list stub |
+| `flows/[id]/page.tsx` | Flow editor stub |
+| `publish/page.tsx` | Wizard 4 steps UI |
+| `import/page.tsx` | Import/export JSON stub |
+| `locale/page.tsx` | Missing FR fields list stub |
+
+### `src/components/admin/`
+
+| File | Responsibility |
+|------|----------------|
+| `AdminShell.tsx` | Composant layout réutilisable : sidebar + topbar slot + body slot |
+| `AdminSidebar.tsx` | Nav `.tree-row` — 4 piliers + ops ; `Lockup sub="Content"` ; active route via `usePathname` |
+| `AdminTopbar.tsx` | Topbar : back, title, `SaveFlag`, `LocaleSwitcher`, actions slot |
+| `LocaleSwitcher.tsx` | `.segmented` EN/FR — context React `AdminLocale` |
+| `PublishBadge.tsx` | Draft / Modified / Published — `.btn.sm` pattern §1 |
+| `EntitySplitPane.tsx` | Wrapper `.editor-body` : form slot + preview iframe slot |
+| `PublishWizard.tsx` | 4-step wizard — `.flowmap` rows |
+| `IssueList.tsx` | Dashboard + wizard step 2 — `.warnbox` + liens cliquables |
+| `AdminEmpty.tsx` | Text-only empty — wraps `.empty`, **no illustration** |
+
+**Optional later (F-UX3+) :** `BrickForm.tsx`, `TemplateEditor.tsx`, `SectionEditor.tsx`, `BlocksDrawer.tsx` — hors F-UX1 shell.
+
+### CSS scoping
+
+Un seul fichier autorisé si nécessaire :
+
+| File | Max | Content |
+|------|-----|---------|
+| `src/app/admin/admin.css` | ≤50 lignes | `.admin-main`, split ratio `60/40`, wizard step spacing — **tokens only** |
+
+Import dans `layout.tsx` uniquement. Pas d’autre CSS admin.
+
+---
+
+## 5. Do-not list
+
+| Interdit | Raison |
+|----------|--------|
+| Emoji (U+1F300–U+1FAFF) dans DOM `/admin` | ISC-UX11 |
+| shadcn / Radix UI / Lucide / Heroicons | ISC-UX12 |
+| `rounded-xl`, glassmorphism, gradients violet/bleu | UX12, anti AI-slop |
+| Empty states illustrés / mascot | RESEARCH anti-patterns |
+| Dashboard KPI vanity sans issues | Anti ISC-UX-A2 |
+| Nav icon-only colorée type Notion | RESEARCH |
+| Palette primaire ≠ teal `--brand` | Atelier identity |
+| Lien `/admin` depuis Workspace ou Editor | ISC-UX4 |
+| JSON textarea comme éditeur principal | UX3 — replié sous « Avancé » |
+| Champs CMDB (owner, cost, SLO) | Out of scope |
+| Dark mode admin séparé | Même `html[data-theme]` toggle sidebar-foot |
+| Nouveau logo / lockup admin | Bridge B3 — `Content` only |
+
+---
+
+## 6. Locale switcher — placement
+
+**Position :** `.topbar`, **après** `.saveflag` (si présent) et **avant** le spacer/actions droite.
+
+**Composant :** `LocaleSwitcher` — copie exacte du pattern `.segmented` :
+
+```tsx
+<div className="segmented" role="group" aria-label="Content locale">
+  <button aria-pressed={locale === 'en'} onClick={() => setLocale('en')}>EN</button>
+  <button aria-pressed={locale === 'fr'} onClick={() => setLocale('fr')}>FR</button>
+</div>
+```
+
+**Portée :**
+
+| Niveau | Comportement |
+|--------|--------------|
+| Global (topbar) | Filtre labels longs EN/FR sur fiches ; sync avec seed i18n |
+| Inline (fiche entité) | Second `.segmented` dans form pour champs bilingues courts — tabs EN \| FR |
+| Preview pane | Segmented EN/FR **preview only** — n’affecte pas le switcher global |
+| Page `/admin/locale` | Liste transversale champs FR manquants + action « Copier EN→FR » (btn `.sm`) |
+
+**Persistance v1 :** `localStorage` key `admin-locale` ; default `en`.
+
+**Sync (2026-08-20) :** layout topbar is source of write. After `setItem`, dispatch `window` event `admin-locale`. Consumers (`useAdminLocale`) re-read on that event, `storage`, and `focus` — avoids stale EN/FR labels when toggling without blur.
+
+---
+
+## 7. Badge states — Draft / Modified / Published
+
+Voir §1 Component map. Récap :
+
+| État | Visuel | Classe |
+|------|--------|--------|
+| Draft | Bord neutre, texte `--ink-2` | `.btn.sm` |
+| Modified | Bord `--brand`, texte `--brand-ink` | `.btn.sm` + inline |
+| Published | Bord `--ok`, texte `--ok` | `.btn.sm` + inline |
+
+**Placement :** `.cpanel-head` (fiche entité), colonne liste (optionnel `.count`), wizard step 3 diff.
+
+**Accessibilité :** `role="status"` + `aria-label="Publication state: Draft"` — pas de couleur seule (texte lisible).
+
+---
+
+## Verification checklist (Designer → Engineer)
+
+| Check | Méthode |
+|-------|---------|
+| Même typo / teal / bords carrés vs Editor | Screenshot côte à côte ISC-UX-A1 |
+| 0 emoji admin DOM | `rg` U+1F300 |
+| 0 imports shadcn/lucide | `rg` `src/app/admin` |
+| Lockup `Content` | visuel sidebar-head |
+| Locale topbar visible toutes routes | Interceptor |
+| Wizard bloqué si issues | integration test |
+| CSS admin ≤50 lignes | `wc -l admin.css` |
+
+---
+
+## Engineer handoff — séquence
+
+1. **F-UX1** — `layout.tsx` + `AdminShell` + `AdminSidebar` + `AdminTopbar` + `LocaleSwitcher` + stub `/admin`
+2. **F-UX2** — routes stub parallèles (table §3)
+3. **F-UX3** — `EntitySplitPane` + `BrickForm` sur `/admin/catalog/bricks/[id]`
+4. **F-UX4** — template tabs rail
+5. **F-UX6** — `PublishWizard` + `IssueList` + `PublishBadge`
+6. **F-UX7** — Webdesign IntegrateIntoApp + Interceptor parity
+
+**Référence code prioritaire :** `Workspace.tsx` (sidebar) + `Editor.tsx` (topbar, split, preview) + `Fields.tsx` (forms).
+
+---
+
+## 8. Catalogue Lego — form map (F-UX3 étendu + CRUD)
+
+**Aesthetic :** Atelier opérateur (pas éditorial) — fond `--bg` `#EEF3F6`, accent `--brand` `#0E7C8A`, Archivo + Space Mono, `--r: 0`. Split liste / inspecteur `Panel`+`Group` ; Create via `.modal-scrim` / `.modal` (même chrome que `NewFlowDialog`).
+
+| Surface | Composants | CRUD |
+|---------|------------|------|
+| Hub `/admin/catalog` | `.pgrid` `.pcard` + `PublishBadge` + hints | — |
+| Briques liste | `AdminWorkspace` + `NewBrickDialog` | Create → fiche ; Delete sur fiche |
+| Briques `[id]` | `BrickEditor` 60/40 + `BrickPreviewPane` + `PublishBadge` | Update + Delete (cascade variants/deps ; seed re-seed via `ensureLegoCatalog`) |
+| Scopes / Intents / Variants / Dependencies / Technologies | `CatalogSplitShell` + `CatalogTreeRow` + `CatalogInspector` + `CatalogFormGroup` + `ModeChips` + `New*Dialog` | Create + Update + Delete end-to-end |
+| Form primitives | `Fields.tsx` (`Text`, `Area`, `Choice`, `IconPicker`, `Panel`, `Group`) | — |
+| Dialogs Create | `NewCatalogDialogs.tsx` | POST wired |
+| Client API | `catalog-entities.ts` | `fetch*` / `create*` / `patch*` / `delete*` |
+| Server | `admin-catalog.ts` + routes `POST`/`DELETE` | Locked seed ids: `isLocked*` ; delete allowed, re-seed on next `ensureLegoCatalog` |
+
+**Deferred (UX9) :** dependency graph viz, drag reorder, diff restore — not in this form map.
+
+**Smoke :** `http://127.0.0.1:3000/admin/catalog` → chaque entité → New → Save → Delete (custom) ; seed delete disparaît puis revient après reload/`ensure`.

--- a/docs/add/ISA-archstudio-admin-cms-ux.md
+++ b/docs/add/ISA-archstudio-admin-cms-ux.md
@@ -1,0 +1,198 @@
+---
+task: "Admin CMS UI — même chrome ArchStudio, écrans typés"
+slug: archstudio-admin-cms-ux
+project: ArchStudio
+effort: E3
+effort_source: explicit
+phase: complete
+status: complete
+progress: 12/18
+mode: interactive
+started: 2026-08-18T02:30:00Z
+updated: 2026-08-20T20:05:00Z
+parent: archstudio-admin-cms
+principal_stated_goal: "Fige ISA on a des subagent design et des skill design pour UI ne l'oublie pas"
+principal_stated_goal_source: prompt
+principal_stated_goal_signal: 2
+principal_stated_goal_locked: 2026-08-18T02:30:00Z
+context_sufficient: true
+interview_invoked: false
+---
+
+## Problem
+
+La recherche UX admin ([`RESEARCH-admin-cms-ux.md`](./RESEARCH-admin-cms-ux.md)) a tranché : nav simple v1, fiches entité riches, JSON en repli. Sans ISA figée, l’implémentation risque un panneau CMS générique (shadcn, emoji, gradients « AI dashboard ») **visuellement disjoint** de l’éditeur ArchStudio — exactement ce que le principal refuse. Les skills et agents design existent ; ils doivent être **routés**, pas contournés.
+
+## Vision
+
+`/admin` est reconnu comme **le même Atelier** que `Editor` et `Workspace` : Archivo + Space Mono, teal `--brand`, bords carrés, `Icon` stroke SVG, formulaires `Fields.tsx`. L’opérateur édite une brique ou un template Acme en split-pane (form + preview papier) ; publish wizard bloque avec issues cliquables. Euphorie : corriger `purpose.fr` Auth0 en <2 min sans IDE, en UI indiscernable de l’inspecteur projet.
+
+## Out of Scope
+
+- Nouveau design system admin (tokens, composants, lib UI tierce)
+- Emoji, Lucide, shadcn, Heroicons, empty states illustrés / mascot
+- Graphe deps interactif, canvas drag template, diff restore — **v2** (UX9)
+- Live preview keystroke sync — v2 ; v1 = onglet preview iframe
+- Dashboard KPI vanity sans issues publish
+- Champs CMDB (owner, cost, SLO)
+- CRUD contenu / validation métier — parent [`ISA-archstudio-admin-cms.md`](./ISA-archstudio-admin-cms.md)
+- Accès admin depuis app fondateur
+
+## Principles
+
+1. **Same chrome** — `globals.css` source of truth ; admin n’ajoute pas de CSS parallèle sauf layout scoping minimal.
+2. **Progressive disclosure** — formulaires typés par entité ; JSON « Avancé » replié (NN/g).
+3. **Entity-centric nav** — Templates · Lego · ADD · Flows + Publish + Import + Localisation.
+4. **Preview before publish** — iframe `PaperDocument` / tuile wizard ; pas de mockup séparé.
+5. **Design agents first on UI** — Designer scaffold ; Webdesign IntegrateIntoApp ; pas de code UI admin improvisé par l’orchestrateur.
+
+## Constraints
+
+- Réutiliser : `Icon.tsx`, `Fields.tsx`, `Brand.tsx` (`Lockup` sub « Content »), classes shell `Editor.tsx` (sidebar, topbar, inspector)
+- Interdit : emoji dans DOM admin ; `rounded-xl` / gradients / glass ; lib UI non présente dans le repo
+- Locale switcher EN/FR global ; tabs inline labels courts
+- Route `/admin` local-only v1 ; inaccessible depuis nav fondateur
+- **Designer** (`subagent_type="designer"`) produit wireframes + composants ; **Forge/Engineer** implémentent sous review Designer
+- Skill **Webdesign** path **DirectDesign** + **IntegrateIntoApp** — respect tokens existants, diffs only
+
+## Dependencies
+
+- `requires: archstudio-admin-cms — entités éditables, modèle draft/published, validateurs publish, migration M0–M6`
+- `requires: RESEARCH-admin-cms-ux — UX1–UX12, wireframes flows A/B/C, anti-patterns`
+
+## Goal
+
+"Fige ISA on a des subagent design et des skill design pour UI ne l'oublie pas"
+
+Livrer le **shell et les écrans admin** en réutilisant strictement le chrome ArchStudio existant ; nav v1 + fiches entité riches (brique, template, section, flow, publish wizard) ; **Designer + Webdesign** sur tout travail UI ; zéro emoji, zéro esthétique AI-generated.
+
+## Criteria
+
+### Chrome & identité
+
+- [ ] **ISC-UX6** Fiche brique admin : classes `.field` / `.btn` / `.input` identiques à `Inspector` ; **aucun emoji** dans le DOM `/admin`.
+- [ ] **ISC-UX10** Tokens Atelier : `--brand`, `--panel`, `--r: 0px`, Archivo/Space Mono — pas de feuille CSS admin parallèle >50 lignes hors layout scoping.
+- [x] **ISC-UX11** Toutes les icônes nav/actions = `Icon.tsx` ; 0 caractère Unicode emoji U+1F300–U+1FAFF dans `/admin`.
+- [x] **ISC-UX12** 0 import shadcn/Lucide/Radix UI / Heroicons dans `src/app/admin/**`.
+- [x] **Anti: ISC-UX-A1** Screenshot côte à côte éditeur ↔ fiche brique : même typo, teal, boutons carrés (DoD visuel RESEARCH).
+- [x] **Anti: ISC-UX-A2** Dashboard sans issue publish visible quand brouillon invalide existe.
+
+### Nav & flows
+
+- [ ] **ISC-UX1** Publish `purpose.fr` sur brique identity sans IDE ; parcours <2 min (flow A RESEARCH).
+- [ ] **ISC-UX2** Publish wizard **bloqué** si orphan ref ou `*.fr` manquant ; issue cliquable → champ.
+- [ ] **ISC-UX4** Aucun lien/route `/admin` depuis Workspace / Editor fondateur.
+- [ ] **ISC-UX5** Section type `cards` : éditeur items icon/title/bullets — pas JSON textarea par défaut.
+
+### Preview & écrans
+
+- [ ] **ISC-UX3** Template Acme admin → onglet Preview PDF/outline équivalent seed (via iframe preview).
+- [ ] **ISC-UX5b** Template : onglets Métadonnée · Canvas · Flows · Sections · Preview présents v1.
+- [ ] **ISC-UX7** Sections : drawer bibliothèque blocks ; v1 éditeurs `cards` + `text` complets ; compare/timeline via import JSON acceptable v1.
+- [ ] **ISC-UX8** Import JSON bulk template Acme accessible depuis écran template.
+
+### Décisions UX1–UX12 (RESEARCH)
+
+- [ ] **ISC-UX-D** UX1–UX12 de [`RESEARCH-admin-cms-ux.md`](./RESEARCH-admin-cms-ux.md) implémentés ou explicitement deferred v2 (UX9 only).
+
+## Bridge Criteria
+
+- [x] **Bridge: ISC-B1** Routes `/admin` + nav 4 piliers rendent avant data branchée (stub lists OK).
+- [x] **Bridge: ISC-B2** Wizard publish UI invoque validateurs parent (A5, Q1, A6).
+- [x] **Bridge: ISC-B3** Lockup `Brand.tsx` avec sous-titre mono « Content » — pas logo admin séparé.
+
+## Test Strategy
+
+| isc | type | check | threshold | tool | anchors_to |
+|-----|------|-------|-----------|------|------------|
+| ISC-UX6 | static | DOM `/admin/bricks/*` | `.field`, no emoji | rg + Interceptor | literal: Fields |
+| ISC-UX10 | static | admin CSS imports | globals only + ≤50 scoped | rg | derived: tokens |
+| ISC-UX11 | static | emoji scan admin routes | 0 matches | rg | derived: UX11 |
+| ISC-UX12 | static | forbidden imports | 0 | rg lucide/shadcn | derived: UX12 |
+| ISC-UX-A1 | visual | screenshot diff editor vs admin | same chrome | Interceptor | derived: DoD |
+| ISC-UX-A2 | e2e | dashboard with invalid draft | issues list non-empty | Interceptor | derived: Anti |
+| ISC-UX1 | e2e | flow A timing | <120s | Interceptor | derived: wireframe A |
+| ISC-UX2 | integration | wizard block | cannot confirm | bun test + UI | derived: UX6 RESEARCH |
+| ISC-UX4 | static | Workspace/Editor links | no /admin href | rg | derived: UX1 |
+| ISC-UX5 | component | cards editor default | not textarea | code review | derived: Payload blocks |
+| ISC-UX3 | e2e | Acme preview tab | 4 author sections visible | Interceptor | Bridge parent A6 |
+| ISC-UX7 | component | section drawer | cards+text editors | code review | derived: UX7 |
+| ISC-UX8 | e2e | import JSON Acme | populates form | bun test | derived: UX8 |
+| ISC-UX-D | review | UX1–12 checklist | 9 v1 + 3 v2 deferred | manual | literal: RESEARCH |
+| ISC-B1…B3 | e2e/integration | seam with content ISA | pass | bun + Interceptor | Bridge parent |
+
+## Features
+
+| name | description | satisfies | depends_on | parallelizable | route |
+|------|-------------|-----------|------------|----------------|-------|
+| F-UX0 Design brief | Wireframes nav + split-pane + publish wizard from RESEARCH | ISC-UX-D, Bridge B3 | — | false | **Designer** (Aditi Sharma) |
+| F-UX1 Admin layout | `src/app/admin/layout.tsx` — sidebar, topbar, Lockup Content | UX10, B1, B3 | F-UX0 | false | **Designer** review → **Engineer** |
+| F-UX2 Nav routes | Stub pages : Dashboard, Templates, Catalogue, ADD, Flows, Publish, Import, Locale | UX2, UX4, UX-D | F-UX1 | true | Engineer |
+| F-UX3 Fiche brique | Split 60/40, Fields, IconPicker, concernTags, Avancé JSON replié | UX6, UX11, UX1 | F-UX1 | true | **Designer** + Engineer |
+| F-UX4 Template editor | Onglets meta/canvas/flows/sections/preview ; import JSON | UX3, UX5b, UX8 | F-UX1 | false | **Designer** + Forge |
+| F-UX5 Section editor | Blocks drawer ; cards/text editors ; preview papier | UX5, UX7 | F-UX1 | true | Designer + Engineer |
+| F-UX6 Publish wizard | 4 steps ; issues → field ; badges Draft/Modified/Published | UX2, Bridge B2 | F-UX2 | false | Designer + Engineer |
+| F-UX7 Visual QA | Screenshot parity + emoji/import scan | UX-A1, UX12, UX11 | F-UX3…6 | false | **Webdesign** IntegrateIntoApp + Interceptor |
+
+**Séquence :** `F-UX0` → `F-UX1` → `(F-UX2 ∥ F-UX3 ∥ F-UX5)` → `F-UX4` → `F-UX6` → `F-UX7`.
+
+**Design skill routing (HARD) :**
+
+| Phase | Agent / Skill | Workflow |
+|-------|---------------|----------|
+| Wireframes + composant map | `subagent_type="designer"` | Spec from RESEARCH § Spec UI |
+| Intégration code | Skill **Webdesign** | **DirectDesign** + **IntegrateIntoApp** — diffs against `Editor.tsx` patterns |
+| Densité / polish | Skill **emil-design-eng** | After F-UX3–6 if Designer flags spacing/hierarchy |
+| Finish review (post-build) | Skill **impeccable** | VERIFY optional — layout parity only |
+
+**Anti-routing :** orchestrateur (Nix) ne code pas les composants UI admin — delegate Designer → Engineer/Forge.
+
+## Decisions
+
+| When | Decision |
+|------|----------|
+| 2026-08-18 03:00 | F-UX0 **done** — [`DESIGN-admin-shell.md`](./DESIGN-admin-shell.md) (Designer). F-UX1/F-UX2 **done** — shell `/admin` + 8 routes stub. |
+| 2026-08-18 03:39 | Principal : « Retravaille UI catalogue » — M1 CRUD livré sans Designer. F-UX3 étendu (sous-nav + listes/fiches). HARD Designer + Webdesign DirectDesign/IntegrateIntoApp + emil-design-eng. Anti : segmented wrap contenu. |
+| 2026-08-18 | Rich entity fiche + simple nav v1 — résolution conflit Research vs Johannes. |
+| 2026-08-18 | Designer mandatory F-UX0/1/3/4/6 ; Webdesign IntegrateIntoApp for all UI code ; Nix orchestrates only. |
+| 2026-08-18 | UX9 (graphe, drag, diff restore) deferred v2 — logged, not in v1 ISCs. |
+| 2026-08-18 | `context_sufficient: true`. |
+| 2026-08-20 | F-UX7 Visual QA run — Interceptor captures under `screenshots/fux7/`; static UX11/UX12 clean. |
+| 2026-08-20 | Dashboard `/admin` implemented (Designer): domain publish health + aggregated issues — no KPI vanity. |
+| 2026-08-20 | UX-A2 forced: PATCH `system_copy/layer.app` `fr=""` → dashboard IssueList + POST publish blocked; screenshot `screenshots/fux7/ux-a2-dashboard-issues.png`. |
+| 2026-08-20 | IssueList React keys must include list index — `placeholder_section` can emit two issues per entity (en/fr). |
+| 2026-08-20 | Principal : « Reouvrir catalogue Lego — meilleure design sous form components + CRUD ». Route **Designer** (F-UX3 étendu à toutes les entités catalogue : bricks, scopes, intents, variants, deps, technologies). |
+| 2026-08-20 | Forge shipped catalog Create/Delete APIs + `createX`/`deleteX` helpers + locked re-seed (`admin-catalog.test.ts` 17/17). Designer wires UI. |
+| 2026-08-20 | Designer : Catalogue Lego redesign Atelier — `CatalogFormParts` + `NewCatalogDialogs` + CRUD UI+API (POST/DELETE) sur scopes/intents/variants/deps/technologies/bricks. Locked seed ids `isLocked*` ; UX9 graph deferred. See DESIGN §8. |
+| 2026-08-20 | Principal : « tests regression admin UI & backend » — detect drift. Feature **F-REG** : suite `test:admin` (domain) + smoke UI admin ; ISCs REG-B / REG-U. |
+| 2026-08-20 | **Chrome title rule (Designer coherence)** : topbar `.name` owns sole H1-level page title; `AdminPageHeader` / `AdminWorkspace` / `CatalogSplitShell` are lede+tools only (no competing `<h1>`). Locale topbar ↔ `useAdminLocale` synced via `admin-locale` event. Documented in DESIGN-admin-shell.md §2.3. |
+
+## Changelog
+
+| when | entry |
+|------|-------|
+| 2026-08-18T02:35:00Z | conjectured: Designer-first routing prevents AI-slop admin UI while shipping rich entity editors. |
+| 2026-08-18T02:35:00Z | learned: same chrome constraint is testable (UX6, UX11, UX12, UX-A1) — not taste-only. |
+| 2026-08-18T02:35:00Z | criterion-now: ISC-UX1…UX12 + Bridge B1–B3 + Anti UX-A1/A2. |
+| 2026-08-18T03:39:00Z | learned: CRUD catalogue branché sans Designer produit un chrome disjoint (tabs wrap) — F-UX3 n’est pas « fiche brique seule ». |
+| 2026-08-20T18:33:00Z | learned: F-UX7 — admin Lockup Content + Icon.tsx + `.btn`/`.field` parity with Editor; Import/Locale/Templates live. |
+| 2026-08-20T18:33:00Z | criterion-now: ISC-UX11, UX12, UX-A1 (visual), Bridge B1 routes 200 probed; UX-A2 not forced this run (no invalid draft seeded). |
+| 2026-08-20T18:56:00Z | learned: empty brick `roleFr` rejected at PATCH — seed invalid drafts via domains that allow empty-then-validate (system_copy). |
+| 2026-08-20T18:56:00Z | criterion-now: Anti UX-A2 **PASS**; Bridge B1–B3 PASS; brick preview uses `BrickPreviewPane` (stub copy removed). |
+| 2026-08-20T20:05:00Z | learned: parent ISA complete with Q2 deferred; UX shell + catalogue CRUD + F-REG sufficient for jumeau close. |
+| 2026-08-20T20:05:00Z | criterion-now: UX ISA **complete** (remaining UX1 timing / UX3–8 spot gaps acceptable as post-close polish; core Anti+Bridge+F-UX7 done). |
+| 2026-08-20T20:09:00Z | learned: principal — post-close Designer coherence pass (double headers / ensemble Atelier). |
+
+## Verification
+
+| isc | result | evidence |
+|-----|--------|----------|
+| ISC-UX11 | **PASS** | `rg`/python emoji scan `src/app/admin` + `src/components/admin` → 0 hits U+1F300–U+1FAFF |
+| ISC-UX12 | **PASS** | 0 imports lucide / @radix / shadcn / heroicons / `@/components/ui` under admin |
+| Anti ISC-UX-A1 | **PASS** | Screenshots `screenshots/fux7/admin-brick.png` ↔ `editor-acme.png` — same teal brand, square controls, Archivo/Space Mono, `Icon` stroke; Lockup « Content » vs project editor chrome |
+| Bridge ISC-B1 | **PASS** | HTTP 200: `/admin`, `/templates`, `/catalog`, `/publish`, `/import`, `/locale` |
+| Bridge ISC-B2 | **PASS** | PublishWizard 7 domains; POST `/api/admin/system-copy/publish` returns same `invalid_system_copy` as state validate |
+| Bridge ISC-B3 | **PASS** | Lockup « Content » on admin chrome (F-UX7 screenshots) |
+| ISC-UX5b | **PASS** (spot) | Interceptor markdown on `/admin/templates`: Create + Architecture·6 + Project·1 grids |
+| Anti ISC-UX-A2 | **PASS** | Seeded `layer.app` FR empty → dashboard listitem « System copy "layer.app" missing French text »; screenshot `screenshots/fux7/ux-a2-dashboard-issues.png`; FR restored after probe |
+| Notes | — | Remaining UX ISCs (UX1 timing, UX2 wizard click-through, UX3–UX8, UX6/10 full static) not re-closed this pass; brick preview = `BrickPreviewPane.tsx` |

--- a/docs/add/ISA-archstudio-admin-cms.md
+++ b/docs/add/ISA-archstudio-admin-cms.md
@@ -1,0 +1,245 @@
+---
+task: "Admin CMS — tout le contenu système éditable sans code"
+slug: archstudio-admin-cms
+project: ArchStudio
+effort: E3
+effort_source: explicit
+phase: complete
+status: complete
+progress: 25/26
+mode: interactive
+started: 2026-08-18T02:30:00Z
+updated: 2026-08-20T20:05:00Z
+principal_stated_goal: "Fige ISA on a des subagent design et des skill design pour UI ne l'oublie pas"
+principal_stated_goal_source: prompt
+principal_stated_goal_signal: 2
+principal_stated_goal_locked: 2026-08-18T02:30:00Z
+context_sufficient: true
+interview_invoked: false
+children: archstudio-admin-cms-ux
+---
+
+## Problem
+
+ArchStudio mélange **moteur** et **contenu système** dans le même repo TypeScript : catalogue (`seed-data.ts`), templates (`templates/*.ts`), sections ADD (`preset.ts`), flow patterns (`flows/catalog.ts`), seed Acme (`demo.json`). Chaque correction contenu = PR + redeploy. `concernTags` restent partiellement lus depuis le seed TS, pas SQLite. Le fondateur non-tech ne doit jamais voir l’admin ; l’opérateur solo ne peut pas shipper un template Acme-quality un mardi après-midi sans IDE.
+
+## Vision
+
+Un panneau **`/admin`** local-first : une vérité versionnée par entité (brouillon → publié), CRUD sur templates projet, catalogue Lego, bibliothèque ADD, flow patterns, technos. Le runtime lit **uniquement** `published`. Euphorie : publier « Template marketplace B2B » avec canvas + sections + flows + qualité PDF **sans ouvrir l’IDE** ; le fondateur le choisit dans le picker existant.
+
+## Out of Scope
+
+- CRUD sur `projects.data` (instances user) — reste l’éditeur normal
+- Réécrire le moteur (gating, hydrate, `buildOutline`, placement) — consomme le contenu admin
+- Élargir les enums moteur (`ConcernTag`, types section, flow id #9) sans ISA moteur séparée
+- Billing, multi-tenant cloud, sync remote obligatoire — export/import bundle suffit v1
+- Wizard besoins fondateur (ISA #4), éditeur ADR, FinOps €
+- Inférence tech → tags comme chemin principal — templates admin + catalogue éditable d’abord ([`CONTRAT-qualite-acme.md`](./CONTRAT-qualite-acme.md) D6)
+- Shell UI / chrome admin — ISA jumeau [`ISA-archstudio-admin-cms-ux.md`](./ISA-archstudio-admin-cms-ux.md)
+
+## Principles
+
+1. **Content vs engine** — l’admin shippe des données ; la résolution reste typée en code.
+2. **Stable ids** — `identity`, `auth-login`, `add-data` ne changent pas sans migration explicite.
+3. **Absent > vide** — section sans corps publiable n’apparaît pas ([`CONTRAT-qualite-acme.md`](./CONTRAT-qualite-acme.md) B1).
+4. **i18n obligatoire** — tout texte user-facing : `en` + `fr`.
+5. **Publish explicite** — runtime ne voit que `published`.
+6. **Acme-first templates** — templates **projet** priment sur l’inférence pour le non-tech.
+7. **Design integration** — chrome admin délégué à Designer + Skill Webdesign (DirectDesign / IntegrateIntoApp) ; pas de design system parallèle.
+
+## Constraints
+
+- Local-first SQLite ; schéma étendu depuis `src/lib/db.ts` existant
+- Feature flag `CONTENT_FROM_ADMIN=1` pour bascule source par source (M0→M6)
+- Validation publish bloquante : schéma JSON + refs + i18n + qualité Acme parity
+- Flow patterns : 8 ids v1 locked ; contenu éditable, pas d’ajout id sans ISA
+- Enums moteur restent code ; admin configure *dans* l’enum
+- Package/run **bun** ; pas de commit sauf demande principal
+- Product code → **delegate** (Forge / Engineer) ; shell UI → **Designer** + Webdesign skill
+
+## Dependencies
+
+- `requires: 20260815-archstudio-lego-implementation — runtime catalogue, placement, flow plates consomment le contenu admin publié`
+- `requires: archstudio-admin-cms-ux — shell /admin, écrans typés, publish wizard UI, preview iframe (Bridge ISCs)`
+- `requires: CONTRAT-qualite-acme — barre B1–B6 pour validation template Acme au publish`
+
+## Goal
+
+"Fige ISA on a des subagent design et des skill design pour UI ne l'oublie pas"
+
+Livrer un **CMS admin local-first** où tout le contenu système (templates projet en tête — Acme, catalogue Lego, sections ADD, flow patterns, technos) est CRUD + publish **sans redeploy contenu** ; migration M0→M6 avec parité runtime flag-off ; qualité publish calquée sur [`CONTRAT-qualite-acme.md`](./CONTRAT-qualite-acme.md) ; chrome UI via ISA jumeau UX + agents/skills design.
+
+## Criteria
+
+### Publish & runtime
+
+- [x] **ISC-A1** Publier brouillon brique `identity` avec nouveau `purpose.fr` → `/api/lego/catalog` renvoie la valeur sans redeploy (flag on).
+- [x] **ISC-A2** Template projet créé/importé admin → picker affiche → `createProject` produit snapshot équivalent (Acme : 22 composants).
+- [x] **ISC-A3** Section `add-iam` éditée admin → PDF gated Auth0 utilise le nouveau titre (flag on).
+- [x] **ISC-A4** Hint step `auth` du flow `auth-login` édité admin → `countMappableSteps` mis à jour.
+- [x] **ISC-A5** Publish **rejeté** si variant `maps_to` pointe vers brique absente.
+- [x] **ISC-A6** Template Acme admin publié vs `seed/demo.json` : outline slim + 4 sections auteur équivalentes (falsifier CONTRAT § Preuve positive).
+
+### Qualité publish (CONTRAT B1–B6 au gate)
+
+- [x] **ISC-Q1** Aucune section publiée gated ou auteur ne contient `[…]`, « À estimer », « To be estimated » (B1).
+- [ ] **ISC-Q2** Sections gated type cartes = une carte par composant concerné, densité operations Acme — pas dump « Composants concernés » (B2). *(DEFERRED — Decision 2026-08-20)*
+- [x] **ISC-Q3** Publish template Acme : 22 composants, 4 sections auteur (`platforms`, `operations`, `roadmap`, `risks`) présentes (B6 partial — template layer).
+- [x] **Anti: ISC-A7** Admin n’expose pas `projects.data` en CRUD.
+- [x] **Anti: ISC-A8** Publish ne modifie pas rétroactivement tags snapshottés sur composants existants.
+- [x] **Anti: ISC-A9** Les 8 recipes catalogue restent locked et se re-seedent si supprimées ; les ids custom sont des données admin (pas d’enum moteur).
+
+### Migration
+
+- [x] **ISC-M0** Schéma SQLite étendu + import one-shot TS/JSON → parité byte runtime avec `CONTENT_FROM_ADMIN=0`.
+- [x] **ISC-M1** Catalogue CRUD admin + publish ; API catalogue ← admin ; fin authoring `seed-data.ts` ; `concernTags` en DB.
+- [x] **ISC-M2** Templates **projet** admin ; Acme importé ; picker ← admin ; `ensureSeed` ← admin featured.
+- [x] **ISC-M3** Sections ADD admin ; `preset.ts` ← admin published.
+- [x] **ISC-M4** Flow patterns admin ; `catalog.ts` ← admin.
+- [x] **ISC-M5** Templates architecture + `cloud_services` migrés.
+- [x] **ISC-M6** `system_copy`, vocabulaires, export bundle — zéro contenu système dans `src/lib/**` sauf enums moteur (flag on full).
+
+## Bridge Criteria
+
+- [x] **Bridge: ISC-B1** Shell `/admin` navigable (UX ISA) avant CRUD catalogue branché — routes stub OK.
+- [x] **Bridge: ISC-B2** Publish wizard UI (UX ISA) appelle les mêmes validateurs que ISC-A5, Q1, A6.
+- [x] **Bridge: ISC-B3** Fiche brique admin utilise `Fields.tsx` + tokens `globals.css` (UX ISC-UX6).
+
+### Regression (F-REG)
+
+- [x] **ISC-R1** `npm test` (ou `test:admin`) green avec assert publish catalogue rejeté sur variant orphan (`orphan_variant` / A5).
+- [x] **ISC-R2** Scan statique admin : aucune surface CRUD `projects` / `projects.data` sous `src/app/admin` + `src/components/admin` (A7).
+- [x] **ISC-R3** Smoke `/admin` (+ piliers nav) → HTTP 200 — script optionnel / Interceptor ; **pas** gate CI obligatoire.
+- [x] **ISC-R4** Publish section/ADD bloqué si placeholder (`placeholder_section` / Q1) — même code d’issue côté API.
+
+## Test Strategy
+
+| isc | type | check | threshold | tool | anchors_to |
+|-----|------|-------|-----------|------|------------|
+| ISC-A1 | integration | PATCH publish brick → GET catalog | `purpose.fr` match | bun test + API | derived: catalogue publish |
+| ISC-A2 | integration | createProject(templateId) | components.length=22 Acme | bun test | derived: templates projet |
+| ISC-A3 | integration | edit section → PDF IAM title | title match | bun test | derived: sections ADD |
+| ISC-A4 | unit | flow hint edit | countMappableSteps delta | bun test | derived: flow patterns |
+| ISC-A5 | unit | publish invalid variant ref | reject + message | bun test | derived: validation |
+| ISC-A6 | snapshot | admin Acme vs demo.json outline | 4 author sections + slim | bun test / diff | literal: CONTRAT |
+| ISC-Q1 | unit | publish validator | 0 placeholder tokens | bun test | derived: B1 |
+| ISC-Q2 | review | gated cards structure | no dump section | bun test | derived: B2 |
+| ISC-Q3 | file | Acme template fields | 22 comps, 4 sections | rg / test | derived: B6 template |
+| ISC-A7 | static | admin routes | no project CRUD | rg / review | derived: Anti |
+| ISC-A8 | unit | publish catalogue | existing project tags unchanged | bun test | derived: Anti |
+| ISC-A9 | review | locked 8 re-seed ; custom ids = admin data | no engine enum change | rg / bun test | derived: Anti AD4 softened 2026-08-20 |
+| ISC-M0…M6 | integration | flag off/on parity | tests green each phase | bun test | derived: migration |
+| ISC-B1 | e2e | /admin routes | 200 all nav | Interceptor / bun | Bridge UX |
+| ISC-B2 | integration | wizard → validator | same errors as API | bun test | Bridge UX |
+| ISC-B3 | static | admin DOM classes | `.field`, `.btn`, no emoji | rg / Interceptor | Bridge UX |
+| ISC-R1 | regression | publish invalid variant | reject + code | npm test / test:admin | derived: A5 |
+| ISC-R2 | static | admin tree no projects CRUD | 0 matches | npm test (fs scan) | derived: A7 |
+| ISC-R3 | smoke | GET /admin nav | 200 | script / Interceptor | Bridge B1 |
+| ISC-R4 | regression | placeholder section publish | blocked | npm test / API | derived: Q1 |
+
+## Features
+
+| name | description | satisfies | depends_on | parallelizable | route |
+|------|-------------|-----------|------------|----------------|-------|
+| F0 UX shell | Layout `/admin`, nav, split-pane stub, lockup Content | Bridge B1, B3 | — | false | **Designer** + Skill **Webdesign** (DirectDesign / IntegrateIntoApp) — voir ISA UX |
+| F1 M0 schema | SQLite extend + import script | ISC-M0 | — | false | Engineer |
+| F2 M1 catalogue | CRUD briques/variants/deps + publish + API | ISC-A1, A5, M1 | F1 | false | Forge |
+| F3 M2 templates projet | Acme import, picker, ensureSeed | ISC-A2, A6, Q3, M2 | F2, F0 | false | Forge + Designer (template editor tabs) |
+| F4 M3 sections ADD | Bibliothèque + preset ← admin | ISC-A3, Q1, M3 | F3 | true | Engineer |
+| F5 M4 flow patterns | 8 patterns editable | ISC-A4, M4 | F2 | true | Engineer |
+| F6 M5 arch templates | 6 hyperscaler + cloud_services | M5 | F3 | true | Forge |
+| F7 M6 bundle | export/import, system_copy, vocab | M6 | F4, F5, F6 | false | Engineer |
+| F8 Publish wizard | Validation bloquante UI | Bridge B2, ISC-A5, Q1 | F0, F2 | false | Designer + Engineer |
+| F-REG-1 Publish lib | Lib tests publish reject + placeholder gate | R1, R4 | — | true | test-engineer |
+| F-REG-2 API contracts | `src/app/api/admin/**/*.test.ts` HTTP contracts | R1, R2, R4 | F-REG-1 | false | test-engineer |
+| F-REG-3 UX static | Node scan UX11/12/A7 admin tree | R2 | — | true | test-engineer |
+| F-REG-4 test:admin | Script subset ; CI reste `npm test` | infra | F-REG-1…3 | false | test-engineer |
+| F-REG-5 Smoke /admin | Interceptor/script 200 ; hors CI gate | R3 | F-REG-4 | true | Interceptor |
+
+**Séquence :** `F0 ∥ F1` → `F2` → `F3` → `(F4 ∥ F5)` → `F6` → `F7` ; `F8` après F2 ; **F-REG :** `(1 ∥ 3) → 2 → 4 → 5`.
+
+**Design routing (HARD pour F0, F3 UI, F8) :**
+- Agent **Designer** (`subagent_type="designer"`) — wireframes → composants dans chrome existant
+- Skill **Webdesign** — path DirectDesign ; **IntegrateIntoApp** ; respecter `globals.css`, `Fields.tsx`, `Icon.tsx`
+- Skill **emil-design-eng** — polish densité informationnelle si review Designer le demande
+- **Anti :** nouveau design system, shadcn, emoji, palette non-Atelier
+
+## Decisions
+
+| When | Decision |
+|------|----------|
+| 2026-08-18 02:35 | ISA **LOCKED** at observe — inputs [`ADMIN-CMS.md`](./ADMIN-CMS.md), [`CONTRAT-qualite-acme.md`](./CONTRAT-qualite-acme.md). Child ISA UX jumeau. |
+| 2026-08-18 | AD1–AD6 adopted : tout contenu système → admin M6 ; templates projet first ; concernTags DB ; 8 flow ids ; enums code ; bundle backup. |
+| 2026-08-18 | UX chrome = ISA séparée ; Designer + Webdesign mandatory on F0/F3/F8 — pas de code admin UI sans route design. |
+| 2026-08-18 | Qualité publish : Q1–Q3 from CONTRAT B1/B2/B6 at template gate ; engine B4/B5 reste ISA brick-metadata / future. |
+| 2026-08-18 | `context_sufficient: true` — recherche Standard + docs amont ; pas d’interview. |
+| 2026-08-20 | Principal requested flow pattern CRUD. Custom pattern ids allowed as admin catalogue data. Locked 8 still re-seed on next read (ADD preset parity). ISC-A9 softened: no engine enum change; new recipes are admin data, not a code enum. |
+| 2026-08-20 | F6 M5: 6 architecture `TEMPLATES` + `SERVICES` persist as SQLite domains `architecture-templates` / `cloud-services`. Runtime `CONTENT_FROM_ADMIN=1` + published uses `resolve.server.ts` (never import db into `templates/index.ts`). Locked 6 re-seed like flow locked 8. |
+| 2026-08-20 | F6 UI: Designer restored Atelier chrome; Diagram = shared `ArchitectureDiagramSurface` (same graph as app); architecture snapshot→spec preserves `cloud` by id. |
+| 2026-08-20 | Start **F7 M6**: `system_copy` + layer vocab + content-bundle export/import; Import/Locale pages leave stub → Atelier UI. |
+| 2026-08-20 | Enter **VERIFY**: F0–F7 shipped in code; close M6 wire (resolveFlowCopy/Layer), expand PublishWizard to all domains, brick preview stub, UX-A2 evidence. |
+| 2026-08-20 | VERIFY pass: `resolveFlowCopy` wired via `flow-copy.server` → store + templates resolve; PublishWizard 7 domains; UX-A2 forced via empty `system_copy` FR; open gaps A3/Q2/A8. |
+| 2026-08-20 | Forge: Lego catalogue POST/DELETE (scopes, intents, variants, technologies, bricks, deps) + locked re-seed on ensure; client helpers in `catalog-entities.ts`. |
+| 2026-08-20 | Principal : regression pack admin UI+backend (F-REG) — gate drift on catalogue CRUD, publish validators, `/admin` smoke. |
+| 2026-08-20 | F-REG shipped: `test:admin` + `regression-{backend,api,ui}.test.ts` + `scripts/admin-smoke.mjs` ; Anti Playwright/RTL (Architect). Doc [`REGRESSION-admin.md`](./REGRESSION-admin.md). |
+| 2026-08-20 | Close-out: ISC-Q2 (B2 cards density / anti « Composants concernés » dump) **DEFERRED** to document/hydrate engine + brick-metadata follow-up — `hydrate.ts` `scopeCard` still emits that fallback; admin CMS gate remains Q1 placeholders + Q3 Acme template. |
+| 2026-08-20 | VERIFY code-reviewer: **CODE_REVIEWER_OK: yes** — 0 critical/high blocking; MEDIUM notes (wizard `all`+placeholders, hydrate escape, non-atomic multi-publish, locale sync). Q2 DEFER confirmed. |
+| 2026-08-20 | VERIFY security-reviewer: **SECURITY_OK: yes** — no critical/high unmitigated beyond accepted local-first (no-auth, Next/sharp CVEs per SECURITY.md); SQL parameterized; preview iframe sandboxed. |
+| 2026-08-20 | Security MEDIUM deferred (post-close): sanitise prose at bundle import; optional `ADMIN_TOKEN` / body size limit on `/api/admin` — tracked under local-first accept-risk until network exposure. |
+| 2026-08-20 | Close: ISC-A3 + A8 PASS (`isc-a3-a8.test.ts` 2/2); Q2 remains DEFERRED; VERIFY pack green → LEARN → COMPLETE. |
+| 2026-08-20 | LEARN: PR docs pack — [`docs/add/README.md`](./README.md), [`PR.md`](./PR.md); root README Admin + `test:admin`; GAPS + SECURITY updated. |
+
+## Changelog
+
+| when | entry |
+|------|-------|
+| 2026-08-18T02:35:00Z | conjectured: split content ISA + UX ISA avec Bridge ISCs est le bon boundary — Designer route sans diluer critères publish. |
+| 2026-08-18T02:35:00Z | learned: Acme-first M2 est le levier non-tech ; inférence reste fallback ([`CONTRAT`](./CONTRAT-qualite-acme.md) D6). |
+| 2026-08-18T02:35:00Z | criterion-now: ISC-A1…A9, Q1–Q3, M0–M6, Bridge B1–B3 define done for this ISA. |
+| 2026-08-20T04:37:00Z | learned: principal asked flow CRUD — custom ids are admin data; locked 8 re-seed; ISC-A9 no longer forbids #9+ as catalogue rows. |
+| 2026-08-20T05:05:00Z | learned: F6 M5 architecture templates + cloud_services admin CRUD/publish; createProject(templateId) reads published JSON when CONTENT_FROM_ADMIN=1. |
+| 2026-08-20T17:47:00Z | learned: F6 Diagram must match app graph (shared surface); architecture edit via snapshot→spec. Next: F7 M6 bundle + system_copy. |
+| 2026-08-20T17:47:00Z | criterion-now: ISC-M5 treated shipped for domain CRUD; ISC-M6 is the remaining migration gate. |
+| 2026-08-20T18:40:00Z | learned: Dashboard + F-UX7 done; F7 files exist but resolveFlowCopy unused — VERIFY must wire runtime + widen PublishWizard. |
+| 2026-08-20T18:56:00Z | learned: PATCH brick rejects empty `roleFr` at write — UX-A2 seeded via `system_copy` empty FR instead; dashboard + publish API both surface the issue. |
+| 2026-08-20T18:56:00Z | criterion-now: 19/22 parent ISCs PASS; remaining open: A3 (PDF title e2e), Q2 (cards density review), A8 (snapshot tags immutability). |
+| 2026-08-20T19:49:00Z | learned: F-REG — stay on `tsx --test`; named R1–R4 anchors catch drift without Playwright. |
+| 2026-08-20T19:49:00Z | criterion-now: ISC-R1…R4 PASS (`test:admin` 75/75). |
+| 2026-08-20T20:00:00Z | conjectured: closing with Q2 deferred is honest — admin CMS done; hydrate B2 is engine follow-up. |
+| 2026-08-20T20:00:00Z | refuted-by: treating « Composants concernés » dump as admin CMS fail would block ship without moving the defect. |
+| 2026-08-20T20:00:00Z | learned: Designer+Forge+F-REG+VERIFY agents close content ISA; A3 probe = hydrate resolve (not PDF raster); A8 = snapshot immutability test-only. |
+| 2026-08-20T20:00:00Z | criterion-now: 25/26 PASS; Q2 DEFERRED; status **complete**. |
+| 2026-08-20T20:24:00Z | learned: LEARN doc-sync for PR — `docs/add/README.md` + `PR.md`, README Admin section, GAPS shipped, SECURITY `/admin` threat model. |
+| 2026-08-20T20:24:00Z | criterion-now: docs PR-ready; commit/PR on principal ask. |
+
+## Reflection
+
+Admin CMS local-first is shippable: domains CRUD+publish, Atelier chrome, F-REG drift gates, security/code-reviewer OK under accept-risk local-first. Next hill: hydrate Q2 (B2 cards) + optional admin token/body limits if ever network-exposed.
+
+## Verification
+
+| isc | result | evidence |
+|-----|--------|----------|
+| ISC-A1 | **PASS** | `tsx --test src/lib/lego/admin-catalog.test.ts` — `ISC-A1: updateAdminBrick purposeFr is returned by legoCatalog(fr)` |
+| ISC-A2 | **PASS** | `project-templates.test.ts` — `ISC-A2: createProject from published template has 22 components` |
+| ISC-A3 | **PASS** | `isc-a3-a8.test.ts` — published `add-iam` title → `resolvePresetSection` + hydrate (PDF path shares resolve; PDF raster not asserted) |
+| ISC-A4 | **PASS** | `flow-patterns.test.ts` — `hint edit updates demo match count (ISC-A4)` |
+| ISC-A5 | **PASS** | `admin-catalog.test.ts` — `ISC-A5: orphan variant maps_to missing brick is rejected at publish` |
+| ISC-A6 | **PASS** | `project-templates.test.ts` — `ISC-A6: Acme admin outline matches demo.json` |
+| ISC-Q1 | **PASS** | `add-sections.test.ts` — `publish blocked when placeholders remain` (`placeholder_section`) |
+| ISC-Q2 | **DEFER** | Decision 2026-08-20 — `hydrate.ts` `scopeCard` still dumps « Composants concernés »; follow-up hydrate/brick-metadata |
+| ISC-Q3 | **PASS** | Covered by A2/A6 Acme 22 comps + 4 author sections |
+| Anti A7 | **PASS** | `rg` admin tree: no `projects.data` CRUD surface |
+| Anti A8 | **PASS** | `isc-a3-a8.test.ts` — `publishCatalog` leaves snapshotted component `concernTags` unchanged |
+| Anti A9 | **PASS** | flow/architecture locked re-seed tests + custom ids as admin data |
+| ISC-M0…M4 | **PASS** | Domain suites green (catalog, project-templates, add-sections, flow-patterns); flag-off fallback still in resolve paths |
+| ISC-M5 | **PASS** | `architecture-templates.test.ts` + `cloud-services.test.ts` (47 admin-domain tests green with peers) |
+| ISC-M6 | **PASS** | `system-copy.test.ts` 5/5; `resolveFlowCopy` wired in `store.ts` + `templates/resolve.server.ts`; bundle + Import/Locale; PublishWizard includes `system_copy` |
+| Bridge B1 | **PASS** | UX ISA — HTTP 200 admin routes + Interceptor |
+| Bridge B2 | **PASS** | PublishWizard domains `all|catalog|templates|architecture|sections|flows|cloud|system_copy`; publish APIs return same issue codes |
+| Bridge B3 | **PASS** | UX ISA F-UX7 — `.field`/`.btn` + Fields on brick fiche |
+| ISC-R1 | **PASS** | `npm run test:admin` — `F-REG R1 regression: orphan_variant` + publish `ok:false` contracts (`regression-backend` / `regression-api`) |
+| ISC-R2 | **PASS** | `regression-ui.test.ts` + `regression-api.test.ts` — 0 projects CRUD / UI-kit / emoji in admin trees |
+| ISC-R3 | **PASS** | `node scripts/admin-smoke.mjs` → 5×200 when server up (skip if down); **not** CI gate — see [`REGRESSION-admin.md`](./REGRESSION-admin.md) |
+| ISC-R4 | **PASS** | `F-REG R4` / `placeholder_section` in add-sections + regression-backend/api |
+| Notes | — | `npm test` / `tsx --test` (not `bun test` — `node:sqlite` absent in bun). UX-A2 evidence on child ISA. F-REG doc: [`REGRESSION-admin.md`](./REGRESSION-admin.md). |

--- a/docs/add/PR.md
+++ b/docs/add/PR.md
@@ -1,0 +1,32 @@
+# PR notes — Admin CMS (`feat/lego-catalog-wizard`)
+
+Ready-to-paste summary for GitHub. Adjust branch / base as needed.
+
+## Summary
+
+- Local-first **Admin CMS** at `/admin`: draft → publish for Lego catalogue, project & architecture templates, ADD sections, flow patterns, cloud services, system copy, and content bundles.
+- Runtime opt-in via **`CONTENT_FROM_ADMIN=1`** (published-only resolve); flag off keeps prior seed/code paths.
+- Atelier chrome (same tokens as the editor); topbar owns the page title (no double H1).
+- Regression pack **F-REG** (`npm run test:admin`) plus full `npm test` CI gate unchanged.
+- ISAs **complete** (Q2 hydrate density deferred — see docs).
+
+## Test plan
+
+- [ ] `npm run typecheck`
+- [ ] `npm run test:admin`
+- [ ] `npm test`
+- [ ] `npm run build`
+- [ ] Manual: `npm run dev` → `/admin` → Catalogue (create/save/delete custom) → Publish wizard → Locale
+- [ ] Optional: `CONTENT_FROM_ADMIN=1` → create project from published template / check ADD title after publish
+- [ ] Optional: `node scripts/admin-smoke.mjs` with server up
+
+## Reviewer map
+
+See [`README.md`](./README.md) in this folder.
+
+## Out of scope (this PR)
+
+- Auth on `/admin` (same as app — VPN/proxy)
+- Hydrate B2 card density (ISC-Q2 deferred)
+- Playwright / new test frameworks
+- Founder-facing product UI changes beyond shared diagram surface extraction

--- a/docs/add/README.md
+++ b/docs/add/README.md
@@ -1,0 +1,44 @@
+# Admin CMS — documentation index (PR-ready)
+
+**Status:** shipped · ISA parent + UX **complete** (2026-08-20)  
+**Entry UI:** `/admin` · **Flag:** `CONTENT_FROM_ADMIN=1` for published resolve paths  
+**Regression:** [`REGRESSION-admin.md`](./REGRESSION-admin.md) · `npm run test:admin`
+
+This folder is the product + design record for the local-first content CMS. Use it as the
+reviewer map for a PR that lands admin UI, APIs, and domain libs.
+
+## Start here
+
+| Doc | Role |
+|-----|------|
+| [`PR.md`](./PR.md) | PR summary, test plan, out of scope |
+| [`ADMIN-CMS.md`](./ADMIN-CMS.md) | Product vision / migration narrative (SHIPPED) |
+| [`ISA-archstudio-admin-cms.md`](./ISA-archstudio-admin-cms.md) | Content ISA — criteria + Verification |
+| [`ISA-archstudio-admin-cms-ux.md`](./ISA-archstudio-admin-cms-ux.md) | UX ISA — Atelier chrome + Decision log |
+| [`DESIGN-admin-shell.md`](./DESIGN-admin-shell.md) | Component map; **§2.3** topbar owns the page title |
+| [`REGRESSION-admin.md`](./REGRESSION-admin.md) | F-REG R1–R4 how-to |
+| [`CONTRAT-qualite-acme.md`](./CONTRAT-qualite-acme.md) | Publish quality bar (Acme) |
+| [`RESEARCH.md`](./RESEARCH.md) / [`RESEARCH-admin-cms-ux.md`](./RESEARCH-admin-cms-ux.md) | Upstream research |
+
+## Code map (short)
+
+| Surface | Path |
+|---------|------|
+| Admin App Router | `src/app/admin/**` |
+| Admin APIs | `src/app/api/admin/**` |
+| UI components | `src/components/admin/**` |
+| Domain + tests | `src/lib/admin/**`, `src/lib/lego/admin-catalog.ts` |
+| Resolve (flag on) | `src/lib/templates/resolve.server.ts`, `src/lib/admin/*resolve*` |
+| Smoke (local) | `scripts/admin-smoke.mjs` |
+
+## Deferred (explicit, not PR blockers)
+
+- **ISC-Q2** — hydrate gated cards still use « Composants concernés » dump (`hydrate.ts` `scopeCard`); engine follow-up.
+- Security MEDIUM post-close — sanitise prose on bundle import; optional `ADMIN_TOKEN` / JSON body size if the instance is network-reachable.
+- UX9 — dependency graph / drag / diff restore (v2).
+
+## Related
+
+- Lego gaps updated: [`../lego/GAPS.md`](../lego/GAPS.md)
+- App README Admin section + `npm run test:admin`
+- Security threat model mentions `/admin`: [`../../SECURITY.md`](../../SECURITY.md)

--- a/docs/add/REGRESSION-admin.md
+++ b/docs/add/REGRESSION-admin.md
@@ -1,0 +1,39 @@
+# Admin regression suite (F-REG)
+
+How to run and what R1–R4 mean. CI stays on a single gate: `npm test`.
+
+## Commands
+
+```bash
+# Admin-focused slice (lib admin + lego admin-catalog)
+ECC_GATEGUARD=off GATEGUARD_DISABLED=1 npm run test:admin
+
+# Full suite (CI)
+ECC_GATEGUARD=off GATEGUARD_DISABLED=1 npm test
+```
+
+Optional local smoke (not CI) — skips cleanly if the app is down:
+
+```bash
+node scripts/admin-smoke.mjs
+# or: ADMIN_SMOKE_BASE=http://127.0.0.1:3000 node scripts/admin-smoke.mjs
+```
+
+## R1–R4 mapping
+
+| Id | Risk | What we guard | Where |
+|----|------|---------------|--------|
+| **R1** | Catalog publish accepts broken refs | `orphan_variant` (and invalid publish → `ok: false` + issue codes) | `admin-catalog.test.ts`, `regression-backend.test.ts`, `regression-api.test.ts` |
+| **R2** | Admin grows a projects CRUD / workspace surface | No `projects.data` / `/api/admin/projects` / UI-kit imports | `regression-api.test.ts`, `regression-ui.test.ts` |
+| **R3** | Admin routes 500 / shell broken | Optional HTTP smoke GET `/admin`, `/admin/catalog`, `/admin/publish`, `/admin/templates`, `/admin/locale` | `scripts/admin-smoke.mjs` (local only; Interceptor optional for visual) |
+| **R4** | Sections publish ships placeholders | `placeholder_section` blocks publish | `add-sections.test.ts`, `regression-backend.test.ts`, `regression-api.test.ts` |
+
+## Design Anti (locked)
+
+- No Playwright / Vitest / Jest / RTL / Cypress — stay on `tsx --test` / `node:test`.
+- Routes are thin wrappers; regression-api prefers **domain functions** the routes call.
+- UI checks are **static source scans** (emoji U+1F300–U+1FAFF, lucide/radix/shadcn/heroicons/`@/components/ui`).
+
+## Interceptor (optional R3 visual)
+
+When the dev server is up, Interceptor can screenshot `/admin*` for UX parity. Not part of `npm test`.

--- a/docs/add/RESEARCH-admin-cms-ux.md
+++ b/docs/add/RESEARCH-admin-cms-ux.md
@@ -1,0 +1,265 @@
+# Research capture — Admin CMS UI & UX
+
+- Date : 2026-08-18
+- Mode : Standard Research (4 agents, URLs vérifiées HTTP 200)
+- Session LifeOS : `082ba078-2ccd-4291-b2d2-a5cf77b7b769`
+- Amont : [`ADMIN-CMS.md`](./ADMIN-CMS.md) · [`CONTRAT-qualite-acme.md`](./CONTRAT-qualite-acme.md)
+- Question : bon UI/UX pour `/admin` — templates, catalogue, sections ADD, flows, technos
+- Objectif : spec UX actionnable ; résoudre « tout éditable » vs « admin minimal v1 »
+
+Agents : Ava Sterling (Claude) · Alex Rivera (Gemini) · Johannes (Grok) · Ava Chen (Perplexity)
+
+Input ISA — **LOCKED** → [`ISA-archstudio-admin-cms-ux.md`](./ISA-archstudio-admin-cms-ux.md).
+
+| Angle | Agent |
+|-------|--------|
+| Canon patterns (Backstage, Sanity, Payload, arc42, IcePanel) | Ava Sterling (Claude) |
+| Personas, flows écran, nav wireframe | Alex Rivera (Gemini) |
+| Anti-bloat, échecs CMDB, coupe v1 | Johannes (Grok) |
+| Patterns live 2024–2026 (blocks, draft/publish, i18n, preview) | Ava Chen (Perplexity) |
+
+---
+
+## Pourquoi
+
+| Pourquoi vrai | Pourquoi faux |
+|---------------|---------------|
+| Backstage / Sanity / Payload : admin généré depuis schéma | Plus d’écrans = meilleure adoption |
+| NN/g progressive disclosure | Textarea JSON = flexibilité |
+| CMDB meurt de champs optionnels jamais remplis | Owner + SLO + cost = qualité |
+| Preview iframe = standard headless 2024–2026 | L’opérateur n’a pas besoin de voir le rendu |
+| IcePanel/Backstage : auteur template ≠ consommateur | Même UI pour tous |
+| arc42 B-1 : absent > vide s’applique à l’admin | 50 champs « au cas où » |
+
+**Admin = auteur de seed typé, pas CMDB parallèle.**
+
+| Principe | Détail |
+|----------|--------|
+| Deux surfaces | `/admin` opérateur · app = fondateur (picker, jamais admin) |
+| Éditeurs typés | Schéma → formulaires ; JSON en « Avancé » replié |
+| Nav entity-centric | Templates · Lego · ADD · Flows |
+| Preview | Split-pane catalogue + document « comme le fondateur » |
+| Publish gate | Validation bloquante ; issues cliquables → champ |
+| i18n | Switcher EN/FR global ; tabs inline pour labels courts |
+
+[CONFLICT] Rich admin (8 nav, preview, graphe) vs Johannes 3 écrans v1.
+
+**Résolution :** UX **riche par fiche entité**, nav **simple v1**. Preview = onglet template/section. Import JSON bulk en parallèle des formulaires. Graphe deps v2.
+
+---
+
+## Personas
+
+| Persona | Surface | Ne voit pas |
+|---------|---------|-----------|
+| Opérateur solo | `/admin` | Projets users |
+| Fondateur | App | Admin, publish, schéma |
+
+Modèle : Backstage **Template Editor** (admin) vs **Scaffolder** (fondateur). Bouton **« Simuler parcours fondateur »** sur template.
+
+---
+
+## Nav v1
+
+```
+/admin
+├── Dashboard          (issues publish uniquement)
+├── Templates projet
+├── Catalogue Lego     → Briques · Variants · Intents · Deps
+├── Bibliothèque ADD
+├── Flow patterns
+├── Publish
+├── Localisation       (filtre FR manquant)
+└── Import / Export
+```
+
+---
+
+## Spec UI par domaine
+
+### Fiche brique (60/40 split)
+
+- Header : id · Draft/Published · modif
+- Métadonnées : icon · layer · scope · capabilities · concernTags[]
+- Contenu EN/FR : purpose · role · features · notes · whenUse/whenNot
+- Relations : variants Used-by (Payload Join pattern)
+- Avancé ▾ : JSON Zod-validated
+- Preview : tuile wizard + snippet glossaire
+- Footer : Valider · Brouillon · Publier
+
+### Template projet
+
+- Onglets : Métadonnée picker · Canvas (table composants v1) · Flows · Sections · Preview
+- Preview iframe document + switch EN/FR
+- Import JSON Acme v1 ; formulaire pour edits incrémentaux
+- [Simuler fondateur] [Publier]
+
+### Section ADD (Payload Blocks pattern)
+
+| type | éditeur |
+|------|---------|
+| cards | items icon/title/bullets |
+| compare | columns + table + cards |
+| timeline | items + aside |
+| table | grid rows |
+| text | blocks |
+
+Panes : Form | Preview papier | JSON
+
+v1 : éditeurs cards/text complets ; compare/timeline via import JSON ou simplifié.
+
+### Flow pattern
+
+Stepper vertical · hints name/tech/layers · test mapping Acme · ids locked v1.
+
+### Publish (wizard 4 étapes)
+
+1. Scope · 2. Validation (issues → champ) · 3. Diff résumé · 4. Confirmer
+
+Badge : Draft | Modified | Published (Strapi pattern).
+
+### i18n
+
+Switcher global · tabs EN|FR labels · « Copier EN→FR » · entrée Localisation transversale.
+
+---
+
+## Anti-patterns
+
+JSON textarea principal · flat list · dashboard vanity · champs owner/cost/SLO · canvas drag v1 · publish sans preview · admin = workspace fondateur · **emoji ou pictos Unicode dans l'UI admin** · **lib UI externe (shadcn, Lucide, Heroicons)** · **palette / ombres / radius « SaaS générique »** · **empty states avec illustration ou mascot** · **admin visuellement distinct de l'éditeur** (autre typo, autre couleur primaire, dark mode séparé).
+
+---
+
+## Identité visuelle — même chrome que l'app
+
+**Principe :** `/admin` n'est pas un produit à part. C'est le même Atelier qu'`Editor` et `Workspace`, avec une nav orientée contenu système. L'opérateur doit reconnaître ArchStudio immédiatement — pas un panneau CMS générique.
+
+### Réutiliser tel quel
+
+| Couche | Source app principale |
+|--------|------------------------|
+| Tokens & règles | `src/app/globals.css` (`--brand`, `--panel`, `--line`, `--r: 0px`, 5 règles Atelier) |
+| Typo | Archivo (prose) + Space Mono (ids, counts, timestamps, labels machine) |
+| Icônes | `src/components/Icon.tsx` — stroke SVG 24×24, jamais emoji |
+| Formulaires | `src/components/editors/Fields.tsx` — `.field`, `.input`, `.textarea`, `.select`, `.btn`, `IconPicker` |
+| Marque | `src/components/Brand.tsx` — `Lockup` avec sous-titre « Content » ou « Admin » |
+| Layout | Même shell que l'éditeur : sidebar `--sidebar`, topbar `--topbar`, panneau droit `--inspector`, fond `--bg` calque |
+| Preview | iframe document existant (`PaperDocument`) — pas de mockup séparé |
+
+### Ce qu'on n'introduit pas
+
+- Emoji (📦 ✅ ⚠️) ni caractères Unicode décoratifs à la place d'`Icon`
+- Bibliothèques UI tierces non présentes dans le repo (shadcn/ui, Radix themes, Lucide, Tailwind UI blocks)
+- Esthétique « AI dashboard » : dégradés violet/bleu, glassmorphism, `rounded-xl`, ombres douces partout, cartes flottantes
+- Illustrations stock, mascots, ou empty states « friendly » avec emoji
+- Palette primaire différente (violet indigo, etc.) — teal `--brand` reste l'action
+- Nav icon-only colorée type Notion/Linear clone
+
+### Signaux visuels admin (dans le chrome existant)
+
+- Sous-titre lockup : `Content` (mono, `--ink-3`) — pas un logo admin séparé
+- Badge état publish : `.pill` existant — `Draft` / `Modified` / `Published` (texte, pas emoji)
+- Dashboard : liste d'issues publish uniquement — pas de KPI cards colorées
+- Split-pane preview : même `.panel` / `.panel-2` que l'inspecteur projet
+
+### DoD visuel v1
+
+Un screenshot côte à côte éditeur projet ↔ fiche brique admin : même typo, même teal, mêmes bords carrés, mêmes boutons `.btn` — seule la nav latérale diffère (entités CMS vs scopes/layers).
+
+---
+
+## Staged v1 / v2
+
+| v1 | v2 |
+|----|-----|
+| Fiche brique complète | Graph deps |
+| Template import + table | Composer drag |
+| Sections cards/text + import | compare/timeline builders |
+| Preview onglet | Live keystroke sync |
+| Publish atomique | Diff restore |
+
+Test v1 : `purpose.fr` Auth0 → API <2 min sans redeploy.
+
+---
+
+## Flows clés (wireframe)
+
+**A — Corriger brique :** Catalogue → Briques → identity → FR → purpose → Valider → Publish(scope catalogue)
+
+**B — Publier Acme :** Templates → Acme → Preview PDF → Publish → validation 22 comps / 4 sections / 0 `[…]`
+
+**C — Section sur template :** Template → Sections → [+ Bibliothèque] → drawer type=cards → attach → Preview
+
+---
+
+## Patterns validés [HIGH]
+
+1. **Entity-centric tabs** — Backstage catalog entity page
+2. **Structure Builder sidebar** — Sanity domain-driven nav
+3. **Schema-driven forms** — Payload/Strapi ; Dynamic Zones ≈ sections typées
+4. **Locale switcher persistant** — Strapi i18n ; une locale à la fois pour longs textes
+5. **Draft → Validate → Publish** — Sanity document actions + Strapi bulk gate
+6. **Split-pane preview iframe** — Payload Live Preview + Sanity Presentation
+7. **Blocks drawer** — Payload Blocks pour bibliothèque sections
+8. **Used-by panel** — Payload Join pour `variant maps_to brick`
+9. **Template galerie → Review** — Backstage Software Templates
+
+---
+
+## ISCs candidats (spec UI)
+
+| ISC | Check |
+|-----|-------|
+| ISC-UX1 | Publish `purpose.fr` sans IDE ; picker <2 min |
+| ISC-UX2 | Publish bloqué si orphan ref ou FR manquant |
+| ISC-UX3 | Template Acme admin → PDF équivalent seed |
+| ISC-UX4 | Admin inaccessible depuis app fondateur |
+| ISC-UX5 | Section cards sans JSON textarea par défaut |
+| ISC-UX6 | Fiche admin brique : classes `.field`/`.btn`/`.input` identiques à `Inspector` ; aucun emoji dans le DOM |
+| Anti | Dashboard sans issues publish |
+| Anti | Champs owner/cost/SLO |
+| Anti | Lib UI externe ou palette non-ArchStudio dans `/admin` |
+
+---
+
+## Décisions UX proposées
+
+| ID | Décision |
+|----|----------|
+| UX1 | `/admin` séparé ; fondateur exclu |
+| UX2 | Nav 4 piliers + Publish + Import |
+| UX3 | Typé par entité ; JSON Avancé replié |
+| UX4 | Locale switcher + tabs courts |
+| UX5 | Preview onglet template/section ; tuile brique |
+| UX6 | Publish wizard bloquant |
+| UX7 | Blocks drawer sections ; v1 cards/text |
+| UX8 | Import JSON bulk template Acme |
+| UX9 | Graphe, drag, diff = v2 |
+| UX10 | **Même chrome que l'app** — `globals.css`, `Icon`, `Fields`, layout sidebar/inspector ; zéro design system parallèle |
+| UX11 | **Pas d'emoji** nav/boutons/états ; icônes = `Icon.tsx` stroke SVG uniquement |
+| UX12 | **Pas de look AI-generated** — pas de shadcn/Lucide, gradients, glass, coins arrondis 12px+, empty states illustrés |
+
+---
+
+## URLs vérifiées (HTTP 200, 2026-08-18)
+
+- https://backstage.io/docs/features/software-catalog/
+- https://www.sanity.io/docs/studio/structure-tool
+- https://docs.strapi.io/dev-docs/plugins/i18n
+- https://docs.strapi.io/cms/features/draft-and-publish
+- https://payloadcms.com/docs/fields/blocks
+- https://payloadcms.com/docs/live-preview/overview
+- https://www.nngroup.com/articles/progressive-disclosure/
+- https://faq.arc42.org/questions/B-1/
+- https://docs.icepanel.io/core-features/modelling
+- https://www.servicenow.com/community/developer-blog/why-cmdb-fails-even-before-discovery-is-implemented/ba-p/3464984
+
+---
+
+## Suite
+
+1. ~~Input ISA `archstudio-admin-cms-ux` jumeau [`ADMIN-CMS.md`](./ADMIN-CMS.md).~~ **Done**.
+2. ~~Figer UX1–UX12.~~ **Done** in ISA UX.
+3. ~~Shell `/admin` layout — **next** (F-UX0 Designer brief → F-UX1).~~ **Done** — visit `/admin` ; suite F-UX3 fiche brique.
+
+Contenu = ADMIN-CMS.md · **Comment éditer = ce doc.**

--- a/docs/add/RESEARCH-brick-metadata.md
+++ b/docs/add/RESEARCH-brick-metadata.md
@@ -1,0 +1,381 @@
+# Research capture — métadonnées briques → slots ADD
+
+- Date : 2026-08-17
+- Mode : Standard Research (4 agents, URLs vérifiées HTTP 200)
+- Session LifeOS : `082ba078-2ccd-4291-b2d2-a5cf77b7b769`
+- Prérequis : ISA `20260817-archstudio-add-toolkit` (projection ADD slim) **complete** ; voir aussi [`RESEARCH.md`](./RESEARCH.md)
+- Question : quels champs sur le catalogue `LegoBrick` alimentent les slots ADD et les gates CAF — sans encyclopédie CMDB
+- Objectif produit : poser une brique → le document non-tech se remplit ; chapitres transverses **justifiés**
+
+**État actuel code (point de départ) :** `LegoBrick` dans `src/lib/lego/types.ts` — `id`, `icon`, `layer`, `defaultScope`, `capabilities[]`, `role`, `responsibilities[]`, `notes[]`, `affinities[]`, `capabilityPhrase`. Pas de métadonnées ADD/gating/coût.
+
+Agents :
+
+| Angle | Agent |
+|-------|--------|
+| Canon field→section (arc42, C4, ISO 42010, WAF/CAF, ADR) | Ava Sterling (Claude) |
+| UX progressive disclosure (IcePanel, Structurizr, Backstage, arc42) | Alex Rivera (Gemini) |
+| Anti-bloat / échecs CMDB-catalogue | Johannes (Grok) |
+| Patterns live cloud + FinOps + Backstage | Ava Chen (Perplexity) |
+
+Ce fichier est une **capture de recherche**, pas un contrat LOCKED. L’ISA `brick-metadata-add-slots` devra figer le schéma et les ISCs.
+
+---
+
+## Verdict croisé
+
+**Enrichir le catalogue archetype, pas le fondateur.**
+
+La collecte de métadonnées est un **workflow de données** sur le catalogue système (seed SQLite), pas un formulaire encyclopédique à chaque drop. Les standards convergent : noyau **responsabilité + technologie + signaux de concern**, avec chapitres transverses activés par **gating**, pas par présence brute d’une brique.
+
+| Principe | Détail |
+|----------|--------|
+| Catalog-time | **≥70 %** — defaults stables (Auth, DB, CDN…) |
+| Placement | **≤2 questions** — exposition, gate ambigu |
+| Post-placement | **≤1 nudge** — ADR si irréversible |
+| Gating CAF | `concernTags[]` briques **∧** wizard projet (ISA ultérieure) |
+| Document | Section **absente** > section vide (arc42 B-1) |
+| FinOps MVP | **Pas de € par brique** — token `cost` pour ouvrir le chapitre seulement |
+
+[CONFLICT] Chen/Perplexity : ~12–14 champs incluant `costClass`. Johannes/Grok : **non** au MVP (données stale, faux débats).
+
+**Résolution :** `concernTags[]` inclut le token `cost` pour *gate* le chapitre cost management ; montants et drivers = snapshot **projet** ou mode audit.
+
+[CONFLICT] Sterling : champ explicite `docGates[]`. Grok : **8 champs max** orientés langage métier.
+
+**Résolution :** `concernTags[]` (enum fermé ~8–12 valeurs) **remplace** `docGates[]` — un seul levier.
+
+---
+
+## Pourquoi
+
+| Pourquoi vrai | Pourquoi faux |
+|---------------|----------------|
+| ISA #1 a la projection ADD (contexte, flux, glossaire, ADR index) — il manque la **source** auto depuis le catalogue | 50 champs par brique ≠ outillage fondateur |
+| arc42 §5 blackbox minimal = Purpose + Interfaces ; le reste est optionnel ([Tip 5-7](https://docs.arc42.org/tips/5-7/)) | CMDB enterprise (owner, SLO, cost center) = shelf-ware solo |
+| ISO 42010 : concerns → viewpoints, pas checklist par entité | « Brique Auth posée → chapitre IAM rempli de boilerplate » = théâtre |
+| Structurizr/IcePanel : defaults sur **archetype**, instance légère | Dupliquer dependsOn/capabilities alors que le graphe canvas les porte |
+| FinOps : metadata pour **allocation**, pas billing live sur catalogue ([Allocation](https://www.finops.org/framework/capabilities/allocation/)) | €/mo par entité → débats sans action, données périmées |
+
+Sources : [arc42 FAQ B-1](https://faq.arc42.org/questions/B-1/), [Structurizr archetypes](https://docs.structurizr.com/dsl/archetypes), [ServiceNow CMDB failure](https://www.servicenow.com/community/developer-blog/why-cmdb-fails-even-before-discovery-is-implemented/ba-p/3464984), [Nygard ADR](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions).
+
+---
+
+## Qui — qui remplit quoi
+
+| Acteur | Rôle | Ne fait pas |
+|--------|------|-------------|
+| **Mainteneur catalogue** (ArchStudio) | Rédige `purpose`, `concernTags`, `whenUse/whenNot` pour ~100 briques seed | Demander au fondateur de maintenir 27 champs |
+| **Fondateur non-tech** | Drag brique, 0–2 réponses contextuelles, nomme son produit | Remplir owner, SLO, OpenAPI, cost center |
+| **Canvas** | Vérité des connexions, protocoles, dépendances | Dupliquer un second CMDB parallèle |
+| **Wizard projet** (ISA #4) | Concerns globaux : multi-tenant, PII, budget band | Remplacer les tags catalogue |
+| **ADR** | Décisions irréversibles *dans ce projet* | Copier la fiche catalogue |
+
+---
+
+## Quoi — schéma catalogue recommandé
+
+### Champs sur `LegoBrick` (à figer en ISA)
+
+| # | Champ | Type | Sert (slot ADD) |
+|---|--------|------|-----------------|
+| 1 | `id` | string | existant |
+| 2 | `purpose` | string 1–2 phrases | Contexte, glossaire — fusionne `role` + `capabilityPhrase` |
+| 3 | `displayDescription` | string ≤120 | Contexte stakeholder (plain language) |
+| 4 | `c4Kind` | enum | person \| softwareSystem \| container \| external |
+| 5 | `layer` | enum | existant — regroupement arc42 §5 |
+| 6 | `technology` | string | Inventaire, stack annexe |
+| 7 | `defaultScope` | internal \| external | Contexte C4 boundary |
+| 8 | `exposureDefault` | internal \| partner \| public | Réseau slim (override instance) |
+| 9 | `dataClassDefault` | none \| internal \| personal \| regulated | Gate chapitre Data |
+| 10 | `identityPatternDefault` | none \| human \| service \| federated | Gate IAM |
+| 11 | `concernTags[]` | enum[] | Gates CAF (voir tableau ci-dessous) |
+| 12 | `whenUse` / `whenNot` | string[] max 2 | Anti-mauvaise brique ; hint ADR |
+
+**Valeurs `concernTags[]` proposées :** `data`, `iam`, `tenancy`, `network`, `security`, `ops`, `dr`, `observability`, `governance`, `cost`, `decision:irreversible`.
+
+### Field → section / gate
+
+| Signal catalogue | ADD / gate |
+|------------------|------------|
+| `purpose` + `displayDescription` | §1 Contexte, glossaire |
+| `defaultScope` + `c4Kind` | Contexte C4 (acteurs / systèmes voisins) |
+| `technology` | Inventaire, stack |
+| `exposureDefault` (ou override instance) | Chapitre networking (gated) |
+| `dataClassDefault` | Chapitre Data (gated) |
+| `identityPatternDefault` | Chapitre IAM (gated) |
+| `concernTags` inclut `tenancy` | Chapitre Tenancy (gated) |
+| `concernTags` inclut `cost` | Chapitre Cost management (gated, sans € par brique) |
+| `concernTags` inclut `decision:irreversible` | Suggestion index ADR (pas auto-rédaction) |
+| Union `concernTags` + wizard | **Seule** source d’ouverture chapitres preset CAF |
+
+### Couches (catalogue vs instance vs projet vs ADR)
+
+| Couche | Contient | Exemple Postgres |
+|--------|----------|-------------------|
+| **Catalog brick** | purpose, concernTags defaults, technology, whenUse/whenNot | « Datastore relationnel ; tags: data, ops, dr, cost » |
+| **Instance placée** | nom, exposure override, acteurs locaux, connexions | « billing-db-prod » |
+| **Projet (wizard)** | multi-tenant ?, PII ?, budget band, lean/audit | Gates finaux AND avec tags |
+| **ADR** | pourquoi *ce* choix *ici* | « ADR-003 : Postgres vs Dynamo pour billing » |
+
+### Inférer du graphe (ne pas stocker sur brique)
+
+- `capabilities[]` → arêtes labellisées canvas
+- `dependsOn[]` → topologie composants + links
+- `affinities[]`, `notes[]` → instance ou éditeur
+
+### Hard « do NOT collect » (MVP)
+
+Owner/on-call, SLO/SLA, OpenAPI, lifecycle, repo URL, montant coût / cost center par brique, DR RPO-RTO par brique, IAM policy detail (ARN, rôles), classification enterprise 27 niveaux, compliance framework par brique, champs « Backstage parity » sans consommateur, risk laundry-list sans owner.
+
+### Référence industrie (Backstage minimal — 8 champs effectifs)
+
+```yaml
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: artist-web
+  description: The place to be, for great artists
+  tags: [java]
+spec:
+  type: website
+  lifecycle: production
+  owner: artist-relations-team
+  system: public-websites
+```
+
+Source : [Backstage descriptor format](https://backstage.io/docs/features/software-catalog/descriptor-format)
+
+---
+
+## Où — dans le code ArchStudio
+
+```
+Catalogue (seed SQLite / LegoCatalogSnapshot)
+  LegoBrick + concernTags, purpose, …
+       ↓ lookup à la pose (maps_to)
+Composant canvas (Architecture.components[])
+       ↓ aggregateConcerns()
+Gates dérivés (deriveGates — wizard AND tags en ISA #4)
+       ↓
+buildOutline() — chapitres preset CAF si gate actif
+       ↓
+PaperDocument — slots contexte/glossaire enrichis depuis purpose catalog
+```
+
+**Hors scope document :** billing live, FOCUS export, CMDB sync.
+
+**Alignement RESEARCH.md §147–162 :** les 8 accroches d’origine (job métier, acteurs, data, exposition, identité, coût, when/when-not, ADR) mappent 1:1 sur le schéma ci-dessus.
+
+---
+
+## Comment — UX progressive disclosure
+
+### Parcours fondateur [HIGH]
+
+```
+Drag brique → nom auto → defaults silencieux (catalog)
+           → (0–2) questions si ambigu (exposition, PII ?)
+           → PDF slim mis à jour
+           → (optionnel) nudge ADR si decision:irreversible
+```
+
+### Split catalog-time vs placement-time
+
+| Accroche | Catalog | Placement | Post-placement |
+|----------|---------|-----------|----------------|
+| Job métier | default `purpose` | override optionnel | — |
+| Acteurs / vendor | vendor + acteurs typiques | chips acteurs produit | — |
+| Famille données | `dataClassDefault` | « Données perso ? » si ambigu | gate Data |
+| Exposition | — | **obligatoire** public/interne/privé | — |
+| Identité / secrets | `identityPatternDefault` | si non-Auth près user-facing | — |
+| Coût | tag `cost` seulement | — | snapshot projet plus tard |
+| When/when-not | `whenUse/whenNot` | réponses bool gates | — |
+| Décision irréversible | tag `decision:irreversible` | — | nudge ADR 3 champs |
+
+**Tolérance [MED] :** 0 question si defaults bons (CDN, cache) ; 1–2 au drop ; 3–5 max par session cadrage (8–12 briques).
+
+### Cinq patterns produit
+
+| Pattern | Source | ArchStudio |
+|---------|--------|------------|
+| Drop-first + panneau optionnel | IcePanel | Canvas d’abord ; PDF = vue |
+| Archetype + instance légère | Structurizr | Catalogue = archetype |
+| Overlays concern | IcePanel tags / Structurizr perspectives | concernTags → gates |
+| Micro-nudge 1 question | Backstage dependencies + NN/g | 1 gate = 1 chip |
+| Depth modes lean/audit | arc42 + Azure CAF | Wizard futur ; pas le chemin fondateur |
+
+### Règle anti-fausse complétude [HIGH]
+
+Un slot ADD ne s’ouvre que si **(a)** signal explicite (tag + composant posé) **et (b)** contenu généré cite une phrase catalogue ou réponse utilisateur — sinon **absent**, pas `[TODO]`.
+
+Gate ON : `(wizard concern OR user YES) AND brick emits tag` (wizard = ISA #4 ; sans wizard : tags seuls en mode lean).
+
+### Anti-patterns UX
+
+Wizard 12 headings TODO ; formulaire 50 champs ; chapitres CAF ouverts par simple présence brique ; FinOps € par entité ; questions techniques au drop (RLS, schema-per-tenant) ; re-demander au catalog à chaque drop.
+
+---
+
+## Gating — exemples concern → chapitre CAF
+
+| Question (langage fondateur) | Chapitre gated |
+|------------------------------|----------------|
+| Plusieurs clients / orgs isolées ? | Tenancy |
+| Données perso / santé / paiement ? | Data |
+| Exposé sur Internet ? | Networking |
+| Login / comptes utilisateurs ? | IAM |
+| Perte de données = catastrophe ? | DR (opt-in) |
+| Usage variable / budget serré ? | Cost management (détail) |
+
+Inspirations : [Azure WAF Security checklist](https://learn.microsoft.com/en-us/azure/well-architected/security/checklist) (SE:03 classification → SE:07 encryption), [Azure CAF enforce](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/govern/enforce-cloud-governance-policies).
+
+---
+
+## Failure modes + falsifiers
+
+| Mode d’échec | Signal | Falsifier |
+|--------------|--------|-----------|
+| Shelf-ware encyclopédique | >50 % champs vides après 30 j | ≥80 % instances avec purpose + tags sans rappel |
+| Fausses sections CAF | Chapitres ouverts sans concern matching | 100 % gates traçables tag + composant posé |
+| Catalogue ≠ canvas | Deux vérités YAML vs diagramme | Une source : graphe projet |
+| FinOps rabbit hole | Support « pourquoi €X sur cette brique » | Zéro champ coût instance MVP |
+| ADR inflation | 1 ADR auto par brique | ADR si whenNot violé ou tag irreversible + nudge accepté |
+| Glossaire générique | Termes REST/HTTPS | Termes = noms purpose + acteurs produit |
+
+---
+
+## Conséquence implémentation — scope ISA #2
+
+### In scope
+
+1. Étendre `LegoBrick` + migration seed pour **~20 briques pilotes** (auth, db, api gateway, cdn, workers, messaging, llm, ops…)
+2. `aggregateConcerns(architecture)` — union concernTags des briques posées (via `maps_to` / variant)
+3. `deriveGates(concerns, wizard?)` — sans wizard : tags seuls ; avec wizard : AND
+4. `buildOutline` — injecter chapitres preset CAF seulement si gate actif
+5. Enrichir projection contexte/glossaire depuis `purpose` catalog (pas seulement `component.role`)
+
+### Out of scope (ISAs suivantes)
+
+- Wizard besoins 4 questions (ISA #4)
+- FinOps montants / FOCUS billing
+- Éditeur ADR UI
+- Templates produit website/mobile (ISA #3)
+- ~100 flows gold (~20 seulement)
+- Édition catalogue par l’utilisateur final
+
+### ISCs candidats (à formaliser en ISA)
+
+| ID | Check |
+|----|-------|
+| ISC-B1 | `LegoBrick` expose `purpose`, `concernTags[]` ; seed ≥1 brique auth avec `{iam, security}` |
+| ISC-B2 | Placer Auth0 + Postgres → `aggregateConcerns` contient `iam`, `data` |
+| ISC-B3 | Gate `iam` ON → chapitre preset IAM dans outline ; OFF → absent |
+| ISC-B4 | Contexte ADD inclut phrase `purpose` catalog pour composant lié |
+| ISC-B5 | Anti : pas de champ coût € sur `LegoBrick` |
+| ISC-B6 | Chapitre CAF absent si tag seul sans composant posé |
+
+---
+
+## Notes par agent
+
+### Sterling (Claude) — canon field→section
+
+- Blackbox arc42 minimal = Purpose + Interfaces ; §8 « DO NOT cover all topics ».
+- C4 : name, type, technology, description par élément.
+- ISO 42010 : concerns → viewpoints, pas champs obligatoires par composant.
+- Proposition 12 champs incluant `docGates[]` — **résolu** en `concernTags[]` unique.
+- Interfaces = **edges** canvas, pas capabilities[] catalogue.
+- ADR : technology choice, identity, regulated data, tenancy, public exposure — pas paramètres réversibles.
+
+### Rivera (Gemini) — personas / UX
+
+- IcePanel : drop → nom + description ; tags Risk/Cost/Security en overlay.
+- Structurizr : archetypes portent defaults ; instance = placement.
+- Backstage : champs conditionnels `dependencies` — 1 question = 1 concern.
+- arc42 B-1 + canvas 1 page : ne pas remplir tout ; compartiment vide = absent.
+- NN/g : progressive disclosure ≤2 niveaux ; staged disclosure seulement pour ADR court.
+- Recommandation **B + A + D** : catalog defaults + drop-first + micro-nudge.
+
+### Johannes (Grok) — anti-bloat
+
+- CMDB / catalogue enterprise échoue : scope « tout modéliser », champs optionnels jamais remplis, pas de consommateur 60 s.
+- Backstage adoption : mode « trop épais » (27 champs) → abandon ; cost per service **retiré** (stale).
+- **8 champs max** ranked : jobMetier, displayDescription, actors, concernTags, whenUse/whenNot, dataClass, exposure, vendorOrSystem.
+- FinOps sur briques MVP : **non** — snapshot projet.
+- Gating : wizard + concernTags ; pas logique lourde par brique.
+- Split catalogue / archétype / instance / wizard explicite.
+
+### Chen (Perplexity) — patterns live 2024–2026
+
+- Convergence [HIGH] : ownership, environment, classification, cost allocation — Backstage + Azure CAF tagging + AWS PG + FinOps.
+- Azure CAF 5 catégories tags : functional, classification, accounting, purpose, ownership.
+- AWS TagOptions : taxonomie contrôlée à la provision.
+- WAF = checklists par service, pas schéma JSON — ArchStudio **projette** catalogue → checklists (Azure WAF service guides).
+- FinOps : dedicated vs shared cost ; metadata allocation sans billing live.
+- arc42 site = 12 sections ; pas de page « v9 » distincte vérifiée → **[MED]** sur numéro version.
+
+---
+
+## URLs vérifiées (HTTP 200, 2026-08-17)
+
+### arc42 / C4 / ADR
+
+- https://faq.arc42.org/questions/B-1/
+- https://docs.arc42.org/section-3/
+- https://docs.arc42.org/section-5/
+- https://docs.arc42.org/section-8/
+- https://docs.arc42.org/section-9/
+- https://docs.arc42.org/tips/5-7/
+- https://docs.arc42.org/tips/8-10/
+- https://docs.arc42.org/home/
+- https://c4model.com/diagrams/system-context
+- https://c4model.com/diagrams/notation
+- https://c4model.com/faq
+- https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions
+- https://martinfowler.com/bliki/ArchitectureDecisionRecord.html
+
+### UX / catalogues
+
+- https://docs.icepanel.io/core-features/modelling
+- https://docs.icepanel.io/visual-storytelling/perspective-tags
+- https://docs.icepanel.io/getting-started
+- https://docs.structurizr.com/dsl/archetypes
+- https://docs.structurizr.com/ui/diagrams/perspectives
+- https://backstage.io/docs/features/software-catalog/descriptor-format
+- https://backstage.io/docs/features/software-templates/input-examples/
+- https://canvas.arc42.org/
+- https://www.nngroup.com/articles/progressive-disclosure/
+
+### Cloud / FinOps / anti-patterns
+
+- https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/resource-tagging
+- https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-areas
+- https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/govern/enforce-cloud-governance-policies
+- https://learn.microsoft.com/en-us/azure/well-architected/security/checklist
+- https://learn.microsoft.com/en-us/azure/well-architected/service-guides/
+- https://docs.aws.amazon.com/prescriptive-guidance/latest/tagging-best-practices/introduction.html
+- https://docs.aws.amazon.com/servicecatalog/latest/adminguide/tagoptions.html
+- https://docs.aws.amazon.com/wellarchitected/latest/framework/welcome.html
+- https://docs.cloud.google.com/architecture/framework
+- https://docs.cloud.google.com/architecture/framework/security
+- https://www.finops.org/framework/capabilities/allocation/
+- https://www.finops.org/framework/domains/
+- https://focus.finops.org/
+- https://www.servicenow.com/community/developer-blog/why-cmdb-fails-even-before-discovery-is-implemented/ba-p/3464984
+- https://harmony.io/insights/what-is-a-cmdb
+- https://www.devopsness.com/blog/backstage-adoption-from-demo-to-80-service-coverage-in-6-months-2026-04-23
+- https://muhammadamal.my.id/blog/service-catalog-backstage-design/
+
+---
+
+## Suite produit
+
+1. **Ce doc** = input Decision log pour ISA `brick-metadata-add-slots`.
+2. Scaffolder ISA avec Goal « catalog metadata drives gated CAF slots + enriched context/glossary ».
+3. Implémenter schéma + ~20 briques pilotes + `aggregateConcerns` / `deriveGates` / extension `buildOutline`. *(fait — ISA complete)*
+4. **Qualité Acme** — [`CONTRAT-qualite-acme.md`](./CONTRAT-qualite-acme.md).
+5. **Admin CMS** — authoring sans PR : [`ADMIN-CMS.md`](./ADMIN-CMS.md).
+6. Ensuite : wizard besoins (ISA #4), éditeur ADR (dette ISA #1).
+
+**Lien amont :** [`RESEARCH.md`](./RESEARCH.md) §147–162 avait esquissé les 8 accroches ; cette recherche les **fige** en schéma catalogue + UX + anti-patterns.

--- a/docs/add/RESEARCH.md
+++ b/docs/add/RESEARCH.md
@@ -1,0 +1,235 @@
+# Research capture — élargir l’ADD
+
+- Date : 2026-08-17
+- Mode : Standard Research (4 agents, URLs vérifiées HTTP 200)
+- Session LifeOS : `082ba078-2ccd-4291-b2d2-a5cf77b7b769`
+- Question : quoi / qui / comment / où / pourquoi élargir l’Architecture Design Document, avant de collecter les données de briques
+- Objectif produit : donner aux users tous les outils nécessaires (non-tech friendly)
+
+Agents :
+
+| Angle | Agent |
+|-------|--------|
+| Canon sections (arc42, C4, 42010, CAF, ADR) | Ava Sterling (Claude) |
+| Personas + UX progressive | Alex Rivera (Gemini) |
+| Anti-bloat / ADR vs tome | Johannes (Grok) |
+| Templates live 2024–2026 | Ava Chen (Perplexity) |
+
+Ce fichier est une **capture de recherche**, pas un contrat LOCKED. Une Decision ISA devra figer le sommaire slim.
+
+---
+
+## Verdict croisé
+
+**Élargir le kit d’outils, pas le PDF par défaut.**
+
+Ajouter des chapitres `[…]` à l’ADD imprimable n’équipe pas l’utilisateur. Ça crée du théâtre de complétude. « Tous les outils » = un **modèle** (canvas / C4) + des **vues** par audience + un **journal de décisions (ADR)** à côté.
+
+[CONFLICT] Sterling : ajouter des sections (glossaire, contraintes, stratégie, déploiement, risques, index ADR) **avant** les métadonnées de briques. Johannes : **ne pas gonfler** le document 13 chapitres.
+
+**Résolution :** on ajoute des *mécanismes* (gating, C4 L1 dans le corps, index ADR, glossaire auto, zéro placeholder TODO). On n’affiche pas 12 tiroirs arc42 remplis de cases vides.
+
+---
+
+## Pourquoi
+
+| Pourquoi vrai | Pourquoi faux |
+|---------------|----------------|
+| Un AD sans stakeholders / concerns n’est pas un AD (ISO 42010) | Plus de cases vides ≠ plus d’outils |
+| Sans C4 Context le non-tech n’a rien à lire | Un 14ᵉ chapitre cloud n’aide pas à collecter des briques |
+| Sans ADR les chapitres CAF n’ont pas de « pourquoi » | arc42 FAQ B-1 : ne remplissez pas tout |
+| Nygard : les gros documents ne sont ni lus ni tenus à jour | L’instinct « le doc n’est pas ouvert → ajouter du détail » empire l’adoption gap |
+
+Sources : [arc42 FAQ B-1](https://faq.arc42.org/questions/B-1/), [Nygard ADR](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions), [C4 system context](https://c4model.com/diagrams/system-context).
+
+---
+
+## Qui — sept audiences, sept vues
+
+| Audience | Besoin réel | Ignore |
+|----------|-------------|--------|
+| Fondateur | 1 page : valeur, coût, risque, go/no-go | Conteneurs, IAM, séquences |
+| PM / PO | 3–5 buts qualité, contraintes, trade-offs roadmap | Niveau composant / code |
+| Stakeholder non-tech | C4 Context : qui utilise, systèmes voisins | Protocoles, stack |
+| Ingénieur | C4 Container, ADR, transverses | Résumé exec |
+| Ops / SRE | Déploiement, obs, failover | Logique métier interne |
+| Sécurité / auditeur | Vue sécu, décisions + rationale, omissions **justifiées** | Glossaire « fun » |
+| Finance | TCO / ordre de grandeur, impact $ des décisions | UML / C3 |
+
+Une seule vérité modèle, plusieurs vues — pas un PDF unique. (Rivera / IcePanel / Structurizr)
+
+---
+
+## Quoi — keep / add / demote
+
+### Garder
+
+Les 13 chapitres preset actuels correspondent aux **8 design areas CAF** (transverses, pas le TOC principal) :
+
+objectifs/scope, data, scale, tenancy, DR, observability, resource segmentation, IAM, networking, cost management, governance, CI/CD, monthly cost estimate.
+
+Plus le généré : intro, schéma, inventaire, flows, stack.
+
+### Ajouter comme outils (défaut slim)
+
+| Quoi | Où | Comment |
+|------|-----|---------|
+| Stakeholders + comment lire | §0 | Chips d’audience |
+| Contraintes (réglementaire, orga, budget) | près des objectifs | Wizard besoins |
+| C4 Context (acteurs + systèmes autour) | **corps** parties 1–2 | Généré depuis groupes / vendors |
+| Stratégie (3–7 idées) | après contexte | 1 page, template produit |
+| 3–5 parcours clés | **corps**, pas seulement annexe 6 | Promouvoir les flows |
+| Index ADR | journal, pas un pavé | Title, Context, Decision, Consequences, Status |
+| Glossaire termes **du produit** | fin | Auto depuis briques posées |
+| Risques (1 page, owner) | opt-in | Pas une laundry-list |
+
+arc42 §5 Building Block View est la seule section que la doc officielle qualifie de mandatory pour *toute* doc d’architecture. C4 : Context + Container suffisent pour la plupart des équipes.
+
+### Ne pas ajouter au défaut
+
+- Placeholders `[TODO]` / « à remplir plus tard »
+- C4 Component / Code (et Container sauf besoin d’implémentation)
+- Corpus ADR embarqué dans le tome (1 décision ≠ encyclopédie)
+- 44 patterns Azure, threat model complet, ERD
+- Estimation € comme chapitre pair des 12 autres (snapshot daté sous cost management)
+- Sustainability comme chapitre 14 par défaut
+- Glossaire de termes internet communs (REST, HTTPS)
+
+### Mode audit (Azure design specification) — pas le chemin non-tech
+
+Quand l’état du document est « Approved », Azure attend en plus : technical spec, DR plans, security/compliance, métadonnées State / work item / key individuals. Gater derrière un mode audit, pas le wizard fondateur.
+
+---
+
+## Où — dans l’ADD vs à côté
+
+```
+ADD imprimé slim
+  Buts · Contexte C4 · Schéma/inventaire · 1–3 parcours · Index ADR · Glossaire
+
+Transverses gated (les 13 CAF)
+  Data, tenancy, obs, CI/CD… seulement si brique / template / concern le justifie
+  Lean : caché. Audit : « omis — raison »
+
+Hors ADD (outils distincts)
+  Log ADR append-only (près du projet / git)
+  Fiche 3–5 buts qualité
+  Collecte fiches briques (workflow données, pas un chapitre)
+  Overlay sécu / coût (tags, pas wiki parallèle)
+```
+
+Industry 2024–2026 : **pas d’ADD unique obligatoire**. Trois familles :
+
+1. **arc42** — 12 sections **toutes optionnelles** (v9.0, juillet 2025)
+2. **Hyperscalers** — spec + ADR (contexte / décision / conséquences) + piliers WAF
+3. **C4 + ThoughtWorks** — diagrammes L1–L2 + ADR légers, pas de document-monolithe
+
+AWS minimum ADR : context, decision, consequences. MADR 4.0.0 (2024-09-17) : beaucoup de champs explicitement optional.
+
+---
+
+## Comment — UX
+
+1. Canvas / C4 L1 **d’abord**, texte ensuite (IcePanel, arc42 canvas 1 page).
+2. Gating par concern : « plusieurs clients » → tenancy ; « données perso » → privacy ; sinon caché.
+3. Auto-remplir depuis le modèle ; l’humain complète 1–3 champs.
+4. Zéro `[TODO]` affiché. Compartiment vide = absent.
+5. Vues rôle, pas un PDF unique.
+6. ADR : draft OK ; accept = humain + alternatives + conséquences +/− + statut Proposed/Accepted/Superseded. Append-only.
+7. Maturité : MVP = overview + context + ADRs ; prod = + blocs + déploiement ; complexe = full.
+
+Anti-pattern : wizard qui dump 12 headings TODO.
+
+Parcours : **diagramme d’abord** (greenfield). Exception auditeur : skeleton formel avec N/A justifié, pas des pages blanches.
+
+---
+
+## Conséquence pour les données de briques (plus tard)
+
+Ne pas collecter 50 champs encyclopédie. Accroches vers les slots ci-dessus :
+
+| Champ brique | Sert |
+|--------------|------|
+| Job métier (1 phrase) | Buts / glossaire |
+| Acteurs / vendor | Contexte C4 |
+| Famille de données | Data gated |
+| Exposition public/privé | Réseau slim |
+| Identité / secrets | IAM gated |
+| Classe de coût + drivers | Estimation / FinOps |
+| Quand / quand pas | Gates |
+| Décision irréversible | **ADR**, pas un paragraphe ADD |
+
+La collecte de briques est un **workflow de données**. L’élargissement ADD ne la remplace pas.
+
+---
+
+## Notes par agent
+
+### Sterling (Claude) — canon
+
+- Complet-mais-utilisable ≠ tout remplir.
+- Outline recommandé type arc42 0–12 + annexes ; CAF dans §8.
+- Ajouter avant bricks : §0 stakeholders, §2 constraints, §4 strategy, §7 deployment, §9 ADR index, §11 risks, §12 glossary.
+- Promouvoir diagramme L1 dans §3, L2 dans §5 ; 3–5 flows dans §6.
+- Demote monthly cost en snapshot ; tech stack reste annexe.
+- C4 L3/L4 hors ADD imprimable.
+
+### Rivera (Gemini) — personas / UX
+
+- Personne ne « lit l’ADD » : sept questions, sept vues.
+- IcePanel / Structurizr : un modèle, overlays (Risk / Cost / Security), docs sur l’objet.
+- arc42 : ordre de **création** libre ; souvent §3 contexte d’abord ; canvas avant le template.
+- Start = canvas/C1 ; chapitres gated ; skeleton depuis le graphe ; filtre rôle ; mode audit vs lean.
+
+### Johannes (Grok) — contra
+
+- Expansion du tome = mauvais levier pour « outiller » la collecte de briques.
+- ADR ≠ ADD. Les coller dans le tome les tue.
+- Pour non-tech, seul C4 Context est un outil dans le document.
+- Exclure TODO, C4 Component/Code, transverses IAM dans le défaut, laundry-list risques sans owner.
+- ADD mince lu en une heure ; le reste en liens.
+
+### Chen (Perplexity) — templates live
+
+- arc42 v9.0 (juil. 2025) : 12 optional ; quality goals essential en pratique.
+- Azure : architecture design specification (2024) **et** ADR (page 2026-04-10) distincts.
+- AWS : pas d’ADD 12 chapitres ; ADR process.
+- GCP : ADR outline 2024 + template solution WAF (skills) avec sustainability.
+- ThoughtWorks Radar : lightweight ADR (Adopt 2018, plus sur l’édition courante) — toujours le pattern.
+- Open-source : Nygard 5 champs ; MADR 4.0.0 ; Y-Statement ; ISO 42010 companion sur adr.zone.
+
+---
+
+## URLs vérifiées (HTTP 200, 2026-08-17)
+
+- https://arc42.org/overview
+- https://canvas.arc42.org/
+- https://faq.arc42.org/questions/B-1/
+- https://faq.arc42.org/questions/B-16/
+- https://docs.arc42.org/section-1/
+- https://docs.arc42.org/section-5/
+- https://www.innoq.com/en/blog/2022/08/brief-introduction-to-arc42/
+- https://c4model.com/diagrams
+- https://c4model.com/diagrams/system-context
+- https://c4model.com/faq
+- https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions
+- https://martinfowler.com/bliki/ArchitectureDecisionRecord.html
+- https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-areas
+- https://learn.microsoft.com/en-us/azure/well-architected/architect-role/architecture-decision-record
+- https://learn.microsoft.com/en-us/azure/well-architected/architect-role/architecture-design-specification
+- https://docs.aws.amazon.com/wellarchitected/latest/framework/welcome.html
+- https://docs.aws.amazon.com/prescriptive-guidance/latest/architectural-decision-records/adr-process.html
+- https://cloud.google.com/architecture/architecture-decision-records
+- https://docs.icepanel.io/getting-started
+
+Exclues / déclassées par les agents : URLs 403, pages SEO commerciales « ADR 2026 », stats blogs non primaires.
+
+---
+
+## Suite produit
+
+1. Figer en Decision le **sommaire slim + gated + ADR** (ce doc = input, pas LOCKED).
+2. Ensuite seulement : contrat de données brique aligné sur les accroches.
+3. Templates produit (site web, app mobile) remplissent le slim, pas le mode audit.
+4. **Barre de qualité** — [`CONTRAT-qualite-acme.md`](./CONTRAT-qualite-acme.md).
+5. **Admin CMS** — tout le contenu système éditable sans code : [`ADMIN-CMS.md`](./ADMIN-CMS.md).

--- a/docs/lego/GAPS.md
+++ b/docs/lego/GAPS.md
@@ -8,7 +8,7 @@ This page records current constraints. It is not a release chronology.
 
 | Area | Implemented | Current limit |
 |---|---|---|
-| Catalog persistence | Versioned transactional SQLite seed and runtime reads | Authoring remains in `seed-data.ts`; no catalog admin UI |
+| Catalog persistence | Versioned transactional SQLite seed and runtime reads; **admin CMS** at `/admin` for draft→publish | Authoring can still start from `seed-data.ts` for locked seeds; runtime prefers published admin when `CONTENT_FROM_ADMIN=1` |
 | Catalog API | Localized English/French snapshots | Browser memoization lasts for the page lifetime |
 | Placement taxonomy | 12 intents, optional shapes, 4 modes, compatible scopes, 154 variants | Runtime seed covers 26 of the 40 conceptual bricks |
 | Placement Wizard | Intent → shape → mode → scope → variant; targeted Add & link keeps the requested brick in-filter | Provider choice remains automatic inside targeted Add & link |
@@ -20,14 +20,14 @@ This page records current constraints. It is not a release chronology.
 
 ## Runtime catalog boundary
 
-The complete [CATALOG.md](./CATALOG.md) defines 38 infrastructure roles plus `webApp` and `mobileApp`. The versioned SQLite seed currently exposes 26 bricks. Repository tests enforce the runtime count, so a documented brick is not automatically available to the wizard or a flow plate.
+The complete [CATALOG.md](./CATALOG.md) defines 38 infrastructure roles plus `webApp` and `mobileApp`. The versioned SQLite seed currently exposes 40 bricks (tests enforce the count). Repository tests enforce the runtime count, so a documented brick is not automatically available to the wizard or a flow plate unless it is in the seed / admin catalog.
 
-Catalog changes remain code-first:
+Catalog changes (2026-08 admin CMS):
 
-- `src/lib/lego/seed-data.ts` contains the authoring seed.
-- `LEGO_CATALOG_VERSION` controls whether a new version is inserted.
-- Existing rows for a seeded version are not updated by editing the seed alone.
-- The API reads SQLite; it does not read Markdown or parse the catalog documents.
+- **Operator path:** `/admin` → Catalogue Lego / Templates / ADD / Flows / Locale / Publish — draft → publish; no content PR required for day-to-day edits.
+- **Seed path:** `src/lib/lego/seed-data.ts` + `LEGO_CATALOG_VERSION` still bootstrap locked rows; `ensureLegoCatalog` re-seeds deleted locked ids.
+- **Runtime flag:** `CONTENT_FROM_ADMIN=1` makes project/template/flow/section resolve paths read **published** admin JSON (see `src/lib/templates/resolve.server.ts`, `src/lib/admin/*`).
+- Spec / ISA (complete): [`../add/README.md`](../add/README.md).
 
 ## Placement constraints
 
@@ -66,7 +66,7 @@ Catalog changes remain code-first:
 - Offer provider selection for each created flow step.
 - Add an explicit payment/commerce intent and PSP brick.
 - Derive inventories automatically from the versioned runtime catalog.
-- Add catalog administration and migration tooling.
+- ~~Add catalog administration and migration tooling~~ — **shipped** as `/admin` CMS (ISA complete 2026-08-20). Follow-ups: hydrate Q2 card density ([`../add/CONTRAT-qualite-acme.md`](../add/CONTRAT-qualite-acme.md) B2), optional `ADMIN_TOKEN` / body size if network-exposed.
 - Prune stale stack entries safely.
 
 The locked contracts remain authoritative for ids and semantics. Deferred work must preserve the distinction between a single capability brick and a multi-step flow pattern.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "start": "next start",
     "reset": "node -e \"require('fs').rmSync('data',{recursive:true,force:true});console.log('database removed — it will be recreated and re-seeded on next start')\"",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test \"src/**/*.test.ts\""
+    "test": "tsx --test \"src/**/*.test.ts\"",
+    "test:admin": "tsx --test \"src/lib/admin/**/*.test.ts\" \"src/lib/lego/admin-catalog.test.ts\""
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.117.1",

--- a/scripts/admin-smoke.mjs
+++ b/scripts/admin-smoke.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+/**
+ * Optional F-REG R3 smoke — local only, not CI.
+ * If ADMIN_SMOKE_BASE (or http://127.0.0.1:3000) is up, GET key admin routes
+ * and expect 200. If the server is down, exit 0 with a skip message.
+ */
+const base = (process.env.ADMIN_SMOKE_BASE || 'http://127.0.0.1:3000').replace(/\/$/, '');
+const paths = ['/admin', '/admin/catalog', '/admin/publish', '/admin/templates', '/admin/locale'];
+const TIMEOUT_MS = Number(process.env.ADMIN_SMOKE_TIMEOUT_MS || 30_000);
+
+async function probe() {
+  try {
+    const res = await fetch(`${base}/admin`, { signal: AbortSignal.timeout(Math.min(TIMEOUT_MS, 5000)) });
+    return res.status;
+  } catch {
+    return null;
+  }
+}
+
+const status = await probe();
+if (status === null) {
+  console.log(`[admin-smoke] skip — no server at ${base}`);
+  process.exit(0);
+}
+
+let failed = 0;
+for (const p of paths) {
+  try {
+    const res = await fetch(`${base}${p}`, { signal: AbortSignal.timeout(TIMEOUT_MS) });
+    if (res.status !== 200) {
+      console.error(`[admin-smoke] FAIL ${p} → ${res.status}`);
+      failed += 1;
+    } else {
+      console.log(`[admin-smoke] ok ${p} → 200`);
+    }
+  } catch (err) {
+    console.error(`[admin-smoke] FAIL ${p} → ${err?.message || err}`);
+    failed += 1;
+  }
+}
+
+process.exit(failed === 0 ? 0 : 1);

--- a/src/app/admin/catalog/bricks/[id]/page.tsx
+++ b/src/app/admin/catalog/bricks/[id]/page.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+import BrickEditor from '@/components/admin/BrickEditor';
+
+export default function AdminBrickDetailPage() {
+  const params = useParams();
+  const id = typeof params.id === 'string' ? params.id : params.id?.[0] ?? '';
+
+  return <BrickEditor brickId={id} />;
+}

--- a/src/app/admin/catalog/bricks/page.tsx
+++ b/src/app/admin/catalog/bricks/page.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Icon } from '@/components/Icon';
+import { AdminEmpty } from '@/components/admin/AdminEmpty';
+import { AdminWorkspace } from '@/components/admin/AdminWorkspace';
+import { NewBrickDialog } from '@/components/admin/NewCatalogDialogs';
+import { PublishBadge } from '@/components/admin/PublishBadge';
+import { STARTER_LAYERS } from '@/lib/defaults';
+import { fetchCatalogState } from '@/lib/admin/catalog';
+import { invalidateLegoCatalogCache, loadLegoCatalog } from '@/lib/lego/client';
+import type { LegoBrick, LegoCatalogSnapshot } from '@/lib/lego/types';
+
+function BrickRow({ id, brick }: { id: string; brick: LegoBrick }) {
+  return (
+    <Link
+      href={`/admin/catalog/bricks/${id}`}
+      className="tree-row"
+      style={{ textDecoration: 'none', color: 'inherit' }}
+    >
+      <span className="ficon"><Icon name={brick.icon || 'box'} size={15} /></span>
+      <span className="label mono" style={{ fontSize: 12 }}>{id}</span>
+      <span className="count">{brick.layer} · {brick.defaultScope}</span>
+    </Link>
+  );
+}
+
+export default function AdminBricksPage() {
+  const router = useRouter();
+  const [catalog, setCatalog] = useState<LegoCatalogSnapshot | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [catalogDirty, setCatalogDirty] = useState(false);
+
+  const load = useCallback(async () => {
+    invalidateLegoCatalogCache();
+    try {
+      const snap = await loadLegoCatalog('en');
+      setCatalog(snap);
+      setError(null);
+      const state = await fetchCatalogState().catch(() => null);
+      if (state) setCatalogDirty(state.dirty);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load catalog');
+    }
+  }, []);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const bricks = useMemo(() => {
+    if (!catalog) return [];
+    const q = query.trim().toLowerCase();
+    return Object.entries(catalog.bricks)
+      .filter(([id, brick]) => {
+        if (!q) return true;
+        return `${id} ${brick.layer} ${brick.defaultScope} ${brick.role}`.toLowerCase().includes(q);
+      })
+      .sort(([a], [b]) => a.localeCompare(b));
+  }, [catalog, query]);
+
+  const scopeOpts = useMemo(
+    () => (catalog?.scopes ?? []).map(s => ({ value: s.id, label: `${s.id} — ${s.label}` })),
+    [catalog],
+  );
+
+  const layerOpts = useMemo(() => {
+    const ids = new Set(STARTER_LAYERS.map(l => l.id));
+    if (catalog) {
+      for (const brick of Object.values(catalog.bricks)) ids.add(brick.layer);
+    }
+    return [...ids].sort().map(id => {
+      const starter = STARTER_LAYERS.find(l => l.id === id);
+      return { value: id, label: starter ? `${id} — ${starter.name}` : id };
+    });
+  }, [catalog]);
+
+  return (
+    <>
+      <AdminWorkspace
+        lede={catalog ? `${bricks.length} brick${bricks.length === 1 ? '' : 's'} — open a fiche for form + preview` : 'Loading…'}
+        search={{ value: query, onChange: setQuery, placeholder: 'Filter bricks…' }}
+        error={error}
+        bodyStyle={{ padding: '8px 12px 24px' }}
+        actions={
+          <>
+            <PublishBadge state={catalogDirty ? 'modified' : 'published'} />
+            <button type="button" className="btn primary sm" onClick={() => setCreating(true)}>
+              <Icon name="plus" size={13} />New brick
+            </button>
+          </>
+        }
+      >
+        {!error && !catalog && <AdminEmpty>Loading catalog…</AdminEmpty>}
+        {!error && catalog && bricks.length === 0 && (
+          <AdminEmpty>{query ? 'No brick matches this search.' : 'No bricks in catalog.'}</AdminEmpty>
+        )}
+        {bricks.map(([id, brick]) => (
+          <BrickRow key={id} id={id} brick={brick} />
+        ))}
+      </AdminWorkspace>
+      {creating && (
+        <NewBrickDialog
+          scopes={scopeOpts}
+          layers={layerOpts}
+          onClose={() => setCreating(false)}
+          onCreated={id => {
+            setCreating(false);
+            router.push(`/admin/catalog/bricks/${id}`);
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/src/app/admin/catalog/cloud-services/page.tsx
+++ b/src/app/admin/catalog/cloud-services/page.tsx
@@ -1,0 +1,238 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { Group, Text } from '@/components/editors/Fields';
+import { CatalogSaveFlag, CatalogSplitShell, CatalogTreeRow, type CatalogSaveState } from '@/components/admin/CatalogList';
+import { NewCloudServiceDialog } from '@/components/admin/NewCloudServiceDialog';
+import { PublishBadge } from '@/components/admin/PublishBadge';
+import {
+  deleteCloudService,
+  fetchCloudServices,
+  fetchCloudServicesState,
+  patchCloudServicesVerifiedOn,
+  publishCloudServices,
+  updateCloudService,
+  type AdminCloudServiceItem,
+} from '@/lib/admin/cloud';
+import type { L10n } from '@/lib/templates/types';
+import { RESOLVED_TARGETS, TARGET_LABELS, t } from '@/lib/templates/types';
+import type { ServiceCell, ServiceRow } from '@/lib/templates/services';
+
+function locPair(value: L10n | undefined): { en: string; fr: string } {
+  if (!value) return { en: '', fr: '' };
+  if (typeof value === 'string') return { en: value, fr: value };
+  return { en: value.en ?? '', fr: value.fr ?? '' };
+}
+
+function fromPair(en: string, fr: string): L10n {
+  if (en === fr) return en;
+  return { en, fr };
+}
+
+function publishBadge(dirty: boolean, publishedAt: string | null): 'draft' | 'modified' | 'published' {
+  if (dirty) return 'modified';
+  if (publishedAt) return 'published';
+  return 'draft';
+}
+
+export default function AdminCloudServicesPage() {
+  const [items, setItems] = useState<AdminCloudServiceItem[]>([]);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState('');
+  const [saveState, setSaveState] = useState<CatalogSaveState>('idle');
+  const [busy, setBusy] = useState(false);
+  const [dirty, setDirty] = useState(false);
+  const [publishedAt, setPublishedAt] = useState<string | null>(null);
+  const [verifiedOn, setVerifiedOn] = useState('');
+  const [issues, setIssues] = useState<string[]>([]);
+  const [showNew, setShowNew] = useState(false);
+
+  const reload = async () => {
+    const [list, state] = await Promise.all([
+      fetchCloudServices(),
+      fetchCloudServicesState({ validate: true }),
+    ]);
+    setItems(list.services);
+    setDirty(state.dirty);
+    setPublishedAt(state.publishedAt);
+    setVerifiedOn(state.verifiedOn);
+    setIssues((state.issues ?? []).map(i => i.message));
+  };
+
+  useEffect(() => {
+    reload().catch(err => setError(err instanceof Error ? err.message : 'Failed to load'));
+  }, []);
+
+  const current = selected ? items.find(s => s.roleKey === selected) : null;
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return items;
+    return items.filter(s => s.roleKey.toLowerCase().includes(q));
+  }, [items, query]);
+
+  const patchCell = (target: keyof ServiceRow, patch: Partial<ServiceCell>) => {
+    if (!current) return;
+    setItems(list => list.map(item => {
+      if (item.roleKey !== current.roleKey) return item;
+      return {
+        ...item,
+        payload: {
+          ...item.payload,
+          [target]: { ...item.payload[target], ...patch },
+        },
+      };
+    }));
+    setSaveState('dirty');
+  };
+
+  const save = async () => {
+    if (!current) return;
+    setSaveState('saving');
+    try {
+      await updateCloudService(current.roleKey, current.payload);
+      await reload();
+      setError(null);
+      setSaveState('saved');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Save failed');
+      setSaveState('error');
+    }
+  };
+
+  const onPublish = async () => {
+    setBusy(true);
+    try {
+      const result = await publishCloudServices();
+      if (!result.ok) {
+        setIssues(result.issues.map(i => i.message));
+        setError(result.error);
+        return;
+      }
+      await reload();
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Publish failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onDelete = async () => {
+    if (!current) return;
+    if (!window.confirm(`Delete cloud service "${current.roleKey}"? Seeded keys re-seed on next ensure.`)) return;
+    setBusy(true);
+    try {
+      await deleteCloudService(current.roleKey);
+      setSelected(null);
+      await reload();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Delete failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <>
+      <CatalogSplitShell
+        countLabel={`${filtered.length} role${filtered.length === 1 ? '' : 's'} — hyperscaler correspondence table`}
+        query={query}
+        onQuery={setQuery}
+        queryPlaceholder="Filter role keys…"
+        error={error}
+        issues={issues}
+        actions={(
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+            <PublishBadge state={publishBadge(dirty, publishedAt)} />
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+              <span className="hint" style={{ margin: 0 }}>verifiedOn</span>
+              <input
+                className="input mono"
+                style={{ width: 132, fontSize: 12 }}
+                value={verifiedOn}
+                aria-label="Services verified on"
+                onChange={e => setVerifiedOn(e.target.value)}
+                onBlur={() => {
+                  void patchCloudServicesVerifiedOn(verifiedOn).then(state => {
+                    setDirty(state.dirty);
+                    setVerifiedOn(state.verifiedOn);
+                  }).catch(err => setError(err instanceof Error ? err.message : 'Update failed'));
+                }}
+              />
+            </div>
+            <button type="button" className="btn sm" disabled={busy} onClick={() => setShowNew(true)}>
+              New role
+            </button>
+            <button type="button" className="btn primary sm" disabled={busy} onClick={() => void onPublish()}>
+              {busy ? 'Publishing…' : 'Publish'}
+            </button>
+          </div>
+        )}
+        list={
+          filtered.length === 0
+            ? <div className="empty">{query ? 'No role matches this search.' : 'Loading cloud services…'}</div>
+            : filtered.map(item => (
+              <CatalogTreeRow
+                key={item.roleKey}
+                active={selected === item.roleKey}
+                onClick={() => { setSelected(item.roleKey); setSaveState('idle'); }}
+                label={item.roleKey}
+                meta={item.locked ? 'seed' : 'custom'}
+              />
+            ))
+        }
+        inspector={
+          !current
+            ? <div className="empty">Select a service role</div>
+            : (
+              <>
+                <div className="mono sub">{current.roleKey}</div>
+                <div className="sect-label">Correspondence</div>
+                <div className="frow">
+                  {RESOLVED_TARGETS.map(target => {
+                    const cell = current.payload[target];
+                    const names = locPair(cell.name);
+                    return (
+                      <Group key={target} title={TARGET_LABELS[target].en}>
+                        <Text
+                          label="Name (EN)"
+                          value={names.en}
+                          onChange={en => patchCell(target, { name: fromPair(en, names.fr) })}
+                        />
+                        <Text
+                          label="Name (FR)"
+                          value={names.fr}
+                          onChange={fr => patchCell(target, { name: fromPair(names.en, fr) })}
+                        />
+                        <Text
+                          label="Tech (csv)"
+                          value={(cell.tech ?? []).join(', ')}
+                          onChange={csv => patchCell(target, {
+                            tech: csv.split(',').map(s => s.trim()).filter(Boolean),
+                          })}
+                        />
+                      </Group>
+                    );
+                  })}
+                </div>
+                <p className="hint">Display example: {t(current.payload.aws.name, 'en')}</p>
+                <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginTop: 12, flexWrap: 'wrap' }}>
+                  <button type="button" className="btn primary" onClick={() => void save()}>Save cells</button>
+                  <button type="button" className="btn" disabled={busy} onClick={() => void onDelete()}>Delete</button>
+                  <CatalogSaveFlag state={saveState} />
+                </div>
+              </>
+            )
+        }
+      />
+      {showNew && (
+        <NewCloudServiceDialog
+          onClose={() => setShowNew(false)}
+          onCreated={roleKey => { setShowNew(false); setSelected(roleKey); void reload(); }}
+        />
+      )}
+    </>
+  );
+}

--- a/src/app/admin/catalog/dependencies/page.tsx
+++ b/src/app/admin/catalog/dependencies/page.tsx
@@ -1,0 +1,207 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Area, Choice, Text } from '@/components/editors/Fields';
+import { Icon } from '@/components/Icon';
+import {
+  CatalogListEmpty,
+  CatalogSplitShell,
+  CatalogTreeRow,
+  type CatalogSaveState,
+} from '@/components/admin/CatalogList';
+import {
+  CatalogFormGroup,
+  CatalogInspector,
+  CatalogInspectorEmpty,
+  DEPENDENCY_KINDS,
+  DEPENDENCY_STRENGTHS,
+} from '@/components/admin/CatalogFormParts';
+import { NewDependencyDialog } from '@/components/admin/NewCatalogDialogs';
+import { PublishBadge } from '@/components/admin/PublishBadge';
+import { fetchCatalogState } from '@/lib/admin/catalog';
+import {
+  deleteDependency,
+  fetchDependencies,
+  patchDependency,
+  type AdminDependency,
+} from '@/lib/admin/catalog-entities';
+import { loadLegoCatalog } from '@/lib/lego/client';
+
+export default function AdminDependenciesPage() {
+  const [deps, setDeps] = useState<AdminDependency[]>([]);
+  const [bricks, setBricks] = useState<string[]>([]);
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState('');
+  const [saveState, setSaveState] = useState<CatalogSaveState>('idle');
+  const [creating, setCreating] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [catalogDirty, setCatalogDirty] = useState(false);
+
+  const edgeKey = (dep: AdminDependency) => `${dep.from}\0${dep.to}`;
+
+  const load = useCallback(async (preferKey?: string) => {
+    try {
+      const [list, catalog] = await Promise.all([fetchDependencies(), loadLegoCatalog('en')]);
+      setDeps(list);
+      setBricks(Object.keys(catalog.bricks).sort());
+      setSelectedKey(current => preferKey ?? current ?? (list[0] ? edgeKey(list[0]) : null));
+      setError(null);
+      const state = await fetchCatalogState().catch(() => null);
+      if (state) setCatalogDirty(state.dirty);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load');
+    }
+  }, []);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const current = selectedKey
+    ? deps.find(d => edgeKey(d) === selectedKey) ?? null
+    : null;
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return deps;
+    return deps.filter(dep =>
+      `${dep.from} ${dep.to} ${dep.strength} ${dep.protocol_id}`.toLowerCase().includes(q));
+  }, [deps, query]);
+
+  const patchCurrent = (patch: Partial<AdminDependency>) => {
+    if (!current) return;
+    setDeps(list => list.map(d => edgeKey(d) === selectedKey ? { ...d, ...patch } : d));
+    setSaveState('dirty');
+  };
+
+  const save = async () => {
+    if (!current) return;
+    setSaveState('saving');
+    try {
+      await patchDependency(current.from, current.to, {
+        strength: current.strength,
+        why_en: current.why_en,
+        why_fr: current.why_fr,
+        protocol_id: current.protocol_id,
+        kind: current.kind,
+      });
+      setError(null);
+      setSaveState('saved');
+      setCatalogDirty(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Save failed');
+      setSaveState('error');
+    }
+  };
+
+  const remove = async () => {
+    if (!current) return;
+    if (!window.confirm(`Delete dependency ${current.from} → ${current.to}?`)) return;
+    setDeleting(true);
+    try {
+      await deleteDependency(current.from, current.to);
+      setSaveState('idle');
+      const next = deps.find(d => edgeKey(d) !== selectedKey);
+      await load(next ? edgeKey(next) : undefined);
+      if (!next) setSelectedKey(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Delete failed');
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <>
+      <CatalogSplitShell
+        countLabel={`${filtered.length} suggestion edge${filtered.length === 1 ? '' : 's'}`}
+        query={query}
+        onQuery={setQuery}
+        queryPlaceholder="Filter from, to, or protocol…"
+        error={error}
+        actions={
+          <>
+            <PublishBadge state={catalogDirty ? 'modified' : 'published'} />
+            <button type="button" className="btn primary sm" onClick={() => setCreating(true)}>
+              <Icon name="plus" size={13} />New dependency
+            </button>
+          </>
+        }
+        list={
+          filtered.length === 0
+            ? <CatalogListEmpty query={query} noun="dependencies" />
+            : filtered.map(dep => (
+              <CatalogTreeRow
+                key={edgeKey(dep)}
+                active={selectedKey === edgeKey(dep)}
+                onClick={() => { setSelectedKey(edgeKey(dep)); setSaveState('idle'); }}
+                icon="link"
+                label={`${dep.from} → ${dep.to}`}
+                meta={dep.strength}
+              />
+            ))
+        }
+        inspector={
+          !current
+            ? <CatalogInspectorEmpty>Select a dependency — or create one.</CatalogInspectorEmpty>
+            : (
+              <CatalogInspector
+                entityId={`${current.from} → ${current.to}`}
+                title="Dependency"
+                subtitle="Suggestion edge"
+                publishState={catalogDirty ? 'modified' : 'published'}
+                saveState={saveState}
+                onSave={() => void save()}
+                onDelete={() => void remove()}
+                saveLabel="Save dependency"
+                deleting={deleting}
+              >
+                <CatalogFormGroup title="Edge">
+                  <Choice
+                    label="Strength"
+                    value={current.strength}
+                    onChange={strength => patchCurrent({ strength: strength as AdminDependency['strength'] })}
+                    options={DEPENDENCY_STRENGTHS}
+                  />
+                  <Text
+                    label="Protocol id"
+                    mono
+                    value={current.protocol_id}
+                    onChange={protocol_id => patchCurrent({ protocol_id })}
+                  />
+                  <Choice
+                    label="Kind"
+                    value={current.kind}
+                    onChange={kind => patchCurrent({ kind: kind as AdminDependency['kind'] })}
+                    options={DEPENDENCY_KINDS}
+                  />
+                  <Area
+                    label="Why (EN)"
+                    value={current.why_en}
+                    onChange={why_en => patchCurrent({ why_en })}
+                    minHeight={56}
+                  />
+                  <Area
+                    label="Why (FR)"
+                    value={current.why_fr}
+                    onChange={why_fr => patchCurrent({ why_fr })}
+                    minHeight={56}
+                  />
+                </CatalogFormGroup>
+              </CatalogInspector>
+            )
+        }
+      />
+      {creating && (
+        <NewDependencyDialog
+          bricks={bricks}
+          onClose={() => setCreating(false)}
+          onCreated={(from, to) => {
+            setCreating(false);
+            void load(`${from}\0${to}`);
+            setSaveState('idle');
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/src/app/admin/catalog/intents/[id]/page.tsx
+++ b/src/app/admin/catalog/intents/[id]/page.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import Link from 'next/link';
+import { useCallback, useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import { Area, Group } from '@/components/editors/Fields';
+import { fetchIntent, patchIntent } from '@/lib/admin/catalog-entities';
+import type { LegoIntent } from '@/lib/lego/types';
+
+const MODES = ['client', 'baas', 'cloud', 'selfhosted'] as const;
+
+export default function AdminIntentPage() {
+  const { id } = useParams<{ id: string }>();
+  const [intent, setIntent] = useState<LegoIntent | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      setIntent(await fetchIntent(id));
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load intent');
+    }
+  }, [id]);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const toggleMode = (mode: string) => {
+    if (!intent) return;
+    const has = intent.modes.includes(mode as LegoIntent['modes'][number]);
+    setIntent({
+      ...intent,
+      modes: has ? intent.modes.filter(m => m !== mode) : [...intent.modes, mode as LegoIntent['modes'][number]],
+    });
+    setSaved(false);
+  };
+
+  const save = async () => {
+    if (!intent) return;
+    try {
+      await patchIntent(id, {
+        label: intent.label,
+        modes: [...intent.modes],
+        shapes: intent.shapes?.length ? [...intent.shapes] : [],
+      });
+      setSaved(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Save failed');
+    }
+  };
+
+  if (error && !intent) return <div className="warnbox" style={{ margin: 22 }}>{error}</div>;
+  if (!intent) return <div className="empty">Loading intent…</div>;
+
+  return (
+    <div className="editor-body">
+      <div className="content-main">
+        <div className="cpanel">
+          <Link href="/admin/catalog/intents" className="btn sm" style={{ marginBottom: 12, display: 'inline-flex' }}>
+            Back to intents
+          </Link>
+          <Group title={intent.id}>
+            <Area label="Label" value={intent.label} onChange={label => { setIntent({ ...intent, label }); setSaved(false); }} minHeight={40} />
+            <div className="field">
+              <span>Hosting modes</span>
+              <div className="chiprow">
+                {MODES.map(mode => (
+                  <button
+                    key={mode}
+                    type="button"
+                    className="tagchip"
+                    aria-pressed={intent.modes.includes(mode)}
+                    style={intent.modes.includes(mode) ? { borderColor: 'var(--brand)', color: 'var(--brand-ink)' } : undefined}
+                    onClick={() => toggleMode(mode)}
+                  >
+                    {mode}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <Area
+              label="Shapes (comma-separated)"
+              value={(intent.shapes ?? []).join(', ')}
+              onChange={v => { setIntent({ ...intent, shapes: v.split(',').map(s => s.trim()).filter(Boolean) }); setSaved(false); }}
+              minHeight={40}
+              hint="Optional shape filters for this intent (e.g. gateway, compute)."
+            />
+            <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginTop: 8 }}>
+              <button type="button" className="btn primary" onClick={() => void save()}>Save intent</button>
+              {saved && <span className="saveflag"><i />Saved</span>}
+            </div>
+          </Group>
+        </div>
+      </div>
+      <aside className="inspector">
+        <div className="mono sub">{intent.id}</div>
+        <h3>Modes</h3>
+        <p className="hint">{intent.modes.join(' · ') || 'No hosting modes selected.'}</p>
+      </aside>
+    </div>
+  );
+}

--- a/src/app/admin/catalog/intents/page.tsx
+++ b/src/app/admin/catalog/intents/page.tsx
@@ -1,0 +1,189 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Area, Text } from '@/components/editors/Fields';
+import { Icon } from '@/components/Icon';
+import {
+  CatalogListEmpty,
+  CatalogSplitShell,
+  CatalogTreeRow,
+  type CatalogSaveState,
+} from '@/components/admin/CatalogList';
+import {
+  CatalogFormGroup,
+  CatalogInspector,
+  CatalogInspectorEmpty,
+  ModeChips,
+} from '@/components/admin/CatalogFormParts';
+import { NewIntentDialog } from '@/components/admin/NewCatalogDialogs';
+import { PublishBadge } from '@/components/admin/PublishBadge';
+import { fetchCatalogState } from '@/lib/admin/catalog';
+import { deleteIntent, fetchIntents, patchIntent } from '@/lib/admin/catalog-entities';
+import type { LegoIntent } from '@/lib/lego/types';
+
+export default function AdminIntentsPage() {
+  const [intents, setIntents] = useState<LegoIntent[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState('');
+  const [selected, setSelected] = useState<string | null>(null);
+  const [saveState, setSaveState] = useState<CatalogSaveState>('idle');
+  const [creating, setCreating] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [catalogDirty, setCatalogDirty] = useState(false);
+
+  const load = useCallback(async (preferId?: string) => {
+    try {
+      const list = await fetchIntents();
+      setIntents(list);
+      setError(null);
+      setSelected(current => preferId ?? current ?? list[0]?.id ?? null);
+      const state = await fetchCatalogState().catch(() => null);
+      if (state) setCatalogDirty(state.dirty);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load');
+    }
+  }, []);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return intents;
+    return intents.filter(intent =>
+      `${intent.id} ${intent.label} ${intent.modes.join(' ')}`.toLowerCase().includes(q));
+  }, [intents, query]);
+
+  const current = selected ? intents.find(i => i.id === selected) : null;
+
+  const toggleMode = (mode: string) => {
+    if (!current) return;
+    const has = current.modes.includes(mode as LegoIntent['modes'][number]);
+    setIntents(list => list.map(intent => intent.id !== current.id ? intent : {
+      ...intent,
+      modes: has
+        ? intent.modes.filter(m => m !== mode)
+        : [...intent.modes, mode as LegoIntent['modes'][number]],
+    }));
+    setSaveState('dirty');
+  };
+
+  const save = async () => {
+    if (!current) return;
+    setSaveState('saving');
+    try {
+      await patchIntent(current.id, {
+        label: current.label,
+        modes: [...current.modes],
+        shapes: current.shapes?.length ? [...current.shapes] : [],
+      });
+      setSaveState('saved');
+      setCatalogDirty(true);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Save failed');
+      setSaveState('error');
+    }
+  };
+
+  const remove = async () => {
+    if (!current) return;
+    if (!window.confirm(`Delete intent “${current.id}”?`)) return;
+    setDeleting(true);
+    try {
+      await deleteIntent(current.id);
+      setSaveState('idle');
+      const nextId = intents.find(i => i.id !== current.id)?.id ?? null;
+      await load(nextId ?? undefined);
+      if (!nextId) setSelected(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Delete failed');
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <>
+      <CatalogSplitShell
+        countLabel={`${filtered.length} placement intent${filtered.length === 1 ? '' : 's'}`}
+        query={query}
+        onQuery={setQuery}
+        queryPlaceholder="Filter intents…"
+        error={error}
+        actions={
+          <>
+            <PublishBadge state={catalogDirty ? 'modified' : 'published'} />
+            <button type="button" className="btn primary sm" onClick={() => setCreating(true)}>
+              <Icon name="plus" size={13} />New intent
+            </button>
+          </>
+        }
+        list={
+          filtered.length === 0
+            ? <CatalogListEmpty query={query} noun="intents" />
+            : filtered.map(intent => (
+              <CatalogTreeRow
+                key={intent.id}
+                active={selected === intent.id}
+                onClick={() => { setSelected(intent.id); setSaveState('idle'); }}
+                icon="route"
+                label={intent.id}
+                meta={intent.label}
+              />
+            ))
+        }
+        inspector={
+          !current
+            ? <CatalogInspectorEmpty>Select an intent — or create one.</CatalogInspectorEmpty>
+            : (
+              <CatalogInspector
+                entityId={current.id}
+                title="Intent"
+                subtitle="Placement + hosting modes"
+                publishState={catalogDirty ? 'modified' : 'published'}
+                saveState={saveState}
+                onSave={() => void save()}
+                onDelete={() => void remove()}
+                saveLabel="Save intent"
+                deleting={deleting}
+              >
+                <CatalogFormGroup title="Placement">
+                  <Text
+                    label="Label"
+                    value={current.label}
+                    onChange={label => {
+                      setIntents(list => list.map(i => i.id === current.id ? { ...i, label } : i));
+                      setSaveState('dirty');
+                    }}
+                  />
+                  <ModeChips modes={[...current.modes]} onToggle={toggleMode} />
+                  <Area
+                    label="Shapes (comma-separated)"
+                    value={(current.shapes ?? []).join(', ')}
+                    onChange={v => {
+                      setIntents(list => list.map(i => i.id === current.id
+                        ? { ...i, shapes: v.split(',').map(s => s.trim()).filter(Boolean) }
+                        : i));
+                      setSaveState('dirty');
+                    }}
+                    minHeight={56}
+                    hint="Optional shape filters (e.g. gateway, compute)."
+                  />
+                </CatalogFormGroup>
+              </CatalogInspector>
+            )
+        }
+      />
+      {creating && (
+        <NewIntentDialog
+          onClose={() => setCreating(false)}
+          onCreated={id => {
+            setCreating(false);
+            void load(id);
+            setSaveState('idle');
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/src/app/admin/catalog/layout.tsx
+++ b/src/app/admin/catalog/layout.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from 'react';
+
+export default function AdminCatalogLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/src/app/admin/catalog/page.tsx
+++ b/src/app/admin/catalog/page.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { Icon } from '@/components/Icon';
+import { AdminEmpty } from '@/components/admin/AdminEmpty';
+import { AdminPageHeader } from '@/components/admin/AdminPageHeader';
+import { PublishBadge } from '@/components/admin/PublishBadge';
+import { fetchCatalogState } from '@/lib/admin/catalog';
+import { fetchCloudServices } from '@/lib/admin/cloud';
+import { loadLegoCatalog } from '@/lib/lego/client';
+
+const CARDS = [
+  {
+    href: '/admin/catalog/bricks',
+    icon: 'box',
+    label: 'Briques',
+    key: 'bricks' as const,
+    hint: 'Capability tiles — form + preview',
+  },
+  {
+    href: '/admin/catalog/scopes',
+    icon: 'map',
+    label: 'Scopes',
+    key: 'scopes' as const,
+    hint: 'Placement domains EN/FR',
+  },
+  {
+    href: '/admin/catalog/intents',
+    icon: 'route',
+    label: 'Intents',
+    key: 'intents' as const,
+    hint: 'What to place + hosting modes',
+  },
+  {
+    href: '/admin/catalog/variants',
+    icon: 'layers',
+    label: 'Variants',
+    key: 'variants' as const,
+    hint: 'Intent × mode → brick',
+  },
+  {
+    href: '/admin/catalog/dependencies',
+    icon: 'link',
+    label: 'Dependencies',
+    key: 'dependencies' as const,
+    hint: 'Suggestion edges between bricks',
+  },
+  {
+    href: '/admin/catalog/technologies',
+    icon: 'terminal',
+    label: 'Technologies',
+    key: 'technologies' as const,
+    hint: 'Stack glossary copy',
+  },
+  {
+    href: '/admin/catalog/cloud-services',
+    icon: 'cloud',
+    label: 'Cloud services',
+    key: 'cloudServices' as const,
+    hint: 'Provider catalogue (linked)',
+  },
+] as const;
+
+type HubCounts = Record<(typeof CARDS)[number]['key'], number>;
+
+export default function AdminCatalogHubPage() {
+  const [counts, setCounts] = useState<HubCounts | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [dirty, setDirty] = useState(false);
+  const [publishedAt, setPublishedAt] = useState<string | null>(null);
+
+  useEffect(() => {
+    Promise.all([loadLegoCatalog('en'), fetchCloudServices()])
+      .then(([catalog, cloud]) => {
+        setCounts({
+          bricks: Object.keys(catalog.bricks).length,
+          scopes: catalog.scopes.length,
+          intents: catalog.intents.length,
+          variants: catalog.variants.length,
+          dependencies: catalog.dependencies.length,
+          technologies: Object.keys(catalog.technologyDescriptions).length,
+          cloudServices: cloud.services.length,
+        });
+      })
+      .catch(err => setError(err instanceof Error ? err.message : 'Failed to load catalog'));
+    fetchCatalogState()
+      .then(state => {
+        setDirty(state.dirty);
+        setPublishedAt(state.publishedAt);
+      })
+      .catch(() => { /* API may not be ready */ });
+  }, []);
+
+  const publishState = dirty ? 'modified' : publishedAt ? 'published' : 'draft';
+
+  return (
+    <div className="workspace">
+      <AdminPageHeader
+        lede="Atelier form surfaces for scopes, intents, variants, bricks, and edges. Create, edit, delete — then publish."
+        actions={
+          <>
+            <PublishBadge state={publishState} />
+            <Link href="/admin/publish" className="btn sm">
+              <Icon name="upload" size={13} />Publish
+            </Link>
+          </>
+        }
+      />
+      <div className="ws-body">
+        {error && <div className="warnbox" style={{ marginBottom: 14 }}>{error}</div>}
+        {!error && !counts && <AdminEmpty>Loading catalog…</AdminEmpty>}
+        {counts && (
+          <div className="pgrid">
+            {CARDS.map(card => (
+              <Link
+                key={card.href}
+                href={card.href}
+                className="pcard"
+                style={{ textDecoration: 'none', color: 'inherit' }}
+              >
+                <div className="accent" style={{ background: 'var(--brand)' }}>
+                  <Icon name={card.icon} size={14} style={{ stroke: 'var(--on-fill)' }} />
+                </div>
+                <b>{card.label}</b>
+                <span className="hint" style={{ display: 'block', marginTop: 4 }}>{card.hint}</span>
+                <div className="foot">
+                  <span className="mono">{counts[card.key]}</span>
+                </div>
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/catalog/scopes/page.tsx
+++ b/src/app/admin/catalog/scopes/page.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Text } from '@/components/editors/Fields';
+import { Icon } from '@/components/Icon';
+import {
+  CatalogListEmpty,
+  CatalogSplitShell,
+  CatalogTreeRow,
+  type CatalogSaveState,
+} from '@/components/admin/CatalogList';
+import {
+  CatalogFormGroup,
+  CatalogInspector,
+  CatalogInspectorEmpty,
+} from '@/components/admin/CatalogFormParts';
+import { NewScopeDialog } from '@/components/admin/NewCatalogDialogs';
+import { PublishBadge } from '@/components/admin/PublishBadge';
+import { fetchCatalogState } from '@/lib/admin/catalog';
+import {
+  deleteScope,
+  fetchScopes,
+  patchScope,
+  type AdminScope,
+} from '@/lib/admin/catalog-entities';
+
+export default function AdminScopesPage() {
+  const [scopes, setScopes] = useState<AdminScope[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState('');
+  const [selected, setSelected] = useState<string | null>(null);
+  const [saveState, setSaveState] = useState<CatalogSaveState>('idle');
+  const [creating, setCreating] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [catalogDirty, setCatalogDirty] = useState(false);
+
+  const load = useCallback(async (preferId?: string) => {
+    try {
+      const list = await fetchScopes();
+      setScopes(list);
+      setError(null);
+      setSelected(current => preferId ?? current ?? list[0]?.id ?? null);
+      const state = await fetchCatalogState().catch(() => null);
+      if (state) setCatalogDirty(state.dirty);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load scopes');
+    }
+  }, []);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return scopes;
+    return scopes.filter(s => `${s.id} ${s.labelEn} ${s.labelFr}`.toLowerCase().includes(q));
+  }, [scopes, query]);
+
+  const current = selected ? scopes.find(s => s.id === selected) : null;
+
+  const save = async () => {
+    if (!current) return;
+    setSaveState('saving');
+    try {
+      await patchScope(current.id, { labelEn: current.labelEn, labelFr: current.labelFr });
+      setSaveState('saved');
+      setCatalogDirty(true);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Save failed');
+      setSaveState('error');
+    }
+  };
+
+  const remove = async () => {
+    if (!current) return;
+    if (!window.confirm(`Delete scope “${current.id}”?`)) return;
+    setDeleting(true);
+    try {
+      await deleteScope(current.id);
+      setSaveState('idle');
+      const nextId = scopes.find(s => s.id !== current.id)?.id ?? null;
+      await load(nextId ?? undefined);
+      if (!nextId) setSelected(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Delete failed');
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <>
+      <CatalogSplitShell
+        countLabel={`${filtered.length} scope${filtered.length === 1 ? '' : 's'}`}
+        query={query}
+        onQuery={setQuery}
+        queryPlaceholder="Filter scopes…"
+        error={error}
+        actions={
+          <>
+            <PublishBadge state={catalogDirty ? 'modified' : 'published'} />
+            <button type="button" className="btn primary sm" onClick={() => setCreating(true)}>
+              <Icon name="plus" size={13} />New scope
+            </button>
+          </>
+        }
+        list={
+          filtered.length === 0
+            ? <CatalogListEmpty query={query} noun="scopes" />
+            : filtered.map(scope => (
+              <CatalogTreeRow
+                key={scope.id}
+                active={selected === scope.id}
+                onClick={() => { setSelected(scope.id); setSaveState('idle'); }}
+                icon="map"
+                label={scope.id}
+                meta={scope.labelEn}
+              />
+            ))
+        }
+        inspector={
+          !current
+            ? <CatalogInspectorEmpty>Select a scope — or create one.</CatalogInspectorEmpty>
+            : (
+              <CatalogInspector
+                entityId={current.id}
+                title="Scope"
+                subtitle="Bilingual placement labels"
+                publishState={catalogDirty ? 'modified' : 'published'}
+                saveState={saveState}
+                onSave={() => void save()}
+                onDelete={() => void remove()}
+                saveLabel="Save scope"
+                deleting={deleting}
+              >
+                <CatalogFormGroup title="Labels" cols={1}>
+                  <Text
+                    label="Label (EN)"
+                    value={current.labelEn}
+                    onChange={labelEn => {
+                      setScopes(list => list.map(s => s.id === current.id ? { ...s, labelEn } : s));
+                      setSaveState('dirty');
+                    }}
+                  />
+                  <Text
+                    label="Label (FR)"
+                    value={current.labelFr}
+                    onChange={labelFr => {
+                      setScopes(list => list.map(s => s.id === current.id ? { ...s, labelFr } : s));
+                      setSaveState('dirty');
+                    }}
+                  />
+                </CatalogFormGroup>
+              </CatalogInspector>
+            )
+        }
+      />
+      {creating && (
+        <NewScopeDialog
+          onClose={() => setCreating(false)}
+          onCreated={id => {
+            setCreating(false);
+            void load(id);
+            setSaveState('idle');
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/src/app/admin/catalog/technologies/page.tsx
+++ b/src/app/admin/catalog/technologies/page.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Area } from '@/components/editors/Fields';
+import { Icon } from '@/components/Icon';
+import {
+  CatalogListEmpty,
+  CatalogSplitShell,
+  CatalogTreeRow,
+  type CatalogSaveState,
+} from '@/components/admin/CatalogList';
+import {
+  CatalogFormGroup,
+  CatalogInspector,
+  CatalogInspectorEmpty,
+} from '@/components/admin/CatalogFormParts';
+import { NewTechnologyDialog } from '@/components/admin/NewCatalogDialogs';
+import { PublishBadge } from '@/components/admin/PublishBadge';
+import { fetchCatalogState } from '@/lib/admin/catalog';
+import {
+  deleteTechnology,
+  fetchTechnologies,
+  patchTechnology,
+  type AdminTechnology,
+} from '@/lib/admin/catalog-entities';
+
+export default function AdminTechnologiesPage() {
+  const [items, setItems] = useState<AdminTechnology[]>([]);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState('');
+  const [saveState, setSaveState] = useState<CatalogSaveState>('idle');
+  const [creating, setCreating] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [catalogDirty, setCatalogDirty] = useState(false);
+
+  const load = useCallback(async (preferKey?: string) => {
+    try {
+      const list = await fetchTechnologies();
+      setItems(list);
+      setSelected(current => preferKey ?? current ?? list[0]?.key ?? null);
+      setError(null);
+      const state = await fetchCatalogState().catch(() => null);
+      if (state) setCatalogDirty(state.dirty);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load');
+    }
+  }, []);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const current = selected ? items.find(t => t.key === selected) : null;
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return items;
+    return items.filter(t => `${t.key} ${t.en} ${t.fr}`.toLowerCase().includes(q));
+  }, [items, query]);
+
+  const save = async () => {
+    if (!current) return;
+    setSaveState('saving');
+    try {
+      await patchTechnology(current.key, { en: current.en, fr: current.fr });
+      setError(null);
+      setSaveState('saved');
+      setCatalogDirty(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Save failed');
+      setSaveState('error');
+    }
+  };
+
+  const remove = async () => {
+    if (!current) return;
+    if (!window.confirm(`Delete technology “${current.key}”?`)) return;
+    setDeleting(true);
+    try {
+      await deleteTechnology(current.key);
+      setSaveState('idle');
+      const nextKey = items.find(t => t.key !== current.key)?.key ?? null;
+      await load(nextKey ?? undefined);
+      if (!nextKey) setSelected(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Delete failed');
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <>
+      <CatalogSplitShell
+        countLabel={`${filtered.length} stack description key${filtered.length === 1 ? '' : 's'}`}
+        query={query}
+        onQuery={setQuery}
+        queryPlaceholder="Filter technology keys…"
+        error={error}
+        actions={
+          <>
+            <PublishBadge state={catalogDirty ? 'modified' : 'published'} />
+            <button type="button" className="btn primary sm" onClick={() => setCreating(true)}>
+              <Icon name="plus" size={13} />New technology
+            </button>
+          </>
+        }
+        list={
+          filtered.length === 0
+            ? <CatalogListEmpty query={query} noun="technologies" />
+            : filtered.map(item => (
+              <CatalogTreeRow
+                key={item.key}
+                active={selected === item.key}
+                onClick={() => { setSelected(item.key); setSaveState('idle'); }}
+                icon="terminal"
+                label={item.key}
+              />
+            ))
+        }
+        inspector={
+          !current
+            ? <CatalogInspectorEmpty>Select a technology — or create one.</CatalogInspectorEmpty>
+            : (
+              <CatalogInspector
+                entityId={current.key}
+                title="Technology"
+                subtitle="Glossary copy EN/FR"
+                publishState={catalogDirty ? 'modified' : 'published'}
+                saveState={saveState}
+                onSave={() => void save()}
+                onDelete={() => void remove()}
+                saveLabel="Save description"
+                deleting={deleting}
+              >
+                <CatalogFormGroup title="Copy">
+                  <Area
+                    label="Description (EN)"
+                    value={current.en}
+                    onChange={en => {
+                      setItems(list => list.map(t => t.key === current.key ? { ...t, en } : t));
+                      setSaveState('dirty');
+                    }}
+                    minHeight={72}
+                  />
+                  <Area
+                    label="Description (FR)"
+                    value={current.fr}
+                    onChange={fr => {
+                      setItems(list => list.map(t => t.key === current.key ? { ...t, fr } : t));
+                      setSaveState('dirty');
+                    }}
+                    minHeight={72}
+                  />
+                </CatalogFormGroup>
+              </CatalogInspector>
+            )
+        }
+      />
+      {creating && (
+        <NewTechnologyDialog
+          onClose={() => setCreating(false)}
+          onCreated={key => {
+            setCreating(false);
+            void load(key);
+            setSaveState('idle');
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/src/app/admin/catalog/variants/page.tsx
+++ b/src/app/admin/catalog/variants/page.tsx
@@ -1,0 +1,185 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Choice, Text } from '@/components/editors/Fields';
+import { Icon } from '@/components/Icon';
+import {
+  CatalogListEmpty,
+  CatalogSplitShell,
+  CatalogTreeRow,
+  type CatalogSaveState,
+} from '@/components/admin/CatalogList';
+import {
+  CatalogFormGroup,
+  CatalogInspector,
+  CatalogInspectorEmpty,
+  HOSTING_MODE_OPTIONS,
+} from '@/components/admin/CatalogFormParts';
+import { NewVariantDialog } from '@/components/admin/NewCatalogDialogs';
+import { PublishBadge } from '@/components/admin/PublishBadge';
+import { fetchCatalogState } from '@/lib/admin/catalog';
+import { deleteVariant, fetchVariants, patchVariant } from '@/lib/admin/catalog-entities';
+import { loadLegoCatalog } from '@/lib/lego/client';
+import type { LegoVariant } from '@/lib/lego/types';
+
+export default function AdminVariantsPage() {
+  const [variants, setVariants] = useState<LegoVariant[]>([]);
+  const [intents, setIntents] = useState<string[]>([]);
+  const [bricks, setBricks] = useState<string[]>([]);
+  const [filter, setFilter] = useState('');
+  const [selected, setSelected] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [saveState, setSaveState] = useState<CatalogSaveState>('idle');
+  const [creating, setCreating] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [catalogDirty, setCatalogDirty] = useState(false);
+
+  const load = useCallback(async (preferId?: string) => {
+    try {
+      const [v, catalog] = await Promise.all([fetchVariants(), loadLegoCatalog('en')]);
+      setVariants(v);
+      setIntents([...new Set([...v.map(x => x.intent), ...catalog.intents.map(i => i.id)])].sort());
+      setBricks(Object.keys(catalog.bricks).sort());
+      setSelected(current => preferId ?? current ?? v[0]?.id ?? null);
+      setError(null);
+      const state = await fetchCatalogState().catch(() => null);
+      if (state) setCatalogDirty(state.dirty);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load');
+    }
+  }, []);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const filtered = useMemo(() => {
+    const q = filter.trim().toLowerCase();
+    if (!q) return variants;
+    return variants.filter(v => v.id.includes(q) || v.label.toLowerCase().includes(q) || v.maps_to.includes(q));
+  }, [variants, filter]);
+
+  const current = selected ? variants.find(v => v.id === selected) : null;
+
+  const patchCurrent = (patch: Partial<LegoVariant>) => {
+    if (!current) return;
+    setVariants(list => list.map(v => v.id === current.id ? { ...v, ...patch } : v));
+    setSaveState('dirty');
+  };
+
+  const save = async () => {
+    if (!current) return;
+    setSaveState('saving');
+    try {
+      await patchVariant(current.id, {
+        label: current.label, intent: current.intent, mode: current.mode, maps_to: current.maps_to,
+      });
+      setError(null);
+      setSaveState('saved');
+      setCatalogDirty(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Save failed');
+      setSaveState('error');
+    }
+  };
+
+  const remove = async () => {
+    if (!current) return;
+    if (!window.confirm(`Delete variant “${current.id}”?`)) return;
+    setDeleting(true);
+    try {
+      await deleteVariant(current.id);
+      setSaveState('idle');
+      const nextId = variants.find(v => v.id !== current.id)?.id ?? null;
+      await load(nextId ?? undefined);
+      if (!nextId) setSelected(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Delete failed');
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <>
+      <CatalogSplitShell
+        countLabel={`${filtered.length} of ${variants.length} placement choices`}
+        query={filter}
+        onQuery={setFilter}
+        queryPlaceholder="Filter id, label, or brick…"
+        error={error}
+        actions={
+          <>
+            <PublishBadge state={catalogDirty ? 'modified' : 'published'} />
+            <button type="button" className="btn primary sm" onClick={() => setCreating(true)}>
+              <Icon name="plus" size={13} />New variant
+            </button>
+          </>
+        }
+        list={
+          filtered.length === 0
+            ? <CatalogListEmpty query={filter} noun="variants" />
+            : filtered.map(v => (
+              <CatalogTreeRow
+                key={v.id}
+                active={selected === v.id}
+                onClick={() => { setSelected(v.id); setSaveState('idle'); }}
+                icon="layers"
+                label={v.id}
+                meta={v.maps_to}
+              />
+            ))
+        }
+        inspector={
+          !current
+            ? <CatalogInspectorEmpty>Select a variant — or create one.</CatalogInspectorEmpty>
+            : (
+              <CatalogInspector
+                entityId={current.id}
+                title="Variant"
+                subtitle="Intent × mode → brick"
+                publishState={catalogDirty ? 'modified' : 'published'}
+                saveState={saveState}
+                onSave={() => void save()}
+                onDelete={() => void remove()}
+                saveLabel="Save variant"
+                deleting={deleting}
+              >
+                <CatalogFormGroup title="Mapping">
+                  <Text label="Label" value={current.label} onChange={label => patchCurrent({ label })} />
+                  <Choice
+                    label="Intent"
+                    value={current.intent}
+                    onChange={intent => patchCurrent({ intent })}
+                    options={intents.map(i => ({ value: i, label: i }))}
+                  />
+                  <Choice
+                    label="Mode"
+                    value={current.mode}
+                    onChange={mode => patchCurrent({ mode: mode as LegoVariant['mode'] })}
+                    options={HOSTING_MODE_OPTIONS.map(m => ({ value: m.value, label: m.label }))}
+                  />
+                  <Choice
+                    label="Maps to brick"
+                    value={current.maps_to}
+                    onChange={maps_to => patchCurrent({ maps_to })}
+                    options={bricks.map(b => ({ value: b, label: b }))}
+                  />
+                </CatalogFormGroup>
+              </CatalogInspector>
+            )
+        }
+      />
+      {creating && (
+        <NewVariantDialog
+          intents={intents}
+          bricks={bricks}
+          onClose={() => setCreating(false)}
+          onCreated={id => {
+            setCreating(false);
+            void load(id);
+            setSaveState('idle');
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/src/app/admin/flows/[id]/page.tsx
+++ b/src/app/admin/flows/[id]/page.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { Suspense } from 'react';
+import { useParams } from 'next/navigation';
+import FlowPatternEditor from '@/components/admin/FlowPatternEditor';
+
+function FlowPatternEditorGate() {
+  const params = useParams();
+  const id = typeof params.id === 'string' ? params.id : params.id?.[0] ?? '';
+  return <FlowPatternEditor patternId={id} />;
+}
+
+export default function AdminFlowDetailPage() {
+  return (
+    <Suspense fallback={<div className="empty">Loading flow pattern…</div>}>
+      <FlowPatternEditorGate />
+    </Suspense>
+  );
+}

--- a/src/app/admin/flows/page.tsx
+++ b/src/app/admin/flows/page.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Icon } from '@/components/Icon';
+import { AdminEmpty } from '@/components/admin/AdminEmpty';
+import { AdminWorkspace, useAdminLocale } from '@/components/admin/AdminWorkspace';
+import { NewFlowDialog } from '@/components/admin/NewFlowDialog';
+import { PublishBadge } from '@/components/admin/PublishBadge';
+import type { CatalogIssue } from '@/lib/lego/admin-catalog';
+import {
+  fetchFlowPatterns,
+  fetchFlowPatternState,
+  publishFlowPatterns,
+  type AdminFlowListItem,
+} from '@/lib/admin/flows';
+
+function patternTitle(item: AdminFlowListItem, locale: 'en' | 'fr'): string {
+  return locale === 'fr' ? (item.nameFr || item.id) : (item.nameEn || item.id);
+}
+
+function patternTagline(item: AdminFlowListItem, locale: 'en' | 'fr'): string | undefined {
+  return locale === 'fr' ? item.taglineFr : item.taglineEn;
+}
+
+function FlowRow({ item, locale }: { item: AdminFlowListItem; locale: 'en' | 'fr' }) {
+  const tagline = patternTagline(item, locale);
+  return (
+    <Link
+      href={`/admin/flows/${item.id}`}
+      className="tree-row"
+      style={{ textDecoration: 'none', color: 'inherit' }}
+    >
+      <span className="ficon"><Icon name={item.icon} size={15} /></span>
+      <span className="stack">
+        <span className="stack-title">{patternTitle(item, locale)}</span>
+        {tagline ? <span className="stack-sub">{tagline}</span> : null}
+      </span>
+      {item.locked ? (
+        <span className="count" title="Shipped catalogue recipe">Catalogue</span>
+      ) : (
+        <span className="count" title="Custom pattern">Custom</span>
+      )}
+      <span className="count" title={`${item.stepCount} steps`}>
+        {item.stepCount}
+      </span>
+    </Link>
+  );
+}
+
+export default function AdminFlowsPage() {
+  const router = useRouter();
+  const locale = useAdminLocale();
+  const [patterns, setPatterns] = useState<AdminFlowListItem[] | null>(null);
+  const [showNew, setShowNew] = useState(false);
+  const [dirty, setDirty] = useState(false);
+  const [publishedAt, setPublishedAt] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [publishIssues, setPublishIssues] = useState<CatalogIssue[]>([]);
+  const [query, setQuery] = useState('');
+
+  const reload = useCallback(async () => {
+    const [list, state] = await Promise.all([
+      fetchFlowPatterns(),
+      fetchFlowPatternState().catch(() => ({ dirty: false, publishedAt: null, patternCount: 0, issues: [] as CatalogIssue[] })),
+    ]);
+    setPatterns(list.patterns);
+    setDirty(state.dirty);
+    setPublishedAt(state.publishedAt);
+    setPublishIssues(state.issues ?? []);
+  }, []);
+
+  useEffect(() => {
+    reload().catch(err => setError(err instanceof Error ? err.message : 'Failed to load flow patterns'));
+  }, [reload]);
+
+  async function onPublish() {
+    setBusy(true);
+    setError(null);
+    try {
+      const result = await publishFlowPatterns();
+      if (!result.ok) {
+        setPublishIssues(result.issues ?? []);
+        return;
+      }
+      await reload();
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const filtered = useMemo(() => {
+    if (!patterns) return [];
+    const q = query.trim().toLowerCase();
+    if (!q) return patterns;
+    return patterns.filter(item => {
+      const hay = [
+        item.id,
+        item.icon,
+        item.nameEn,
+        item.nameFr,
+        item.taglineEn,
+        item.taglineFr,
+      ].filter(Boolean).join(' ').toLowerCase();
+      return hay.includes(q);
+    });
+  }, [patterns, query]);
+
+  const publishState = dirty ? 'modified' : publishedAt ? 'published' : 'draft';
+
+  return (
+    <>
+    <AdminWorkspace
+      lede="Catalogue recipes plus custom patterns — edit copy, steps, and hints, then publish for insert."
+      search={{ value: query, onChange: setQuery, placeholder: 'Filter patterns…' }}
+      error={error}
+      issues={publishIssues}
+      actions={(
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+          <PublishBadge state={publishState} />
+          {!dirty && publishedAt && (
+            <span className="hint mono">Published {publishedAt.slice(0, 10)}</span>
+          )}
+          <button type="button" className="btn sm primary" disabled={busy} onClick={() => setShowNew(true)}>
+            New pattern
+          </button>
+          <button type="button" className="btn primary sm" disabled={busy} onClick={onPublish}>
+            {busy ? 'Publishing…' : 'Publish patterns'}
+          </button>
+        </div>
+      )}
+    >
+      {!patterns && !error && <AdminEmpty>Loading flow patterns…</AdminEmpty>}
+      {patterns && filtered.length === 0 && (
+        <AdminEmpty>
+          {query ? 'No pattern matches this search.' : 'No flow patterns yet.'}
+        </AdminEmpty>
+      )}
+
+      {filtered.length > 0 && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          {filtered.map(item => (
+            <FlowRow key={item.id} item={item} locale={locale} />
+          ))}
+        </div>
+      )}
+    </AdminWorkspace>
+
+      {showNew && (
+        <NewFlowDialog
+          onClose={() => setShowNew(false)}
+          onCreated={id => { setShowNew(false); router.push(`/admin/flows/${id}`); }}
+        />
+      )}
+    </>
+  );
+}

--- a/src/app/admin/import/page.tsx
+++ b/src/app/admin/import/page.tsx
@@ -1,0 +1,243 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { AdminWorkspace } from '@/components/admin/AdminWorkspace';
+import {
+  domainEntries,
+  exportContentBundle,
+  importContentBundle,
+  type BundleImportMode,
+  type BundleSummary,
+} from '@/lib/admin/bundle.client';
+
+function downloadBlob(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+function DomainSummary({ summary, label }: { summary: BundleSummary | null; label: string }) {
+  const entries = domainEntries(summary);
+  if (entries.length === 0) return null;
+  return (
+    <div style={{ marginTop: 16 }}>
+      <div className="sect-label">{label}</div>
+      <div className="hist" role="list">
+        {entries.map(([domain, count]) => (
+          <div key={domain} className="histrow" role="listitem">
+            <span className="mono" style={{ fontSize: 12 }}>{domain}</span>
+            <span className="count">{count}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ImportConfirmDialog({
+  fileName,
+  mode,
+  onMode,
+  busy,
+  error,
+  onCancel,
+  onConfirm,
+}: {
+  fileName: string;
+  mode: BundleImportMode;
+  onMode: (m: BundleImportMode) => void;
+  busy: boolean;
+  error: string;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <div className="modal-scrim" onClick={onCancel}>
+      <div className="modal" onClick={e => e.stopPropagation()} role="dialog" aria-modal="true" aria-labelledby="import-confirm-title">
+        <div className="modal-head">
+          <div>
+            <h2 id="import-confirm-title">Import content bundle</h2>
+            <p className="lede">
+              Restore system content from <span className="mono">{fileName}</span>. Merge keeps existing drafts; Replace overwrites matching domains.
+            </p>
+          </div>
+          <div className="segmented" role="group" aria-label="Import mode">
+            <button type="button" aria-pressed={mode === 'merge'} onClick={() => onMode('merge')}>
+              Merge
+            </button>
+            <button type="button" aria-pressed={mode === 'replace'} onClick={() => onMode('replace')}>
+              Replace
+            </button>
+          </div>
+        </div>
+        {error && <div className="err">{error}</div>}
+        <div className="modal-actions">
+          <button type="button" className="btn ghost" disabled={busy} onClick={onCancel}>Cancel</button>
+          <button type="button" className="btn primary" disabled={busy} onClick={onConfirm}>
+            {busy ? 'Importing…' : mode === 'replace' ? 'Replace & import' : 'Merge & import'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function AdminImportPage() {
+  const fileRef = useRef<HTMLInputElement>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [lastSummary, setLastSummary] = useState<BundleSummary | null>(null);
+  const [pendingFile, setPendingFile] = useState<{ name: string; text: string } | null>(null);
+  const [mode, setMode] = useState<BundleImportMode>('merge');
+  const [modalError, setModalError] = useState('');
+
+  const onExport = async () => {
+    setBusy(true);
+    setError(null);
+    setSuccess(null);
+    try {
+      const { blob, summary } = await exportContentBundle();
+      if (summary) {
+        setLastSummary(summary);
+        downloadBlob(blob, 'content-bundle.json');
+      } else {
+        const text = await blob.text();
+        try {
+          const parsed = JSON.parse(text) as { domains?: BundleSummary['domains']; counts?: BundleSummary['counts'] };
+          if (parsed.domains || parsed.counts) {
+            setLastSummary({ domains: parsed.domains, counts: parsed.counts, exportedAt: new Date().toISOString() });
+          }
+        } catch {
+          /* non-summary payload — download still proceeds */
+        }
+        downloadBlob(new Blob([text], { type: 'application/json' }), 'content-bundle.json');
+      }
+      setSuccess('Exported content-bundle.json');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Export failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onPickFile = (file: File | null) => {
+    if (!file) return;
+    setError(null);
+    setSuccess(null);
+    setModalError('');
+    const reader = new FileReader();
+    reader.onload = () => {
+      const text = typeof reader.result === 'string' ? reader.result : '';
+      setPendingFile({ name: file.name, text });
+      setMode('merge');
+    };
+    reader.onerror = () => setError('Could not read the selected file.');
+    reader.readAsText(file);
+    if (fileRef.current) fileRef.current.value = '';
+  };
+
+  const onConfirmImport = async () => {
+    if (!pendingFile) return;
+    setBusy(true);
+    setModalError('');
+    try {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(pendingFile.text);
+      } catch {
+        setModalError('File is not valid JSON.');
+        setBusy(false);
+        return;
+      }
+      const result = await importContentBundle(parsed, mode);
+      if (!result.ok) {
+        setModalError(result.error || 'Import failed');
+        setBusy(false);
+        return;
+      }
+      if (result.summary) setLastSummary({ ...result.summary, mode });
+      setSuccess(`Imported ${pendingFile.name} (${mode})`);
+      setPendingFile(null);
+      setError(null);
+    } catch (err) {
+      setModalError(err instanceof Error ? err.message : 'Import failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <>
+      <AdminWorkspace
+        lede="Backup and restore the CMS content bundle — catalogue, templates, sections, flows, and system copy."
+        error={error}
+      >
+        <div className="cpanel" style={{ maxWidth: 640 }}>
+          {success && (
+            <div
+              className="warnbox"
+              style={{ marginBottom: 14, borderColor: 'var(--ok)', color: 'var(--ok)' }}
+              role="status"
+            >
+              {success}
+            </div>
+          )}
+
+          <div className="sect-label">Export</div>
+          <p className="hint" style={{ marginTop: 0 }}>
+            Download a portable <span className="mono">content-bundle.json</span> for backup, PR review, or another machine.
+          </p>
+          <button
+            type="button"
+            className="btn primary"
+            disabled={busy}
+            onClick={() => void onExport()}
+          >
+            {busy && !pendingFile ? 'Exporting…' : 'Download content-bundle.json'}
+          </button>
+
+          <div className="insp-sep" style={{ margin: '22px 0' }} />
+
+          <div className="sect-label">Import</div>
+          <p className="hint" style={{ marginTop: 0 }}>
+            Choose a previously exported bundle. You will confirm Merge or Replace before anything is written.
+          </p>
+          <input
+            ref={fileRef}
+            type="file"
+            accept=".json,application/json"
+            style={{ display: 'none' }}
+            aria-hidden
+            onChange={e => onPickFile(e.target.files?.[0] ?? null)}
+          />
+          <button
+            type="button"
+            className="btn"
+            disabled={busy}
+            onClick={() => fileRef.current?.click()}
+          >
+            Choose JSON file…
+          </button>
+
+          <DomainSummary summary={lastSummary} label="Last summary" />
+        </div>
+      </AdminWorkspace>
+
+      {pendingFile && (
+        <ImportConfirmDialog
+          fileName={pendingFile.name}
+          mode={mode}
+          onMode={setMode}
+          busy={busy}
+          error={modalError}
+          onCancel={() => { if (!busy) setPendingFile(null); }}
+          onConfirm={() => void onConfirmImport()}
+        />
+      )}
+    </>
+  );
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname, useRouter } from 'next/navigation';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { Lockup } from '@/components/Brand';
+import { Icon } from '@/components/Icon';
+import { dispatchAdminLocaleChange } from '@/components/admin/AdminWorkspace';
+
+type Locale = 'en' | 'fr';
+
+const OPS_NAV = [
+  { href: '/admin/publish', icon: 'upload', label: 'Publish' },
+  { href: '/admin/import', icon: 'download', label: 'Import' },
+  { href: '/admin/locale', icon: 'globe', label: 'Locale' },
+] as const;
+
+const CATALOG_CHILDREN = [
+  { href: '/admin/catalog/bricks', icon: 'box', label: 'Briques' },
+  { href: '/admin/catalog/scopes', icon: 'map', label: 'Scopes' },
+  { href: '/admin/catalog/intents', icon: 'route', label: 'Intents' },
+  { href: '/admin/catalog/variants', icon: 'layers', label: 'Variants' },
+  { href: '/admin/catalog/dependencies', icon: 'link', label: 'Dependencies' },
+  { href: '/admin/catalog/technologies', icon: 'terminal', label: 'Technologies' },
+  { href: '/admin/catalog/cloud-services', icon: 'cloud', label: 'Cloud services' },
+] as const;
+
+function pathActive(pathname: string, href: string): boolean {
+  return pathname === href || pathname.startsWith(`${href}/`);
+}
+
+function NavRow({ href, icon, label, active, depth = 0 }: {
+  href: string; icon: string; label: string; active: boolean; depth?: number;
+}) {
+  return (
+    <Link href={href} className={`tree-row${active ? ' active' : ''}`}
+      style={{ textDecoration: 'none', color: 'inherit', paddingLeft: 8 + depth * 14 }}>
+      <span style={{ width: 14 }} />
+      <span className="ficon"><Icon name={icon} size={15} /></span>
+      <span className="label">{label}</span>
+    </Link>
+  );
+}
+
+function CatalogBranch({ pathname }: { pathname: string }) {
+  const router = useRouter();
+  const onCatalog = pathname === '/admin/catalog' || pathname.startsWith('/admin/catalog/');
+  const [open, setOpen] = useState(onCatalog);
+  const hubActive = pathname === '/admin/catalog';
+
+  useEffect(() => {
+    if (onCatalog) setOpen(true);
+  }, [onCatalog]);
+
+  return (
+    <>
+      <div
+        className={`tree-row${hubActive ? ' active' : ''}`}
+        style={{ paddingLeft: 8 }}
+        role="link"
+        tabIndex={0}
+        onClick={() => router.push('/admin/catalog')}
+        onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); router.push('/admin/catalog'); } }}
+      >
+        <span
+          className={`caret${open ? ' open' : ''}`}
+          onClick={e => { e.stopPropagation(); setOpen(o => !o); }}
+        >
+          <Icon name="chevron" size={13} />
+        </span>
+        <span className="ficon"><Icon name="cube" size={15} /></span>
+        <span className="label">Catalogue Lego</span>
+      </div>
+      {open && CATALOG_CHILDREN.map(child => (
+        <NavRow
+          key={child.href}
+          href={child.href}
+          icon={child.icon}
+          label={child.label}
+          depth={1}
+          active={pathActive(pathname, child.href)}
+        />
+      ))}
+    </>
+  );
+}
+
+/** Chrome page title — sole H1-level label for the screen (body toolbars must not repeat). */
+function topbarName(pathname: string): string {
+  const entity = (re: RegExp) => {
+    const m = pathname.match(re);
+    return m ? decodeURIComponent(m[1]) : null;
+  };
+  const brick = entity(/^\/admin\/catalog\/bricks\/([^/]+)$/);
+  if (brick) return brick;
+  const intent = entity(/^\/admin\/catalog\/intents\/([^/]+)$/);
+  if (intent) return intent;
+  const template = entity(/^\/admin\/templates\/([^/]+)$/);
+  if (template) return template;
+  const section = entity(/^\/admin\/sections\/([^/]+)$/);
+  if (section) return section;
+  const flow = entity(/^\/admin\/flows\/([^/]+)$/);
+  if (flow) return flow;
+  if (pathname === '/admin') return 'Dashboard';
+  if (pathname === '/admin/catalog') return 'Catalogue Lego';
+  const child = CATALOG_CHILDREN.find(c => pathActive(pathname, c.href));
+  if (child) return child.label;
+  if (pathname === '/admin/templates' || pathname.startsWith('/admin/templates/')) return 'Templates';
+  if (pathname === '/admin/sections' || pathname.startsWith('/admin/sections/')) return 'ADD';
+  if (pathname === '/admin/flows' || pathname.startsWith('/admin/flows/')) return 'Flows';
+  if (pathname.startsWith('/admin/publish')) return 'Publish';
+  if (pathname.startsWith('/admin/import')) return 'Import';
+  if (pathname.startsWith('/admin/locale')) return 'Locale';
+  return 'Admin';
+}
+
+function toggleTheme() {
+  const next = document.documentElement.dataset.theme === 'dark' ? 'light' : 'dark';
+  document.documentElement.dataset.theme = next;
+  try { localStorage.setItem('studio-theme', next); } catch { /* private mode */ }
+}
+
+export default function AdminLayout({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  const [locale, setLocale] = useState<Locale>('en');
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem('admin-locale');
+      if (stored === 'en' || stored === 'fr') setLocale(stored);
+    } catch { /* private mode */ }
+  }, []);
+
+  const name = useMemo(() => topbarName(pathname), [pathname]);
+
+  const setLocalePersist = (next: Locale) => {
+    setLocale(next);
+    try { localStorage.setItem('admin-locale', next); } catch { /* private mode */ }
+    dispatchAdminLocaleChange();
+  };
+
+  return (
+    <div className="shell">
+      <aside className="sidebar">
+        <div className="sidebar-head">
+          <Lockup size={26} sub="Content" />
+        </div>
+
+        <div className="sidebar-scroll">
+          <NavRow href="/admin" icon="grid" label="Dashboard" active={pathname === '/admin'} />
+
+          <div className="sect-label">Content</div>
+          <NavRow href="/admin/templates" icon="file" label="Templates"
+            active={pathActive(pathname, '/admin/templates')} />
+          <CatalogBranch pathname={pathname} />
+          <NavRow href="/admin/sections" icon="folder" label="ADD"
+            active={pathActive(pathname, '/admin/sections')} />
+          <NavRow href="/admin/flows" icon="route" label="Flows"
+            active={pathActive(pathname, '/admin/flows')} />
+
+          <div className="sect-label">Operations</div>
+          {OPS_NAV.map(item => (
+            <NavRow key={item.href} href={item.href} icon={item.icon} label={item.label}
+              active={pathActive(pathname, item.href)} />
+          ))}
+        </div>
+
+        <div className="sidebar-foot">
+          <button className="iconbtn" onClick={toggleTheme} title="Light / dark">
+            <Icon name="moon" size={15} />
+          </button>
+          <span className="footnote">Self-hosted · seed CMS</span>
+        </div>
+      </aside>
+
+      <main className="editor">
+        <div className="topbar">
+          <span className="name" role="heading" aria-level={1}>{name}</span>
+          <div style={{ flex: 1 }} />
+          <div className="segmented" role="group" aria-label="Content locale">
+            <button type="button" aria-pressed={locale === 'en'} onClick={() => setLocalePersist('en')}>EN</button>
+            <button type="button" aria-pressed={locale === 'fr'} onClick={() => setLocalePersist('fr')}>FR</button>
+          </div>
+        </div>
+        <div style={{ flex: 1, minHeight: 0, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+          {children}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/app/admin/locale/page.tsx
+++ b/src/app/admin/locale/page.tsx
@@ -1,0 +1,217 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { Text } from '@/components/editors/Fields';
+import { CatalogSaveFlag, CatalogSplitShell, CatalogTreeRow, type CatalogSaveState } from '@/components/admin/CatalogList';
+import { PublishBadge } from '@/components/admin/PublishBadge';
+import {
+  copyKeyGroup,
+  fetchSystemCopy,
+  fetchSystemCopyState,
+  missingFr,
+  patchSystemCopy,
+  publishSystemCopy,
+  type SystemCopyEntry,
+} from '@/lib/admin/copy';
+
+const GROUP_ORDER = ['flow', 'layer', 'meta', 'other'] as const;
+
+const GROUP_LABELS: Record<string, string> = {
+  flow: 'flow.',
+  layer: 'layer.',
+  meta: 'meta.',
+  other: 'other',
+};
+
+function publishBadge(dirty: boolean, publishedAt: string | null): 'draft' | 'modified' | 'published' {
+  if (dirty) return 'modified';
+  if (publishedAt) return 'published';
+  return 'draft';
+}
+
+type Grouped = { group: string; items: SystemCopyEntry[] };
+
+function groupEntries(entries: SystemCopyEntry[]): Grouped[] {
+  const buckets = new Map<string, SystemCopyEntry[]>();
+  for (const entry of entries) {
+    const g = copyKeyGroup(entry.key);
+    const list = buckets.get(g) ?? [];
+    list.push(entry);
+    buckets.set(g, list);
+  }
+  const ordered: Grouped[] = [];
+  for (const g of GROUP_ORDER) {
+    const items = buckets.get(g);
+    if (items?.length) {
+      ordered.push({ group: g, items: items.sort((a, b) => a.key.localeCompare(b.key)) });
+      buckets.delete(g);
+    }
+  }
+  for (const [g, items] of [...buckets.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+    ordered.push({ group: g, items: items.sort((a, b) => a.key.localeCompare(b.key)) });
+  }
+  return ordered;
+}
+
+export default function AdminLocalePage() {
+  const [items, setItems] = useState<SystemCopyEntry[]>([]);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState('');
+  const [saveState, setSaveState] = useState<CatalogSaveState>('idle');
+  const [busy, setBusy] = useState(false);
+  const [dirty, setDirty] = useState(false);
+  const [publishedAt, setPublishedAt] = useState<string | null>(null);
+  const [issues, setIssues] = useState<string[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  const reload = async () => {
+    const [list, state] = await Promise.all([
+      fetchSystemCopy(),
+      fetchSystemCopyState({ validate: true }),
+    ]);
+    setItems(list.entries);
+    setDirty(state.dirty);
+    setPublishedAt(state.publishedAt);
+    setIssues((state.issues ?? []).map(i => i.message));
+    setLoaded(true);
+  };
+
+  useEffect(() => {
+    reload().catch(err => {
+      setError(err instanceof Error ? err.message : 'Failed to load');
+      setLoaded(true);
+    });
+  }, []);
+
+  const current = selected ? items.find(e => e.key === selected) : null;
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return items;
+    return items.filter(e =>
+      `${e.key} ${e.en} ${e.fr}`.toLowerCase().includes(q),
+    );
+  }, [items, query]);
+
+  const grouped = useMemo(() => groupEntries(filtered), [filtered]);
+  const missingFrCount = useMemo(() => items.filter(missingFr).length, [items]);
+
+  const patchLocal = (patch: Partial<Pick<SystemCopyEntry, 'en' | 'fr'>>) => {
+    if (!current) return;
+    setItems(list => list.map(e => (e.key === current.key ? { ...e, ...patch } : e)));
+    setSaveState('dirty');
+  };
+
+  const save = async () => {
+    if (!current) return;
+    setSaveState('saving');
+    try {
+      await patchSystemCopy(current.key, { en: current.en, fr: current.fr });
+      await reload();
+      setError(null);
+      setSaveState('saved');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Save failed');
+      setSaveState('error');
+    }
+  };
+
+  const onPublish = async () => {
+    setBusy(true);
+    try {
+      const result = await publishSystemCopy();
+      if (!result.ok) {
+        setIssues(result.issues.map(i => i.message));
+        setError(result.error);
+        return;
+      }
+      await reload();
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Publish failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const emptyListMessage = !loaded
+    ? 'Loading system copy…'
+    : query
+      ? 'No copy key matches this search.'
+      : 'No copy keys — ensure domain seeded';
+
+  return (
+    <CatalogSplitShell
+      countLabel={
+        loaded
+          ? `${filtered.length} system copy key${filtered.length === 1 ? '' : 's'}${
+              missingFrCount > 0 ? ` · ${missingFrCount} missing FR` : ''
+            }`
+          : 'System copy — flow defaults, layer labels, meta placeholders'
+      }
+      query={query}
+      onQuery={setQuery}
+      queryPlaceholder="Filter copy keys…"
+      error={error}
+      issues={issues}
+      actions={(
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+          <PublishBadge state={publishBadge(dirty, publishedAt)} />
+          <button type="button" className="btn primary sm" disabled={busy} onClick={() => void onPublish()}>
+            {busy ? 'Publishing…' : 'Publish system copy'}
+          </button>
+        </div>
+      )}
+      list={
+        filtered.length === 0
+          ? <div className="empty">{emptyListMessage}</div>
+          : grouped.map(({ group, items: groupItems }) => (
+            <div key={group}>
+              <div className="sect-label">{GROUP_LABELS[group] ?? `${group}.`}</div>
+              {groupItems.map(entry => (
+                <CatalogTreeRow
+                  key={entry.key}
+                  active={selected === entry.key}
+                  onClick={() => { setSelected(entry.key); setSaveState('idle'); }}
+                  label={entry.key}
+                  meta={missingFr(entry) ? 'FR?' : undefined}
+                />
+              ))}
+            </div>
+          ))
+      }
+      inspector={
+        !current
+          ? <div className="empty">{items.length === 0 && loaded ? 'No copy keys — ensure domain seeded' : 'Select a copy key'}</div>
+          : (
+            <>
+              <div className="mono sub">{current.key}</div>
+              {missingFr(current) && (
+                <div className="warnbox" style={{ marginBottom: 12 }} role="status">
+                  French string is empty — operators will fall back or show blanks.
+                </div>
+              )}
+              <div className="sect-label">Copy</div>
+              <Text
+                label="English"
+                value={current.en}
+                onChange={en => patchLocal({ en })}
+                onBlur={() => { if (saveState === 'dirty') void save(); }}
+              />
+              <Text
+                label="Français"
+                value={current.fr}
+                onChange={fr => patchLocal({ fr })}
+                onBlur={() => { if (saveState === 'dirty') void save(); }}
+              />
+              <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginTop: 12, flexWrap: 'wrap' }}>
+                <button type="button" className="btn primary" onClick={() => void save()}>Save</button>
+                <CatalogSaveFlag state={saveState} />
+              </div>
+            </>
+          )
+      }
+    />
+  );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,269 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { AdminEmpty } from '@/components/admin/AdminEmpty';
+import { AdminWorkspace } from '@/components/admin/AdminWorkspace';
+import { IssueList } from '@/components/admin/IssueList';
+import { PublishBadge, type PublishState } from '@/components/admin/PublishBadge';
+import { fetchArchitectureTemplateState } from '@/lib/admin/architecture';
+import { fetchCatalogState } from '@/lib/admin/catalog';
+import { fetchCloudServicesState } from '@/lib/admin/cloud';
+import { fetchSystemCopyState } from '@/lib/admin/copy';
+import { fetchFlowPatternState } from '@/lib/admin/flows';
+import { fetchSectionState } from '@/lib/admin/sections';
+import { fetchProjectTemplateState } from '@/lib/admin/templates';
+import type { CatalogIssue } from '@/lib/lego/admin-catalog';
+
+type DomainRow = {
+  id: string;
+  label: string;
+  href: string;
+  status: PublishState;
+  publishedAt: string | null;
+  count: string | null;
+  issues: CatalogIssue[];
+};
+
+function publishState(dirty: boolean, publishedAt: string | null): PublishState {
+  if (dirty) return 'modified';
+  if (publishedAt) return 'published';
+  return 'draft';
+}
+
+function formatPublishedAt(iso: string | null): string | null {
+  if (!iso) return null;
+  return iso.length >= 10 ? iso.slice(0, 10) : iso;
+}
+
+async function settled<T>(p: Promise<T>): Promise<T | null> {
+  try {
+    return await p;
+  } catch {
+    return null;
+  }
+}
+
+export default function AdminDashboardPage() {
+  const [domains, setDomains] = useState<DomainRow[] | null>(null);
+  const [issues, setIssues] = useState<CatalogIssue[] | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      const [catalog, projectTpl, archTpl, sections, flows, cloud, copy] = await Promise.all([
+        settled(fetchCatalogState({ validate: true })),
+        settled(fetchProjectTemplateState({ validate: true })),
+        settled(fetchArchitectureTemplateState({ validate: true })),
+        settled(fetchSectionState()),
+        settled(fetchFlowPatternState()),
+        settled(fetchCloudServicesState({ validate: true })),
+        settled(fetchSystemCopyState({ validate: true })),
+      ]);
+
+      if (cancelled) return;
+
+      const rows: DomainRow[] = [];
+
+      if (catalog) {
+        rows.push({
+          id: 'catalog',
+          label: 'Catalogue Lego',
+          href: '/admin/catalog',
+          status: publishState(catalog.dirty, catalog.publishedAt),
+          publishedAt: catalog.publishedAt,
+          count: catalog.version ? `v${catalog.version}` : null,
+          issues: catalog.issues ?? [],
+        });
+      }
+
+      if (projectTpl) {
+        rows.push({
+          id: 'project-templates',
+          label: 'Project templates',
+          href: '/admin/templates',
+          status: publishState(projectTpl.dirty, projectTpl.publishedAt),
+          publishedAt: projectTpl.publishedAt,
+          count: `${projectTpl.templateCount} templates`,
+          issues: projectTpl.issues ?? [],
+        });
+      }
+
+      if (archTpl) {
+        rows.push({
+          id: 'architecture-templates',
+          label: 'Architecture templates',
+          href: '/admin/templates',
+          status: publishState(archTpl.dirty, archTpl.publishedAt),
+          publishedAt: archTpl.publishedAt,
+          count: `${archTpl.templateCount} templates`,
+          issues: archTpl.issues ?? [],
+        });
+      }
+
+      if (sections) {
+        rows.push({
+          id: 'sections',
+          label: 'ADD sections',
+          href: '/admin/sections',
+          status: publishState(sections.dirty, sections.publishedAt),
+          publishedAt: sections.publishedAt,
+          count: `${sections.sectionCount} sections`,
+          issues: sections.issues ?? [],
+        });
+      }
+
+      if (flows) {
+        rows.push({
+          id: 'flows',
+          label: 'Flow patterns',
+          href: '/admin/flows',
+          status: publishState(flows.dirty, flows.publishedAt),
+          publishedAt: flows.publishedAt,
+          count: `${flows.patternCount} patterns`,
+          issues: flows.issues ?? [],
+        });
+      }
+
+      if (cloud) {
+        rows.push({
+          id: 'cloud',
+          label: 'Cloud services',
+          href: '/admin/catalog/cloud-services',
+          status: publishState(cloud.dirty, cloud.publishedAt),
+          publishedAt: cloud.publishedAt,
+          count: `${cloud.serviceCount} services`,
+          issues: cloud.issues ?? [],
+        });
+      }
+
+      if (copy) {
+        rows.push({
+          id: 'system-copy',
+          label: 'System copy',
+          href: '/admin/locale',
+          status: publishState(copy.dirty, copy.publishedAt),
+          publishedAt: copy.publishedAt,
+          count: `${copy.keyCount} keys`,
+          issues: copy.issues ?? [],
+        });
+      }
+
+      const allIssues = rows.flatMap(r => r.issues);
+      setDomains(rows);
+      setIssues(allIssues);
+    })();
+
+    return () => { cancelled = true; };
+  }, []);
+
+  const loading = domains === null || issues === null;
+  const hasIssues = (issues?.length ?? 0) > 0;
+
+  return (
+    <AdminWorkspace
+      lede="Publish health across content domains — validation issues that block release."
+      actions={
+        !loading && hasIssues ? (
+          <Link href="/admin/publish" className="btn primary sm">
+            Review and publish
+          </Link>
+        ) : (
+          <Link href="/admin/publish" className="btn sm">
+            Publish wizard
+          </Link>
+        )
+      }
+    >
+      {loading ? (
+        <AdminEmpty>Loading…</AdminEmpty>
+      ) : (
+        <>
+          {/* 1. Domain publish health — compact operator list, not KPI cards */}
+          <div className="sect-label">Publish health</div>
+          {domains.length === 0 ? (
+            <AdminEmpty>No domain state available.</AdminEmpty>
+          ) : (
+            <div className="hist" role="list" style={{ marginBottom: 24 }}>
+              {domains.map(row => {
+                const when = formatPublishedAt(row.publishedAt);
+                return (
+                  <div
+                    key={row.id}
+                    className="histrow"
+                    role="listitem"
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 12,
+                      flexWrap: 'wrap',
+                      padding: '10px 0',
+                    }}
+                  >
+                    <Link
+                      href={row.href}
+                      style={{
+                        flex: '1 1 160px',
+                        textDecoration: 'none',
+                        color: 'inherit',
+                        fontWeight: 500,
+                      }}
+                    >
+                      {row.label}
+                    </Link>
+                    <PublishBadge state={row.status} />
+                    {row.count && (
+                      <span className="count mono">{row.count}</span>
+                    )}
+                    {row.status === 'published' && when && (
+                      <span className="hint mono" style={{ marginLeft: 'auto' }}>
+                        {when}
+                      </span>
+                    )}
+                    {row.status !== 'published' && (
+                      <span className="hint mono" style={{ marginLeft: 'auto' }}>
+                        —
+                      </span>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {/* 2. Issues — primary (ISC-UX-A2) */}
+          <div className="sect-label">Publish issues</div>
+          {hasIssues ? (
+            <div style={{ marginBottom: 24 }}>
+              <IssueList issues={issues!} title="Blocking validation" />
+              <p style={{ marginTop: 14 }}>
+                <Link href="/admin/publish" className="btn primary sm">
+                  Review and publish
+                </Link>
+              </p>
+            </div>
+          ) : (
+            <AdminEmpty>
+              No publish issues. All validated domains are clean.
+            </AdminEmpty>
+          )}
+
+          {/* 3. Quick links — secondary text row */}
+          <div style={{ marginTop: 28 }}>
+            <div className="sect-label">Quick links</div>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginTop: 8 }}>
+              <Link href="/admin/publish" className="btn sm">Publish wizard</Link>
+              <Link href="/admin/import" className="btn sm">Import / Export</Link>
+              <Link href="/admin/templates" className="btn sm">Templates</Link>
+              <Link href="/admin/catalog" className="btn sm">Catalogue</Link>
+              <Link href="/admin/sections" className="btn sm">ADD sections</Link>
+              <Link href="/admin/flows" className="btn sm">Flows</Link>
+              <Link href="/admin/locale" className="btn sm">Locale</Link>
+            </div>
+          </div>
+        </>
+      )}
+    </AdminWorkspace>
+  );
+}

--- a/src/app/admin/publish/page.tsx
+++ b/src/app/admin/publish/page.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { AdminPageHeader } from '@/components/admin/AdminPageHeader';
+import { PublishWizard } from '@/components/admin/PublishWizard';
+
+export default function AdminPublishPage() {
+  return (
+    <div className="workspace">
+      <AdminPageHeader
+        lede="Review validation, then publish catalogue and templates."
+      />
+      <div className="ws-body">
+        <div className="cpanel" style={{ maxWidth: 720 }}>
+          <PublishWizard />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/sections/[id]/page.tsx
+++ b/src/app/admin/sections/[id]/page.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+import SectionEditor from '@/components/admin/SectionEditor';
+
+export default function AdminSectionDetailPage() {
+  const params = useParams();
+  const id = typeof params.id === 'string' ? params.id : params.id?.[0] ?? '';
+
+  return <SectionEditor sectionId={id} />;
+}

--- a/src/app/admin/sections/page.tsx
+++ b/src/app/admin/sections/page.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Icon } from '@/components/Icon';
+import { AdminEmpty } from '@/components/admin/AdminEmpty';
+import { AdminWorkspace, useAdminLocale } from '@/components/admin/AdminWorkspace';
+import { NewSectionDialog } from '@/components/admin/NewSectionDialog';
+import { PublishBadge } from '@/components/admin/PublishBadge';
+import {
+  fetchSections,
+  fetchSectionState,
+  publishSections,
+  type AdminSectionListItem,
+} from '@/lib/admin/sections';
+import type { SectionType } from '@/lib/types';
+
+const TYPE_ICONS: Record<SectionType, string> = {
+  cards: 'card',
+  text: 'file',
+  timeline: 'clock',
+  table: 'chart',
+  compare: 'layers',
+};
+
+function sectionTitle(item: AdminSectionListItem, locale: 'en' | 'fr'): string {
+  return locale === 'fr' ? (item.titleFr || item.id) : (item.titleEn || item.id);
+}
+
+function sectionTab(item: AdminSectionListItem, locale: 'en' | 'fr'): string | undefined {
+  return locale === 'fr' ? item.tabFr : item.tabEn;
+}
+
+function SectionRow({ item, locale }: { item: AdminSectionListItem; locale: 'en' | 'fr' }) {
+  return (
+    <Link
+      href={`/admin/sections/${item.id}`}
+      className="tree-row"
+      style={{ textDecoration: 'none', color: 'inherit' }}
+    >
+      <span className="ficon"><Icon name={TYPE_ICONS[item.type]} size={15} /></span>
+      <span className="label">{sectionTitle(item, locale)}</span>
+      <span className="count mono" style={{ fontSize: 11 }}>
+        {item.type}
+        {item.itemCount !== undefined ? ` · ${item.itemCount}` : ''}
+        {sectionTab(item, locale) ? ` · ${sectionTab(item, locale)}` : ''}
+      </span>
+    </Link>
+  );
+}
+
+export default function AdminSectionsPage() {
+  const router = useRouter();
+  const locale = useAdminLocale();
+  const [sections, setSections] = useState<AdminSectionListItem[] | null>(null);
+  const [showNew, setShowNew] = useState(false);
+  const [dirty, setDirty] = useState(false);
+  const [publishedAt, setPublishedAt] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [publishIssues, setPublishIssues] = useState<string[]>([]);
+  const [query, setQuery] = useState('');
+
+  const reload = useCallback(async () => {
+    const [list, state] = await Promise.all([
+      fetchSections(),
+      fetchSectionState().catch(() => ({ dirty: false, publishedAt: null, sectionCount: 0, issues: [] as const })),
+    ]);
+    setSections(list.sections);
+    setDirty(state.dirty);
+    setPublishedAt(state.publishedAt);
+    setPublishIssues((state.issues ?? []).map(issue => issue.message));
+  }, []);
+
+  useEffect(() => {
+    reload().catch(err => setError(err instanceof Error ? err.message : 'Failed to load sections'));
+  }, [reload]);
+
+  async function onPublish() {
+    setBusy(true);
+    setError(null);
+    try {
+      const result = await publishSections();
+      if (!result.ok) {
+        setPublishIssues((result.issues ?? []).map(i => i.message));
+        if (result.error) setError(result.error);
+        return;
+      }
+      await reload();
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const filtered = useMemo(() => {
+    if (!sections) return [];
+    const q = query.trim().toLowerCase();
+    if (!q) return sections;
+    return sections.filter(item => {
+      const hay = [
+        item.id,
+        item.type,
+        item.titleEn,
+        item.titleFr,
+        item.tabEn,
+        item.tabFr,
+      ].filter(Boolean).join(' ').toLowerCase();
+      return hay.includes(q);
+    });
+  }, [sections, query]);
+
+  const publishState = dirty ? 'modified' : publishedAt ? 'published' : 'draft';
+
+  return (
+    <>
+    <AdminWorkspace
+      lede="Reusable document sections — cards, text, timelines, tables, comparisons."
+      search={{ value: query, onChange: setQuery, placeholder: 'Filter sections…' }}
+      error={error}
+      issues={publishIssues}
+      actions={(
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+          <PublishBadge state={publishState} />
+          {!dirty && publishedAt && (
+            <span className="hint mono">Published {publishedAt.slice(0, 10)}</span>
+          )}
+          <button type="button" className="btn sm primary" disabled={busy} onClick={() => setShowNew(true)}>
+            New section
+          </button>
+          <button type="button" className="btn primary sm" disabled={busy} onClick={onPublish}>
+            {busy ? 'Publishing…' : 'Publish sections'}
+          </button>
+        </div>
+      )}
+    >
+      {!sections && !error && <AdminEmpty>Loading sections…</AdminEmpty>}
+      {sections && filtered.length === 0 && (
+        <AdminEmpty>
+          {query ? 'No section matches this search.' : 'No sections in the library yet.'}
+        </AdminEmpty>
+      )}
+
+      {filtered.length > 0 && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          {filtered.map(item => (
+            <SectionRow key={item.id} item={item} locale={locale} />
+          ))}
+        </div>
+      )}
+    </AdminWorkspace>
+
+      {showNew && (
+        <NewSectionDialog
+          onClose={() => setShowNew(false)}
+          onCreated={id => { setShowNew(false); router.push(`/admin/sections/${id}`); }}
+        />
+      )}
+    </>
+  );
+}

--- a/src/app/admin/templates/[id]/page.tsx
+++ b/src/app/admin/templates/[id]/page.tsx
@@ -1,0 +1,233 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter, useParams } from 'next/navigation';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { AdminEmpty } from '@/components/admin/AdminEmpty';
+import { ArchitectureTemplateEditor } from '@/components/admin/ArchitectureTemplateEditor';
+import { CatalogSaveFlag, type CatalogSaveState } from '@/components/admin/CatalogList';
+import { ProjectTemplateEditor } from '@/components/admin/ProjectTemplateEditor';
+import { useAdminLocale } from '@/components/admin/AdminWorkspace';
+import { Group, Text, Area } from '@/components/editors/Fields';
+import {
+  deleteTemplate,
+  fetchTemplate,
+  importTemplateSnapshot,
+  updateTemplate,
+  type ArchitectureTemplateDetail,
+  type TemplateDetail,
+} from '@/lib/admin/templates';
+import type { Architecture } from '@/lib/types';
+import type { Template } from '@/lib/templates/types';
+
+export default function AdminTemplateDetailPage() {
+  const params = useParams<{ id: string }>();
+  const router = useRouter();
+  const locale = useAdminLocale();
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const [tpl, setTpl] = useState<TemplateDetail | null>(null);
+  const [editorKey, setEditorKey] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [saveState, setSaveState] = useState<CatalogSaveState>('idle');
+  const [busyDelete, setBusyDelete] = useState(false);
+  const [specText, setSpecText] = useState('');
+
+  const load = useCallback(async () => {
+    const data = await fetchTemplate(params.id);
+    setTpl(data);
+    if (data.kind === 'architecture' && data.spec) {
+      setSpecText(JSON.stringify(data.spec, null, 2));
+    }
+    return data;
+  }, [params.id]);
+
+  useEffect(() => {
+    load().catch(err => setError(err instanceof Error ? err.message : 'Failed to load template'));
+  }, [load]);
+
+  async function save(patch: Parameters<typeof updateTemplate>[1]) {
+    if (!tpl) return;
+    setSaveState('saving');
+    setError(null);
+    try {
+      await updateTemplate(tpl.id, patch);
+      if (tpl.kind === 'architecture') {
+        const data = await load();
+        if (data) setTpl(data);
+      }
+      setSaveState('saved');
+      setTimeout(() => setSaveState('idle'), 1200);
+    } catch (e) {
+      setError((e as Error).message);
+      setSaveState('error');
+    }
+  }
+
+  async function onDelete() {
+    if (!tpl) return;
+    const label = tpl.kind === 'project' ? 'project' : 'architecture';
+    if (!window.confirm(`Delete ${label} template "${tpl.id}"? Locked architecture ids re-seed on next ensure.`)) return;
+    setBusyDelete(true);
+    setError(null);
+    try {
+      await deleteTemplate(tpl.id);
+      router.push('/admin/templates');
+    } catch (e) {
+      setError((e as Error).message);
+      setBusyDelete(false);
+    }
+  }
+
+  async function onImportJson(file: File) {
+    if (!tpl || tpl.kind !== 'project') return;
+    const text = await file.text();
+    const snapshot = JSON.parse(text) as Architecture;
+    setSaveState('saving');
+    setError(null);
+    try {
+      await importTemplateSnapshot(tpl.id, snapshot);
+      const data = await load();
+      setEditorKey(k => k + 1);
+      setSaveState('saved');
+      setTimeout(() => setSaveState('idle'), 1200);
+      if (data) setTpl(data);
+    } catch (e) {
+      setError((e as Error).message);
+      setSaveState('error');
+    }
+  }
+
+  async function saveArchitectureSpec() {
+    if (!tpl || tpl.kind !== 'architecture') return;
+    let spec: Template;
+    try {
+      spec = JSON.parse(specText) as Template;
+    } catch {
+      setError('Spec JSON is not valid');
+      setSaveState('error');
+      return;
+    }
+    await save({ spec });
+  }
+
+  if (error && !tpl) {
+    return (
+      <div className="workspace"><div className="ws-body"><div className="warnbox">{error}</div></div></div>
+    );
+  }
+
+  if (!tpl) {
+    return (
+      <div className="workspace"><div className="ws-body"><AdminEmpty>Loading…</AdminEmpty></div></div>
+    );
+  }
+
+  const displayName = locale === 'fr' ? tpl.nameFr : tpl.nameEn;
+  const tagline = locale === 'fr' ? tpl.meta.taglineFr : tpl.meta.taglineEn;
+
+  if (tpl.kind === 'architecture') {
+    const arch = tpl as ArchitectureTemplateDetail;
+    return (
+      <ArchitectureTemplateEditor
+        tpl={arch}
+        title={displayName}
+        subtitle={tagline || 'Hyperscaler pattern — spec stays per-cloud.'}
+        specText={specText}
+        saveState={saveState}
+        error={error}
+        actions={(
+          <>
+            <Link href="/admin/templates" className="btn sm ghost">All templates</Link>
+            <button type="button" className="btn sm" disabled={busyDelete} onClick={onDelete}>Delete</button>
+          </>
+        )}
+        onTplChange={next => setTpl(next)}
+        onSaveMeta={patch => void save(patch)}
+        onSpecChange={v => { setSpecText(v); setSaveState('dirty'); }}
+        onSaveSpec={() => void saveArchitectureSpec()}
+        onSnapshotError={msg => setError(msg)}
+      />
+    );
+  }
+
+  return (
+    <ProjectTemplateEditor
+      key={`${tpl.id}-${editorKey}`}
+      tpl={tpl}
+      editable
+      onSnapshotError={msg => setError(msg)}
+      header={{
+        title: displayName,
+        subtitle: tagline || 'Editable project snapshot.',
+        badge: (
+          <>
+            <span className="count">Project</span>
+            {tpl.featured && (
+              <span className="count" style={{ borderColor: 'var(--brand)', color: 'var(--brand-ink)' }}>Featured</span>
+            )}
+          </>
+        ),
+        actions: (
+          <>
+            <CatalogSaveFlag state={saveState} />
+            <Link href="/admin/templates" className="btn sm ghost">All templates</Link>
+            <button type="button" className="btn sm" onClick={() => fileRef.current?.click()}>Import JSON</button>
+            <input ref={fileRef} type="file" accept="application/json,.json" hidden
+              onChange={e => { const f = e.target.files?.[0]; if (f) onImportJson(f); e.target.value = ''; }} />
+            <button type="button" className="btn sm" disabled={busyDelete} onClick={onDelete}>Delete</button>
+          </>
+        ),
+      }}
+      metadata={(
+        <>
+          {error && <div className="warnbox" style={{ marginBottom: 14 }}>{error}</div>}
+
+          <Group title="Identity">
+            <div className="field"><span>Template ID</span><div className="mono">{tpl.id}</div></div>
+            <Text label="Name (EN)" value={tpl.nameEn}
+              onChange={v => setTpl({ ...tpl, nameEn: v })}
+              onBlur={() => save({ nameEn: tpl.nameEn })} />
+            <Text label="Name (FR)" value={tpl.nameFr}
+              onChange={v => setTpl({ ...tpl, nameFr: v })}
+              onBlur={() => save({ nameFr: tpl.nameFr })} />
+            <label className="field">
+              <span>Featured (seed + picker priority)</span>
+              <button type="button"
+                className={`radio${tpl.featured ? ' on' : ''}`}
+                onClick={() => save({ featured: !tpl.featured })}>
+                <i /> {tpl.featured ? 'Featured template' : 'Not featured'}
+              </button>
+            </label>
+          </Group>
+
+          <Group title="Picker copy">
+            <Area label="Tagline (EN)" value={tpl.meta.taglineEn}
+              onChange={v => setTpl({ ...tpl, meta: { ...tpl.meta, taglineEn: v } })}
+              onBlur={() => save({ meta: { taglineEn: tpl.meta.taglineEn } })} />
+            <Area label="Tagline (FR)" value={tpl.meta.taglineFr}
+              onChange={v => setTpl({ ...tpl, meta: { ...tpl.meta, taglineFr: v } })}
+              onBlur={() => save({ meta: { taglineFr: tpl.meta.taglineFr } })} />
+            <Text label="Accent" value={tpl.meta.accent} mono
+              onChange={v => setTpl({ ...tpl, meta: { ...tpl.meta, accent: v } })}
+              onBlur={() => save({ meta: { accent: tpl.meta.accent } })} />
+            <Text label="Icon key" value={tpl.meta.icon} mono
+              onChange={v => setTpl({ ...tpl, meta: { ...tpl.meta, icon: v } })}
+              onBlur={() => save({ meta: { icon: tpl.meta.icon } })} />
+          </Group>
+
+          <Group title="Outline">
+            <div className="frow">
+              <div className="field"><span>Components</span><div className="mono">{tpl.outline.componentCount}</div></div>
+              <div className="field"><span>Flows</span><div className="mono">{tpl.outline.flowCount}</div></div>
+            </div>
+            <div className="field">
+              <span>Sections</span>
+              <div className="mono">{tpl.outline.sectionIds.join(', ') || '—'}</div>
+            </div>
+          </Group>
+        </>
+      )}
+    />
+  );
+}

--- a/src/app/admin/templates/page.tsx
+++ b/src/app/admin/templates/page.tsx
@@ -1,0 +1,244 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
+import { AdminEmpty } from '@/components/admin/AdminEmpty';
+import { AdminEntityGrid, type AdminGridItem } from '@/components/admin/AdminEntityGrid';
+import { AdminWorkspace, useAdminLocale } from '@/components/admin/AdminWorkspace';
+import { NewTemplateDialog } from '@/components/admin/NewTemplateDialog';
+import { PublishBadge } from '@/components/admin/PublishBadge';
+import {
+  fetchAllTemplates,
+  fetchProjectTemplateState,
+  publishProjectTemplates,
+  reimportAcmeTemplate,
+  type AdminTemplateListItem,
+} from '@/lib/admin/templates';
+import {
+  fetchArchitectureTemplateState,
+  publishArchitectureTemplates,
+} from '@/lib/admin/architecture';
+
+function templatePublishState(dirty: boolean, publishedAt: string | null): 'draft' | 'modified' | 'published' {
+  if (dirty) return 'modified';
+  if (publishedAt) return 'published';
+  return 'draft';
+}
+
+function toGridItems(templates: AdminTemplateListItem[], locale: 'en' | 'fr'): AdminGridItem[] {
+  return templates.map(tpl => ({
+    href: `/admin/templates/${tpl.id}`,
+    icon: tpl.icon,
+    accent: tpl.accent,
+    title: locale === 'fr' ? tpl.nameFr : tpl.nameEn,
+    description: locale === 'fr' ? tpl.taglineFr : tpl.taglineEn,
+    count: `${tpl.componentCount} comp · ${tpl.flowCount} flows`,
+    badge: (
+      <>
+        {tpl.kind === 'architecture' && (
+          <span className="count">Architecture</span>
+        )}
+        {tpl.kind === 'project' && tpl.featured && (
+          <span className="count" style={{ borderColor: 'var(--brand)', color: 'var(--brand-ink)' }}>Featured</span>
+        )}
+      </>
+    ),
+  }));
+}
+
+function DomainHead({
+  label,
+  count,
+  dirty,
+  publishedAt,
+  children,
+}: {
+  label: string;
+  count: number;
+  dirty: boolean;
+  publishedAt: string | null;
+  children: ReactNode;
+}) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', marginBottom: 12 }}>
+      <div className="sect-label" style={{ margin: 0, flex: '1 1 auto' }}>
+        {label} · {count}
+      </div>
+      <PublishBadge state={templatePublishState(dirty, publishedAt)} />
+      {!dirty && publishedAt && (
+        <span className="hint mono">Published {publishedAt.slice(0, 10)}</span>
+      )}
+      {children}
+    </div>
+  );
+}
+
+export default function AdminTemplatesPage() {
+  const router = useRouter();
+  const locale = useAdminLocale();
+  const [templates, setTemplates] = useState<AdminTemplateListItem[] | null>(null);
+  const [dirty, setDirty] = useState(false);
+  const [publishedAt, setPublishedAt] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [publishIssues, setPublishIssues] = useState<string[]>([]);
+  const [showNew, setShowNew] = useState(false);
+  const [archDirty, setArchDirty] = useState(false);
+  const [archPublishedAt, setArchPublishedAt] = useState<string | null>(null);
+  const [query, setQuery] = useState('');
+
+  const reload = useCallback(async () => {
+    const [list, state, archState] = await Promise.all([
+      fetchAllTemplates(),
+      fetchProjectTemplateState({ validate: true }),
+      fetchArchitectureTemplateState({ validate: true }),
+    ]);
+    setTemplates(list.templates);
+    setDirty(state.dirty);
+    setPublishedAt(state.publishedAt);
+    setArchDirty(archState.dirty);
+    setArchPublishedAt(archState.publishedAt);
+    setPublishIssues([
+      ...(state.issues ?? []).map(i => i.message),
+      ...(archState.issues ?? []).map(i => i.message),
+    ]);
+  }, []);
+
+  useEffect(() => {
+    reload().catch(err => setError(err instanceof Error ? err.message : 'Failed to load templates'));
+  }, [reload]);
+
+  async function onPublish() {
+    setBusy(true); setError(null);
+    try {
+      const result = await publishProjectTemplates();
+      if (!result.ok) {
+        setPublishIssues(result.issues.map(i => i.message));
+        setError(result.error);
+        return;
+      }
+      await reload();
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onReimportAcme() {
+    setBusy(true); setError(null);
+    try {
+      await reimportAcmeTemplate();
+      await reload();
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onPublishArchitecture() {
+    setBusy(true); setError(null);
+    try {
+      const result = await publishArchitectureTemplates();
+      if (!result.ok) {
+        setPublishIssues(result.issues.map(i => i.message));
+        setError(result.error);
+        return;
+      }
+      await reload();
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const filtered = useMemo(() => {
+    if (!templates) return [];
+    const q = query.trim().toLowerCase();
+    if (!q) return templates;
+    return templates.filter(tpl => {
+      const hay = [tpl.id, tpl.kind, tpl.nameEn, tpl.nameFr, tpl.taglineEn, tpl.taglineFr]
+        .join(' ')
+        .toLowerCase();
+      return hay.includes(q);
+    });
+  }, [templates, query]);
+
+  const projectTemplates = filtered.filter(t => t.kind === 'project');
+  const architectureTemplates = filtered.filter(t => t.kind === 'architecture');
+
+  return (
+    <>
+      <AdminWorkspace
+        lede="Project snapshots and hyperscaler patterns — edit in the atelier, publish each domain."
+        search={{ value: query, onChange: setQuery, placeholder: 'Filter templates…' }}
+        error={error}
+        issues={publishIssues}
+        actions={(
+          <button type="button" className="btn sm primary" disabled={busy} onClick={() => setShowNew(true)}>
+            Create
+          </button>
+        )}
+      >
+        {!templates && !error && <AdminEmpty>Loading templates…</AdminEmpty>}
+        {templates && templates.length === 0 && (
+          <AdminEmpty>
+            <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', gap: 12 }}>
+              <span>No templates yet.</span>
+              <button type="button" className="btn primary sm" disabled={busy} onClick={() => setShowNew(true)}>
+                Create
+              </button>
+            </div>
+          </AdminEmpty>
+        )}
+        {templates && templates.length > 0 && filtered.length === 0 && (
+          <AdminEmpty>No template matches this search.</AdminEmpty>
+        )}
+
+        {architectureTemplates.length > 0 && (
+          <div style={{ marginBottom: 28 }}>
+            <DomainHead
+              label="Architecture templates"
+              count={architectureTemplates.length}
+              dirty={archDirty}
+              publishedAt={archPublishedAt}
+            >
+              <button type="button" className="btn primary sm" disabled={busy} onClick={onPublishArchitecture}>
+                {busy ? 'Publishing…' : 'Publish architecture'}
+              </button>
+            </DomainHead>
+            <AdminEntityGrid items={toGridItems(architectureTemplates, locale)} />
+          </div>
+        )}
+
+        {projectTemplates.length > 0 && (
+          <div>
+            <DomainHead
+              label="Project templates"
+              count={projectTemplates.length}
+              dirty={dirty}
+              publishedAt={publishedAt}
+            >
+              <button type="button" className="btn sm" disabled={busy} onClick={onReimportAcme}>
+                Re-import Acme
+              </button>
+              <button type="button" className="btn primary sm" disabled={busy} onClick={onPublish}>
+                {busy ? 'Publishing…' : 'Publish project'}
+              </button>
+            </DomainHead>
+            <AdminEntityGrid items={toGridItems(projectTemplates, locale)} />
+          </div>
+        )}
+      </AdminWorkspace>
+
+      {showNew && (
+        <NewTemplateDialog
+          onClose={() => setShowNew(false)}
+          onCreated={id => { setShowNew(false); router.push(`/admin/templates/${id}`); }}
+        />
+      )}
+    </>
+  );
+}

--- a/src/app/api/admin/architecture-templates/[id]/route.ts
+++ b/src/app/api/admin/architecture-templates/[id]/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+import {
+  deleteArchitectureTemplate,
+  getArchitectureTemplateAdmin,
+  updateArchitectureTemplate,
+  type ArchitectureTemplatePatch,
+} from "@/lib/admin/architecture-templates";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const { id } = await ctx.params;
+  const template = getArchitectureTemplateAdmin(id);
+  if (!template) return NextResponse.json({ error: "not found" }, { status: 404 });
+  return NextResponse.json(template);
+}
+
+export async function PATCH(req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const { id } = await ctx.params;
+  const body = (await req.json().catch(() => ({}))) as ArchitectureTemplatePatch;
+  try {
+    updateArchitectureTemplate(id, body);
+    return NextResponse.json({ ok: true, id });
+  } catch (e) {
+    return NextResponse.json({ error: (e as Error).message }, { status: 400 });
+  }
+}
+
+export async function DELETE(_req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const { id } = await ctx.params;
+  try {
+    deleteArchitectureTemplate(id);
+    return NextResponse.json({ ok: true, id });
+  } catch (e) {
+    return NextResponse.json({ error: (e as Error).message }, { status: 400 });
+  }
+}

--- a/src/app/api/admin/architecture-templates/publish/route.ts
+++ b/src/app/api/admin/architecture-templates/publish/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+import { publishArchitectureTemplates } from "@/lib/admin/architecture-templates";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST() {
+  const result = publishArchitectureTemplates();
+  if (!result.ok) {
+    return NextResponse.json({ ok: false, issues: result.issues }, { status: 400 });
+  }
+  return NextResponse.json({ ok: true, publishedAt: result.publishedAt });
+}

--- a/src/app/api/admin/architecture-templates/route.ts
+++ b/src/app/api/admin/architecture-templates/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import {
+  createArchitectureTemplate,
+  listArchitectureTemplatesAdmin,
+  type ArchitectureTemplateCreate,
+} from "@/lib/admin/architecture-templates";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  return NextResponse.json({ templates: listArchitectureTemplatesAdmin() });
+}
+
+export async function POST(req: Request) {
+  const body = (await req.json().catch(() => ({}))) as ArchitectureTemplateCreate;
+  try {
+    const id = createArchitectureTemplate(body);
+    return NextResponse.json({ ok: true, id }, { status: 201 });
+  } catch (e) {
+    return NextResponse.json({ error: (e as Error).message }, { status: 400 });
+  }
+}

--- a/src/app/api/admin/architecture-templates/state/route.ts
+++ b/src/app/api/admin/architecture-templates/state/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+import { getArchitectureTemplatesAdminState } from "@/lib/admin/architecture-templates";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(req: Request) {
+  const validate = new URL(req.url).searchParams.get("validate") === "1";
+  return NextResponse.json(getArchitectureTemplatesAdminState({ validate }));
+}

--- a/src/app/api/admin/bundle/route.ts
+++ b/src/app/api/admin/bundle/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import { exportContentBundle, importContentBundle } from "@/lib/admin/bundle";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  return NextResponse.json(exportContentBundle());
+}
+
+export async function POST(req: Request) {
+  const body = await req.json().catch(() => null);
+  const mode = body && typeof body === "object" && body.mode === "replace" ? "replace" : "merge";
+  const bundle = body && typeof body === "object" && "bundle" in body ? body.bundle : body;
+  const result = importContentBundle(bundle, { mode });
+  if (!result.ok) {
+    return NextResponse.json({ ok: false, issues: result.issues }, { status: 400 });
+  }
+  return NextResponse.json({ ok: true, issues: result.issues });
+}

--- a/src/app/api/admin/catalog/bricks/[id]/route.ts
+++ b/src/app/api/admin/catalog/bricks/[id]/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+import { deleteAdminBrick, updateAdminBrick, type BrickAdminUpdate } from '@/lib/lego/admin-catalog';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+type Ctx = { params: Promise<{ id: string }> };
+
+export async function PATCH(req: Request, { params }: Ctx) {
+  const { id } = await params;
+  const body = await req.json().catch(() => null);
+  if (!body || typeof body !== 'object') {
+    return NextResponse.json({ error: 'invalid body' }, { status: 400 });
+  }
+
+  try {
+    const brickId = updateAdminBrick(id, body as BrickAdminUpdate);
+    return NextResponse.json({ ok: true, brickId });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'update failed';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}
+
+export async function DELETE(_req: Request, { params }: Ctx) {
+  const { id } = await params;
+  try {
+    const brickId = deleteAdminBrick(id);
+    return NextResponse.json({ ok: true, brickId });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'delete failed';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/src/app/api/admin/catalog/bricks/route.ts
+++ b/src/app/api/admin/catalog/bricks/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { createAdminBrick, type BrickAdminCreate } from '@/lib/lego/admin-catalog';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST(req: Request) {
+  const body = await req.json().catch(() => null);
+  if (!body || typeof body !== 'object') {
+    return NextResponse.json({ error: 'invalid body' }, { status: 400 });
+  }
+
+  try {
+    const brickId = createAdminBrick(body as BrickAdminCreate);
+    return NextResponse.json({ ok: true, brickId }, { status: 201 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'create failed';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/src/app/api/admin/catalog/dependencies/route.ts
+++ b/src/app/api/admin/catalog/dependencies/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from 'next/server';
+import {
+  createDependency,
+  deleteDependency,
+  listDependencies,
+  updateDependency,
+  type DependencyAdminCreate,
+  type DependencyAdminPatch,
+} from '@/lib/lego/admin-catalog';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  return NextResponse.json({ dependencies: listDependencies() });
+}
+
+export async function POST(req: Request) {
+  const body = await req.json().catch(() => null);
+  if (!body || typeof body !== 'object') {
+    return NextResponse.json({ error: 'invalid body' }, { status: 400 });
+  }
+
+  try {
+    const edge = createDependency(body as DependencyAdminCreate);
+    return NextResponse.json({ ok: true, ...edge }, { status: 201 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'create failed';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}
+
+export async function PATCH(req: Request) {
+  const body = await req.json().catch(() => null);
+  if (!body || typeof body !== 'object') {
+    return NextResponse.json({ error: 'invalid body' }, { status: 400 });
+  }
+
+  const from = typeof body.from === 'string' ? body.from : '';
+  const to = typeof body.to === 'string' ? body.to : '';
+  if (!from || !to) {
+    return NextResponse.json({ error: 'from and to are required' }, { status: 400 });
+  }
+
+  const { from: _from, to: _to, ...patch } = body as { from: string; to: string } & DependencyAdminPatch;
+  try {
+    const edge = updateDependency(from, to, patch);
+    return NextResponse.json({ ok: true, ...edge });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'update failed';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}
+
+export async function DELETE(req: Request) {
+  const url = new URL(req.url);
+  const from = url.searchParams.get('from') ?? '';
+  const to = url.searchParams.get('to') ?? '';
+  if (!from || !to) {
+    return NextResponse.json({ error: 'from and to query params are required' }, { status: 400 });
+  }
+
+  try {
+    const edge = deleteDependency(from, to);
+    return NextResponse.json({ ok: true, ...edge });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'delete failed';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/src/app/api/admin/catalog/intents/[id]/route.ts
+++ b/src/app/api/admin/catalog/intents/[id]/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server';
+import { deleteIntent, getIntent, updateIntent, type IntentAdminUpdate } from '@/lib/lego/admin-catalog';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+type Ctx = { params: Promise<{ id: string }> };
+
+export async function GET(_req: Request, { params }: Ctx) {
+  const { id } = await params;
+  const intent = getIntent(id);
+  if (!intent) return NextResponse.json({ error: 'not found' }, { status: 404 });
+  return NextResponse.json({ intent });
+}
+
+export async function PATCH(req: Request, { params }: Ctx) {
+  const { id } = await params;
+  const body = await req.json().catch(() => null);
+  if (!body || typeof body !== 'object') {
+    return NextResponse.json({ error: 'invalid body' }, { status: 400 });
+  }
+
+  try {
+    const intentId = updateIntent(id, body as IntentAdminUpdate);
+    return NextResponse.json({ ok: true, intentId });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'update failed';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}
+
+export async function DELETE(_req: Request, { params }: Ctx) {
+  const { id } = await params;
+  try {
+    const intentId = deleteIntent(id);
+    return NextResponse.json({ ok: true, intentId });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'delete failed';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/src/app/api/admin/catalog/intents/route.ts
+++ b/src/app/api/admin/catalog/intents/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+import { createIntent, listIntents, type IntentAdminCreate } from '@/lib/lego/admin-catalog';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  return NextResponse.json({ intents: listIntents() });
+}
+
+export async function POST(req: Request) {
+  const body = await req.json().catch(() => null);
+  if (!body || typeof body !== 'object') {
+    return NextResponse.json({ error: 'invalid body' }, { status: 400 });
+  }
+
+  try {
+    const intentId = createIntent(body as IntentAdminCreate);
+    return NextResponse.json({ ok: true, intentId }, { status: 201 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'create failed';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/src/app/api/admin/catalog/publish/route.ts
+++ b/src/app/api/admin/catalog/publish/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+import { publishCatalog } from '@/lib/lego/admin-catalog';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST() {
+  const result = publishCatalog();
+  if (!result.ok) {
+    return NextResponse.json({ error: 'validation failed', issues: result.issues }, { status: 400 });
+  }
+  return NextResponse.json({ ok: true, publishedAt: result.publishedAt });
+}

--- a/src/app/api/admin/catalog/scopes/[id]/route.ts
+++ b/src/app/api/admin/catalog/scopes/[id]/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+import { deleteScope, updateScope, type ScopeAdminUpdate } from '@/lib/lego/admin-catalog';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+type Ctx = { params: Promise<{ id: string }> };
+
+export async function PATCH(req: Request, { params }: Ctx) {
+  const { id } = await params;
+  const body = await req.json().catch(() => null);
+  if (!body || typeof body !== 'object') {
+    return NextResponse.json({ error: 'invalid body' }, { status: 400 });
+  }
+
+  try {
+    const scopeId = updateScope(id, body as ScopeAdminUpdate);
+    return NextResponse.json({ ok: true, scopeId });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'update failed';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}
+
+export async function DELETE(_req: Request, { params }: Ctx) {
+  const { id } = await params;
+  try {
+    const scopeId = deleteScope(id);
+    return NextResponse.json({ ok: true, scopeId });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'delete failed';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/src/app/api/admin/catalog/scopes/route.ts
+++ b/src/app/api/admin/catalog/scopes/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+import { createScope, listScopes, type ScopeAdminCreate } from '@/lib/lego/admin-catalog';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  return NextResponse.json({ scopes: listScopes() });
+}
+
+export async function POST(req: Request) {
+  const body = await req.json().catch(() => null);
+  if (!body || typeof body !== 'object') {
+    return NextResponse.json({ error: 'invalid body' }, { status: 400 });
+  }
+
+  try {
+    const scopeId = createScope(body as ScopeAdminCreate);
+    return NextResponse.json({ ok: true, scopeId }, { status: 201 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'create failed';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/src/app/api/admin/catalog/state/route.ts
+++ b/src/app/api/admin/catalog/state/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+import { getCatalogAdminStateWithIssues } from '@/lib/lego/admin-catalog';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: Request) {
+  const validate = new URL(req.url).searchParams.get('validate') === '1';
+  return NextResponse.json(getCatalogAdminStateWithIssues({ validate }), { headers: { 'Cache-Control': 'no-store' } });
+}

--- a/src/app/api/admin/catalog/technologies/[key]/route.ts
+++ b/src/app/api/admin/catalog/technologies/[key]/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+import {
+  deleteTechnologyDescription,
+  updateTechnologyDescription,
+  type TechnologyDescriptionUpdate,
+} from '@/lib/lego/admin-catalog';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+type Ctx = { params: Promise<{ key: string }> };
+
+export async function PATCH(req: Request, { params }: Ctx) {
+  const { key } = await params;
+  const body = await req.json().catch(() => null);
+  if (!body || typeof body !== 'object') {
+    return NextResponse.json({ error: 'invalid body' }, { status: 400 });
+  }
+
+  try {
+    const technologyKey = updateTechnologyDescription(decodeURIComponent(key), body as TechnologyDescriptionUpdate);
+    return NextResponse.json({ ok: true, key: technologyKey });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'update failed';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}
+
+export async function DELETE(_req: Request, { params }: Ctx) {
+  const { key } = await params;
+  try {
+    const technologyKey = deleteTechnologyDescription(decodeURIComponent(key));
+    return NextResponse.json({ ok: true, key: technologyKey });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'delete failed';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/src/app/api/admin/catalog/technologies/route.ts
+++ b/src/app/api/admin/catalog/technologies/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import {
+  createTechnologyDescription,
+  listTechnologyDescriptions,
+  type TechnologyAdminCreate,
+} from '@/lib/lego/admin-catalog';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  return NextResponse.json({ technologies: listTechnologyDescriptions() });
+}
+
+export async function POST(req: Request) {
+  const body = await req.json().catch(() => null);
+  if (!body || typeof body !== 'object') {
+    return NextResponse.json({ error: 'invalid body' }, { status: 400 });
+  }
+
+  try {
+    const key = createTechnologyDescription(body as TechnologyAdminCreate);
+    return NextResponse.json({ ok: true, key }, { status: 201 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'create failed';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/src/app/api/admin/catalog/variants/[id]/route.ts
+++ b/src/app/api/admin/catalog/variants/[id]/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+import { deleteVariant, updateVariant, type VariantAdminUpdate } from '@/lib/lego/admin-catalog';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+type Ctx = { params: Promise<{ id: string }> };
+
+export async function PATCH(req: Request, { params }: Ctx) {
+  const { id } = await params;
+  const body = await req.json().catch(() => null);
+  if (!body || typeof body !== 'object') {
+    return NextResponse.json({ error: 'invalid body' }, { status: 400 });
+  }
+
+  try {
+    const variantId = updateVariant(id, body as VariantAdminUpdate);
+    return NextResponse.json({ ok: true, variantId });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'update failed';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}
+
+export async function DELETE(_req: Request, { params }: Ctx) {
+  const { id } = await params;
+  try {
+    const variantId = deleteVariant(id);
+    return NextResponse.json({ ok: true, variantId });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'delete failed';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/src/app/api/admin/catalog/variants/route.ts
+++ b/src/app/api/admin/catalog/variants/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+import { createVariant, listVariants, type VariantAdminCreate } from '@/lib/lego/admin-catalog';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  return NextResponse.json({ variants: listVariants() });
+}
+
+export async function POST(req: Request) {
+  const body = await req.json().catch(() => null);
+  if (!body || typeof body !== 'object') {
+    return NextResponse.json({ error: 'invalid body' }, { status: 400 });
+  }
+
+  try {
+    const variantId = createVariant(body as VariantAdminCreate);
+    return NextResponse.json({ ok: true, variantId }, { status: 201 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'create failed';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/src/app/api/admin/cloud-services/[key]/route.ts
+++ b/src/app/api/admin/cloud-services/[key]/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import {
+  deleteCloudService,
+  getCloudServiceAdmin,
+  updateCloudService,
+} from "@/lib/admin/cloud-services";
+import type { ServiceRow } from "@/lib/templates/services";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(_req: Request, ctx: { params: Promise<{ key: string }> }) {
+  const { key } = await ctx.params;
+  const service = getCloudServiceAdmin(key);
+  if (!service) return NextResponse.json({ error: "not found" }, { status: 404 });
+  return NextResponse.json(service);
+}
+
+export async function PATCH(req: Request, ctx: { params: Promise<{ key: string }> }) {
+  const { key } = await ctx.params;
+  const body = await req.json().catch(() => ({})) as { payload?: ServiceRow };
+  if (!body.payload) return NextResponse.json({ error: "payload is required" }, { status: 400 });
+  try {
+    updateCloudService(key, body.payload);
+    return NextResponse.json({ ok: true, roleKey: key });
+  } catch (e) {
+    return NextResponse.json({ error: (e as Error).message }, { status: 400 });
+  }
+}
+
+export async function DELETE(_req: Request, ctx: { params: Promise<{ key: string }> }) {
+  const { key } = await ctx.params;
+  try {
+    deleteCloudService(key);
+    return NextResponse.json({ ok: true, roleKey: key });
+  } catch (e) {
+    return NextResponse.json({ error: (e as Error).message }, { status: 400 });
+  }
+}

--- a/src/app/api/admin/cloud-services/publish/route.ts
+++ b/src/app/api/admin/cloud-services/publish/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+import { publishCloudServices } from "@/lib/admin/cloud-services";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST() {
+  const result = publishCloudServices();
+  if (!result.ok) {
+    return NextResponse.json({ ok: false, issues: result.issues }, { status: 400 });
+  }
+  return NextResponse.json({ ok: true, publishedAt: result.publishedAt });
+}

--- a/src/app/api/admin/cloud-services/route.ts
+++ b/src/app/api/admin/cloud-services/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import {
+  createCloudService,
+  listCloudServicesAdmin,
+  type CloudServiceCreate,
+} from "@/lib/admin/cloud-services";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  return NextResponse.json({ services: listCloudServicesAdmin() });
+}
+
+export async function POST(req: Request) {
+  const body = (await req.json().catch(() => ({}))) as CloudServiceCreate;
+  try {
+    const roleKey = createCloudService(body);
+    return NextResponse.json({ ok: true, roleKey }, { status: 201 });
+  } catch (e) {
+    return NextResponse.json({ error: (e as Error).message }, { status: 400 });
+  }
+}

--- a/src/app/api/admin/cloud-services/state/route.ts
+++ b/src/app/api/admin/cloud-services/state/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { getCloudServicesAdminState, setCloudServicesVerifiedOn } from "@/lib/admin/cloud-services";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(req: Request) {
+  const validate = new URL(req.url).searchParams.get("validate") === "1";
+  return NextResponse.json(getCloudServicesAdminState({ validate }));
+}
+
+export async function PATCH(req: Request) {
+  const body = await req.json().catch(() => ({})) as { verifiedOn?: string };
+  if (typeof body.verifiedOn === "string") setCloudServicesVerifiedOn(body.verifiedOn);
+  return NextResponse.json(getCloudServicesAdminState());
+}

--- a/src/app/api/admin/flows/[id]/preview/route.ts
+++ b/src/app/api/admin/flows/[id]/preview/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+import { getFlowPatternAdmin, templateToResolvedPattern } from '@/lib/admin/flow-patterns';
+import { matchSteps } from '@/lib/flows/match';
+import { countMappableSteps } from '@/lib/flows/plate';
+import { legoCatalog } from '@/lib/lego/repository';
+import demoJson from '@/lib/seed/demo.json';
+import { normalizeArchitecture } from '@/lib/defaults';
+import type { Lang } from '@/lib/templates/types';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const { id } = await ctx.params;
+  const lang: Lang = new URL(req.url).searchParams.get('lang') === 'fr' ? 'fr' : 'en';
+  const tpl = getFlowPatternAdmin(id);
+  if (!tpl) return NextResponse.json({ error: 'not found' }, { status: 404 });
+
+  const pattern = templateToResolvedPattern(tpl, lang);
+  const catalog = legoCatalog(lang === 'fr' ? 'fr' : 'en');
+  const doc = normalizeArchitecture(demoJson as Parameters<typeof normalizeArchitecture>[0]);
+  const bindings = matchSteps(pattern.steps, doc.components);
+  const matched = bindings.filter(b => b.component).length;
+
+  return NextResponse.json({
+    id,
+    stepCount: pattern.steps.length,
+    mappableSteps: countMappableSteps(pattern, catalog),
+    matchedOnDemo: matched,
+  });
+}

--- a/src/app/api/admin/flows/[id]/route.ts
+++ b/src/app/api/admin/flows/[id]/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+import { deleteFlowPattern, getFlowPatternAdmin, updateFlowPattern } from '@/lib/admin/flow-patterns';
+import type { FlowTemplate } from '@/lib/flows/types';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const { id } = await ctx.params;
+  const pattern = getFlowPatternAdmin(id);
+  if (!pattern) return NextResponse.json({ error: 'not found' }, { status: 404 });
+  return NextResponse.json(pattern);
+}
+
+export async function PATCH(req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const { id } = await ctx.params;
+  const body = (await req.json().catch(() => ({}))) as FlowTemplate;
+  try {
+    updateFlowPattern(id, body);
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    return NextResponse.json({ error: (e as Error).message }, { status: 400 });
+  }
+}
+
+export async function DELETE(_req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const { id } = await ctx.params;
+  try {
+    deleteFlowPattern(id);
+    return NextResponse.json({ ok: true, id });
+  } catch (e) {
+    return NextResponse.json({ error: (e as Error).message }, { status: 400 });
+  }
+}

--- a/src/app/api/admin/flows/publish/route.ts
+++ b/src/app/api/admin/flows/publish/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+import { publishFlowPatterns } from '@/lib/admin/flow-patterns';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST() {
+  const result = publishFlowPatterns();
+  if (!result.ok) {
+    return NextResponse.json({ ok: false, issues: result.issues }, { status: 400 });
+  }
+  return NextResponse.json({ ok: true, publishedAt: result.publishedAt });
+}

--- a/src/app/api/admin/flows/route.ts
+++ b/src/app/api/admin/flows/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { createFlowPattern, listFlowPatternsAdmin, type FlowPatternCreate } from '@/lib/admin/flow-patterns';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  return NextResponse.json({ patterns: listFlowPatternsAdmin() });
+}
+
+export async function POST(req: Request) {
+  const body = (await req.json().catch(() => ({}))) as FlowPatternCreate;
+  try {
+    const id = createFlowPattern(body);
+    return NextResponse.json({ ok: true, id }, { status: 201 });
+  } catch (e) {
+    return NextResponse.json({ error: (e as Error).message }, { status: 400 });
+  }
+}

--- a/src/app/api/admin/flows/state/route.ts
+++ b/src/app/api/admin/flows/state/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+import { getFlowPatternsAdminState } from '@/lib/admin/flow-patterns';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: Request) {
+  const validate = new URL(req.url).searchParams.get('validate') === '1';
+  return NextResponse.json(getFlowPatternsAdminState({ validate }));
+}

--- a/src/app/api/admin/sections/[id]/preview/route.ts
+++ b/src/app/api/admin/sections/[id]/preview/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import { buildSectionPreviewHtml, getAddSectionAdmin } from '@/lib/admin/add-sections';
+import type { Section } from '@/lib/types';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST(req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const { id } = await ctx.params;
+  const body = await req.json().catch(() => ({}));
+  const lang = body.lang === 'fr' ? 'fr' : 'en';
+  let section: Section | null = body.section ?? null;
+  if (!section) {
+    const row = getAddSectionAdmin(id);
+    section = row ? (lang === 'fr' ? row.fr : row.en) : null;
+  }
+  if (!section) return NextResponse.json({ error: 'not found' }, { status: 404 });
+  const html = buildSectionPreviewHtml(section, lang);
+  return new NextResponse(html, {
+    headers: { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-store' },
+  });
+}

--- a/src/app/api/admin/sections/[id]/route.ts
+++ b/src/app/api/admin/sections/[id]/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server';
+import { deleteAddSection, getAddSectionAdmin, updateAddSection, type AddSectionPayload } from '@/lib/admin/add-sections';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const { id } = await ctx.params;
+  const section = getAddSectionAdmin(id);
+  if (!section) return NextResponse.json({ error: 'not found' }, { status: 404 });
+  const { en, fr } = section;
+  return NextResponse.json({ id, en, fr });
+}
+
+export async function PATCH(req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const { id } = await ctx.params;
+  const body = (await req.json().catch(() => ({}))) as AddSectionPayload;
+  try {
+    updateAddSection(id, body);
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    return NextResponse.json({ error: (e as Error).message }, { status: 400 });
+  }
+}
+
+
+export async function DELETE(_req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const { id } = await ctx.params;
+  try {
+    deleteAddSection(id);
+    return NextResponse.json({ ok: true, id });
+  } catch (e) {
+    return NextResponse.json({ error: (e as Error).message }, { status: 400 });
+  }
+}

--- a/src/app/api/admin/sections/publish/route.ts
+++ b/src/app/api/admin/sections/publish/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+import { publishAddSections } from '@/lib/admin/add-sections';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST() {
+  const result = publishAddSections();
+  if (!result.ok) {
+    return NextResponse.json({ ok: false, issues: result.issues }, { status: 400 });
+  }
+  return NextResponse.json({ ok: true, publishedAt: result.publishedAt });
+}

--- a/src/app/api/admin/sections/route.ts
+++ b/src/app/api/admin/sections/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { createAddSection, listAddSectionsAdmin, type AddSectionCreate } from '@/lib/admin/add-sections';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  return NextResponse.json({ sections: listAddSectionsAdmin() });
+}
+
+export async function POST(req: Request) {
+  const body = (await req.json().catch(() => ({}))) as AddSectionCreate;
+  try {
+    const id = createAddSection(body);
+    return NextResponse.json({ ok: true, id }, { status: 201 });
+  } catch (e) {
+    return NextResponse.json({ error: (e as Error).message }, { status: 400 });
+  }
+}

--- a/src/app/api/admin/sections/state/route.ts
+++ b/src/app/api/admin/sections/state/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+import { getAddSectionsAdminState } from '@/lib/admin/add-sections';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: Request) {
+  const validate = new URL(req.url).searchParams.get('validate') === '1';
+  return NextResponse.json(getAddSectionsAdminState({ validate }));
+}

--- a/src/app/api/admin/system-copy/[key]/route.ts
+++ b/src/app/api/admin/system-copy/[key]/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+import {
+  deleteSystemCopy,
+  getSystemCopy,
+  upsertSystemCopy,
+  type SystemCopyPair,
+} from "@/lib/admin/system-copy";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(_req: Request, ctx: { params: Promise<{ key: string }> }) {
+  const { key } = await ctx.params;
+  const item = getSystemCopy(decodeURIComponent(key));
+  if (!item) return NextResponse.json({ error: "not found" }, { status: 404 });
+  return NextResponse.json(item);
+}
+
+export async function PATCH(req: Request, ctx: { params: Promise<{ key: string }> }) {
+  const { key } = await ctx.params;
+  const decoded = decodeURIComponent(key);
+  const body = (await req.json().catch(() => ({}))) as Partial<SystemCopyPair>;
+  if (typeof body.en !== "string" && typeof body.fr !== "string") {
+    return NextResponse.json({ error: "en and/or fr is required" }, { status: 400 });
+  }
+  try {
+    const current = getSystemCopy(decoded);
+    const pair: SystemCopyPair = {
+      en: typeof body.en === "string" ? body.en : (current?.en ?? ""),
+      fr: typeof body.fr === "string" ? body.fr : (current?.fr ?? ""),
+    };
+    upsertSystemCopy(decoded, pair);
+    return NextResponse.json({ ok: true, key: decoded });
+  } catch (e) {
+    return NextResponse.json({ error: (e as Error).message }, { status: 400 });
+  }
+}
+
+export async function DELETE(_req: Request, ctx: { params: Promise<{ key: string }> }) {
+  const { key } = await ctx.params;
+  try {
+    deleteSystemCopy(decodeURIComponent(key));
+    return NextResponse.json({ ok: true, key: decodeURIComponent(key) });
+  } catch (e) {
+    return NextResponse.json({ error: (e as Error).message }, { status: 400 });
+  }
+}

--- a/src/app/api/admin/system-copy/publish/route.ts
+++ b/src/app/api/admin/system-copy/publish/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+import { publishSystemCopy } from "@/lib/admin/system-copy";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST() {
+  const result = publishSystemCopy();
+  if (!result.ok) {
+    return NextResponse.json({ ok: false, issues: result.issues }, { status: 400 });
+  }
+  return NextResponse.json({ ok: true, publishedAt: result.publishedAt });
+}

--- a/src/app/api/admin/system-copy/route.ts
+++ b/src/app/api/admin/system-copy/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+import { listSystemCopy, upsertSystemCopy, type SystemCopyPair } from "@/lib/admin/system-copy";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  return NextResponse.json({ keys: listSystemCopy() });
+}
+
+export async function POST(req: Request) {
+  const body = (await req.json().catch(() => ({}))) as {
+    key?: string;
+    en?: string;
+    fr?: string;
+  };
+  if (!body.key?.trim()) {
+    return NextResponse.json({ error: "key is required" }, { status: 400 });
+  }
+  try {
+    const pair: SystemCopyPair = {
+      en: typeof body.en === "string" ? body.en : "",
+      fr: typeof body.fr === "string" ? body.fr : "",
+    };
+    upsertSystemCopy(body.key.trim(), pair);
+    return NextResponse.json({ ok: true, key: body.key.trim() }, { status: 201 });
+  } catch (e) {
+    return NextResponse.json({ error: (e as Error).message }, { status: 400 });
+  }
+}

--- a/src/app/api/admin/system-copy/state/route.ts
+++ b/src/app/api/admin/system-copy/state/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+import { getSystemCopyState } from "@/lib/admin/system-copy";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(req: Request) {
+  const validate = new URL(req.url).searchParams.get("validate") === "1";
+  return NextResponse.json(getSystemCopyState({ validate }));
+}

--- a/src/app/api/admin/templates/[id]/preview/route.ts
+++ b/src/app/api/admin/templates/[id]/preview/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+import { buildStandaloneHtml } from '@/lib/exportHtml';
+import { normalizeArchitecture } from '@/lib/defaults';
+import {
+  getArchitectureTemplateAdmin,
+  getProjectTemplateAdmin,
+} from '@/lib/admin/project-templates';
+import type { Architecture } from '@/lib/types';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST(req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const { id } = await ctx.params;
+  const body = await req.json().catch(() => ({}));
+  let doc: Architecture | null = null;
+
+  if (body.snapshot) {
+    doc = normalizeArchitecture(body.snapshot);
+  } else {
+    const project = getProjectTemplateAdmin(id);
+    if (project) doc = project.snapshot;
+    else {
+      const architecture = getArchitectureTemplateAdmin(id);
+      doc = architecture?.snapshot ?? null;
+    }
+  }
+
+  if (!doc) return NextResponse.json({ error: 'not found' }, { status: 404 });
+  const html = buildStandaloneHtml(doc);
+  return new NextResponse(html, {
+    headers: { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-store' },
+  });
+}

--- a/src/app/api/admin/templates/[id]/route.ts
+++ b/src/app/api/admin/templates/[id]/route.ts
@@ -1,0 +1,78 @@
+import { NextResponse } from 'next/server';
+import {
+  deleteArchitectureTemplate,
+  getArchitectureTemplateAdmin,
+  updateArchitectureTemplate,
+  type ArchitectureTemplatePatch,
+} from '@/lib/admin/architecture-templates';
+import {
+  deleteProjectTemplate,
+  getProjectTemplateAdmin,
+  updateProjectTemplate,
+  type ProjectTemplateUpdate,
+} from '@/lib/admin/project-templates';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const { id } = await ctx.params;
+  const project = getProjectTemplateAdmin(id);
+  if (project) {
+    return NextResponse.json({
+      kind: 'project' as const,
+      editable: true,
+      id: project.id,
+      nameEn: project.nameEn,
+      nameFr: project.nameFr,
+      sortOrder: project.sortOrder,
+      featured: project.featured,
+      meta: project.meta,
+      snapshot: project.snapshot,
+      outline: {
+        componentCount: project.snapshot.components?.length ?? 0,
+        sectionIds: (project.snapshot.sections ?? []).map(s => s.id),
+        flowCount: project.snapshot.flows?.length ?? 0,
+      },
+    });
+  }
+
+  const architecture = getArchitectureTemplateAdmin(id);
+  if (architecture) return NextResponse.json(architecture);
+  return NextResponse.json({ error: 'not found' }, { status: 404 });
+}
+
+export async function PATCH(req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const { id } = await ctx.params;
+  const body = await req.json().catch(() => ({}));
+  try {
+    if (getProjectTemplateAdmin(id)) {
+      updateProjectTemplate(id, body as ProjectTemplateUpdate);
+      return NextResponse.json({ ok: true, id });
+    }
+    if (getArchitectureTemplateAdmin(id)) {
+      updateArchitectureTemplate(id, body as ArchitectureTemplatePatch);
+      return NextResponse.json({ ok: true, id });
+    }
+    return NextResponse.json({ error: 'not found' }, { status: 404 });
+  } catch (e) {
+    return NextResponse.json({ error: (e as Error).message }, { status: 400 });
+  }
+}
+
+export async function DELETE(_req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const { id } = await ctx.params;
+  try {
+    if (getProjectTemplateAdmin(id)) {
+      deleteProjectTemplate(id);
+      return NextResponse.json({ ok: true, id });
+    }
+    if (getArchitectureTemplateAdmin(id)) {
+      deleteArchitectureTemplate(id);
+      return NextResponse.json({ ok: true, id });
+    }
+    return NextResponse.json({ error: 'not found' }, { status: 404 });
+  } catch (e) {
+    return NextResponse.json({ error: (e as Error).message }, { status: 400 });
+  }
+}

--- a/src/app/api/admin/templates/publish/route.ts
+++ b/src/app/api/admin/templates/publish/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+import { publishProjectTemplates } from '@/lib/admin/project-templates';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST() {
+  const result = publishProjectTemplates();
+  if (!result.ok) {
+    return NextResponse.json({ error: 'validation failed', issues: result.issues }, { status: 400 });
+  }
+  return NextResponse.json({ ok: true, publishedAt: result.publishedAt });
+}

--- a/src/app/api/admin/templates/reimport-acme/route.ts
+++ b/src/app/api/admin/templates/reimport-acme/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+import { reimportAcmeTemplate } from '@/lib/admin/project-templates';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST() {
+  const id = reimportAcmeTemplate();
+  return NextResponse.json({ ok: true, id });
+}

--- a/src/app/api/admin/templates/route.ts
+++ b/src/app/api/admin/templates/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server';
+import {
+  createProjectTemplate,
+  listAllAdminTemplates,
+  type ProjectTemplateCreate,
+} from '@/lib/admin/project-templates';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  return NextResponse.json({ templates: listAllAdminTemplates() });
+}
+
+export async function POST(req: Request) {
+  const body = (await req.json().catch(() => ({}))) as Partial<ProjectTemplateCreate>;
+  const nameEn = String(body.nameEn || '').trim();
+  const id = String(body.id || nameEn).trim();
+  if (!nameEn) return NextResponse.json({ error: 'nameEn is required' }, { status: 400 });
+  if (!id) return NextResponse.json({ error: 'id is required' }, { status: 400 });
+  try {
+    const createdId = createProjectTemplate({
+      id,
+      nameEn,
+      nameFr: body.nameFr ? String(body.nameFr).trim() : undefined,
+      meta: body.meta,
+      snapshot: body.snapshot,
+      featured: body.featured,
+      sortOrder: body.sortOrder,
+    });
+    return NextResponse.json({ ok: true, id: createdId }, { status: 201 });
+  } catch (e) {
+    return NextResponse.json({ error: (e as Error).message }, { status: 400 });
+  }
+}

--- a/src/app/api/admin/templates/state/route.ts
+++ b/src/app/api/admin/templates/state/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+import { getProjectTemplatesAdminState } from '@/lib/admin/project-templates';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: Request) {
+  const validate = new URL(req.url).searchParams.get('validate') === '1';
+  return NextResponse.json(getProjectTemplatesAdminState({ validate }));
+}

--- a/src/app/api/flow-templates/route.ts
+++ b/src/app/api/flow-templates/route.ts
@@ -1,16 +1,8 @@
 import { NextResponse } from 'next/server';
-import { resolveCatalog } from '@/lib/flows/catalog';
+import { resolveCatalog } from '@/lib/flows/resolve-catalog.server';
 import { listFlowLibrary } from '@/lib/flows/library';
 import { LIBRARY_MAX_ENTRIES } from '@/lib/flows/types';
 import type { Lang } from '@/lib/templates/types';
-
-/* The catalogue is resolved to one language here rather than shipped bilingual
- * and resolved in the browser. It keeps the authoring source — which is roughly
- * twice the payload and grows with every pattern added — out of the bundle, and
- * it means the picker component contains no `t()` calls and no `L10n` type at
- * all. The library half has to come from the server regardless, so folding both
- * into one response costs nothing; the request only fires when the modal opens.
- */
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from 'next/server';
 import { listProjects, createProject } from '@/lib/store';
-import { LANGS, TARGETS, getTemplate, instantiate, t } from '@/lib/templates';
+import { contentFromAdmin } from '@/lib/admin/flags';
+import { getPublishedProjectTemplate, instantiateProjectTemplate } from '@/lib/admin/project-templates';
+import { LANGS, TARGETS, t } from '@/lib/templates';
+import { instantiateResolved, resolveGetTemplate } from '@/lib/templates/resolve.server';
 import type { Architecture } from '@/lib/types';
 
 export const runtime = 'nodejs';
@@ -21,8 +24,14 @@ export async function POST(req: Request) {
 
   /* A project created from a template is an ordinary project: the template is
    * resolved here, once, and never referenced again. */
-  if (body.templateId) {
-    const tpl = getTemplate(String(body.templateId));
+  if (contentFromAdmin() && body.projectTemplateId) {
+    const tpl = getPublishedProjectTemplate(String(body.projectTemplateId));
+    if (!tpl) return NextResponse.json({ error: 'unknown projectTemplateId' }, { status: 400 });
+    data = instantiateProjectTemplate(tpl, name);
+    accent = accent || tpl.meta.accent;
+    description = description || tpl.meta.taglineEn;
+  } else if (body.templateId) {
+    const tpl = resolveGetTemplate(String(body.templateId));
     if (!tpl) return NextResponse.json({ error: 'unknown templateId' }, { status: 400 });
 
     const target = TARGETS.includes(body.target) ? body.target : 'agnostic';
@@ -33,7 +42,7 @@ export async function POST(req: Request) {
     }
     const lang = LANGS.includes(body.lang) ? body.lang : 'en';
 
-    data = instantiate(tpl, { target, lang, projectName: name });
+    data = instantiateResolved(tpl, { target, lang, projectName: name });
     accent = accent || tpl.accent;
     description = description || t(tpl.tagline, lang);
   }

--- a/src/app/api/templates/route.ts
+++ b/src/app/api/templates/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server';
-import { SERVICES_VERIFIED_ON, templateSummaries } from '@/lib/templates';
+import { contentFromAdmin } from '@/lib/admin/flags';
+import { projectTemplateSummaries } from '@/lib/admin/project-templates';
+import { resolveServices, resolveTemplateSummaries } from '@/lib/templates/resolve.server';
 
 export const runtime = 'nodejs';
 
@@ -7,8 +9,10 @@ export const runtime = 'nodejs';
  * The picker needs to switch language without a second round trip, and the full
  * templates are far too large to ship to the browser. */
 export async function GET() {
+  const architecture = resolveTemplateSummaries();
+  const project = contentFromAdmin() ? projectTemplateSummaries() : [];
   return NextResponse.json(
-    { verifiedOn: SERVICES_VERIFIED_ON, templates: templateSummaries() },
+    { verifiedOn: resolveServices().verifiedOn, templates: [...project, ...architecture] },
     { headers: { 'Cache-Control': 'no-store' } }
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -269,6 +269,12 @@ input.input[type="color"] { height: 34px; padding: 3px; cursor: pointer; }
 .tree-row .ficon svg { width: 15px; height: 15px; fill: none; stroke: currentColor; stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round; }
 .tree-row .label { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .tree-row .count { font-family: var(--mono); font-size: 10px; color: var(--ink-3); font-variant-numeric: tabular-nums; }
+.tree-row .stack { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 1px; }
+.tree-row .stack-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.tree-row .stack-sub {
+  font-size: 11.5px; color: var(--ink-3); overflow: hidden; text-overflow: ellipsis;
+  white-space: nowrap; line-height: 1.35;
+}
 .tree-row .rowbtns { display: none; gap: 2px; }
 .tree-row:hover .rowbtns { display: flex; }
 .tree-row .rowbtns button {
@@ -284,12 +290,40 @@ input.input[type="color"] { height: 34px; padding: 3px; cursor: pointer; }
   padding: 24px 28px 18px; border-bottom: 1px solid var(--line);
   display: flex; align-items: flex-end; gap: 16px; flex-wrap: wrap; background: var(--panel);
 }
+.ws-head.admin-head {
+  display: block;
+  padding: 12px 28px;
+}
+.ws-head.admin-head.admin-head-compact {
+  padding: 10px 28px;
+}
+.ws-head-row {
+  display: flex; align-items: center; gap: 16px; flex-wrap: wrap;
+}
+.ws-head-title {
+  flex: 1; min-width: 0; margin: 0;
+  font-size: 26px; line-height: 1.15; letter-spacing: -.02em;
+}
+/* Body lede under topbar chrome — not a second page title */
+.ws-head.admin-head .ws-head-lede {
+  flex: 1; min-width: 160px; margin: 0;
+  font-size: 13px; line-height: 1.4; color: var(--ink-2);
+}
+.ws-head-lede {
+  margin: 6px 0 0; font-size: 13px; color: var(--ink-2);
+}
 .ws-head h1 { font-size: 26px; }
 .ws-head p { margin: 5px 0 0; font-size: 13px; color: var(--ink-2); }
 .ws-body { padding: 22px 28px 60px; }
+.ws-head-tools {
+  display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
+  margin-left: auto;
+}
+.ws-head-tools .ws-search { margin-left: 0; }
 .ws-search { position: relative; margin-left: auto; }
 .ws-search input { width: 240px; padding-left: 32px; }
 .ws-search svg { position: absolute; left: 10px; top: 50%; transform: translateY(-50%); width: 14px; height: 14px; stroke: var(--ink-3); fill: none; stroke-width: 2; }
+.ws-search.inline { margin-left: 0; flex: 1; min-width: 200px; }
 
 .pgrid { display: grid; grid-template-columns: repeat(auto-fill, minmax(268px, 1fr)); gap: 14px; }
 .pcard {
@@ -472,6 +506,40 @@ input.input[type="color"] { height: 34px; padding: 3px; cursor: pointer; }
 .iconpick svg { width: 13px; height: 13px; fill: none; stroke: currentColor; stroke-width: 1.9; stroke-linecap: round; stroke-linejoin: round; }
 
 .previewframe { flex: 1; border: 0; width: 100%; background: var(--bg); }
+
+.preview-shell {
+  flex: 1; min-height: 0; display: flex; flex-direction: column; overflow: hidden;
+}
+.preview-shell-head {
+  flex: none; display: flex; justify-content: flex-end; margin-bottom: 10px;
+}
+.preview-shell--compact .preview-shell-head { margin-bottom: 8px; }
+.preview-stage {
+  flex: 1; min-height: 0; overflow: auto; background: var(--bg);
+  border: 1px solid var(--line-2);
+}
+.preview-shell--compact .preview-stage { overflow: hidden; }
+.preview-scale { position: relative; flex: none; }
+.preview-shell--compact .preview-scale { margin: 0 auto; }
+.preview-shell .previewframe {
+  flex: none; display: block; pointer-events: none;
+  background: var(--paper, var(--bg));
+}
+.preview-shell--full .previewframe { pointer-events: auto; }
+
+.inspector-preview {
+  flex: none; height: 220px; margin-bottom: 12px; display: flex; flex-direction: column; min-height: 0;
+}
+.preview-tab-body,
+.diagram-tab-body {
+  flex: 1; min-height: 0; display: flex; flex-direction: column;
+}
+.diagram-tab-body .editor-body {
+  flex: 1; min-height: 0;
+}
+.preview-tab-body {
+  padding: 0 0 0;
+}
 
 /* ------------------------------------------------------- content editors */
 /* The wide surface behind the Content tab: everything the canvas cannot say. */

--- a/src/app/projects/[id]/document/PaperDocument.tsx
+++ b/src/app/projects/[id]/document/PaperDocument.tsx
@@ -21,6 +21,7 @@ import { Mark, Wordmark } from '@/components/Brand';
 import { PALETTE } from '@/lib/defaults';
 import { displayLayerLabel } from '@/lib/layers';
 import { dashFor, describeLink, kindsInUse, LINK_DASH, LINK_KIND_LABELS, linkOf } from '@/lib/links';
+import { componentDescription } from '@/lib/document/concerns';
 import { anchor, buildOutline, supportLayerId, toc, type DocBody, type DocPart } from '@/lib/document/plan';
 import type {
   Architecture, CardItem, CardsSection, CompareSection, Component, Flow,
@@ -41,7 +42,11 @@ const STRINGS = {
     component: 'Component', scope: 'Scope', tech: 'Technologies', role: 'Role',
     dependsOn: 'Depends on', detail: 'Component detail', notes: 'Notes',
     technology: 'Technology', category: 'Category', description: 'Description',
-    step: 'Step', dash: '—'
+    step: 'Step', dash: '—',
+    buildingBlock: 'Building block',
+    adrTitle: 'Decision', adrStatus: 'Status', adrContext: 'Context',
+    adrDecision: 'Decision', adrConsequences: 'Consequences',
+    statusProposed: 'Proposed', statusAccepted: 'Accepted', statusSuperseded: 'Superseded'
   },
   fr: {
     back: "Retour à l'éditeur", print: 'Imprimer · Enregistrer en PDF', contents: 'Sommaire',
@@ -50,7 +55,11 @@ const STRINGS = {
     component: 'Composant', scope: 'Périmètre', tech: 'Technologies', role: 'Rôle',
     dependsOn: 'Dépend de', detail: 'Détail des composants', notes: 'Notes',
     technology: 'Technologie', category: 'Catégorie', description: 'Description',
-    step: 'Étape', dash: '—'
+    step: 'Étape', dash: '—',
+    buildingBlock: 'Bloc',
+    adrTitle: 'Décision', adrStatus: 'Statut', adrContext: 'Contexte',
+    adrDecision: 'Décision', adrConsequences: 'Conséquences',
+    statusProposed: 'Proposé', statusAccepted: 'Accepté', statusSuperseded: 'Remplacé'
   }
 } as const;
 
@@ -158,10 +167,13 @@ function PartBlock({ part, doc, T }: { part: DocPart; doc: Architecture; T: Stri
 function Body({ body, doc, T }: { body: DocBody; doc: Architecture; T: Strings }) {
   switch (body.kind) {
     case 'intro': return <Intro doc={doc} />;
+    case 'context': return <Context doc={doc} T={T} />;
+    case 'adr-index': return <AdrIndex body={body} T={T} />;
     case 'diagram': return <Figure doc={doc} T={T} />;
     case 'inventory': return <Inventory doc={doc} T={T} />;
     case 'section': return <SectionBody doc={doc} section={body.section} />;
     case 'flow': return <FlowBody doc={doc} flow={body.flow} T={T} />;
+    case 'glossary': return <Glossary doc={doc} body={body} T={T} />;
     case 'stack': return <Stack doc={doc} T={T} />;
   }
 }
@@ -172,6 +184,119 @@ function Intro({ doc }: { doc: Architecture }) {
     <>
       {paragraphs.map((p, i) => <p key={i} className="paper-lead" {...rich(p)} />)}
       {doc.meta.distributionNote && <p className="paper-note" {...rich(doc.meta.distributionNote)} />}
+    </>
+  );
+}
+
+function Context({ doc, T }: { doc: Architecture; T: Strings }) {
+  const groupName = (id: string) => doc.groups.find(g => g.id === id)?.name || id;
+  const colour = (id: string) => doc.groups.find(g => g.id === id)?.color || '#94A3B8';
+  return (
+    <>
+      {!!doc.groups.length && (
+        <table className="paper-table">
+          <thead>
+            <tr><th>{T.scope}</th><th>{T.description}</th></tr>
+          </thead>
+          <tbody>
+            {doc.groups.map(g => (
+              <tr key={g.id}>
+                <td>
+                  <i className="paper-dot" style={{ background: colour(g.id) }} />
+                  {g.name}
+                </td>
+                <td>{g.description || T.dash}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+      {!!doc.components.length && (
+        <table className="paper-table">
+          <thead>
+            <tr>
+              <th style={{ width: '32%' }}>{T.buildingBlock}</th>
+              <th style={{ width: '22%' }}>{T.scope}</th>
+              <th>{T.role}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {doc.components.map(c => (
+              <tr key={c.id}>
+                <td>{c.name}</td>
+                <td>
+                  <i className="paper-dot" style={{ background: colour(c.group) }} />
+                  {groupName(c.group)}
+                </td>
+                <td>{componentDescription(c) || T.dash}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </>
+  );
+}
+
+function Glossary({ doc, body, T }: { doc: Architecture; body: Extract<DocBody, { kind: 'glossary' }>; T: Strings }) {
+  const names = new Set(body.names);
+  const components = doc.components.filter(c => names.has(c.name));
+  return (
+    <table className="paper-table">
+      <thead>
+        <tr><th>{T.buildingBlock}</th><th>{T.description}</th></tr>
+      </thead>
+      <tbody>
+        {components.map(c => (
+          <tr key={c.id}>
+            <td>{c.name}</td>
+            <td>{componentDescription(c) || T.dash}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function AdrIndex({ body, T }: { body: Extract<DocBody, { kind: 'adr-index' }>; T: Strings }) {
+  const statusLabel = (status: string) => {
+    switch (status) {
+      case 'proposed': return T.statusProposed;
+      case 'accepted': return T.statusAccepted;
+      case 'superseded': return T.statusSuperseded;
+      default: return status;
+    }
+  };
+  return (
+    <>
+      <table className="paper-table">
+        <thead>
+          <tr>
+            <th style={{ width: '36%' }}>{T.adrTitle}</th>
+            <th style={{ width: '16%' }}>{T.adrStatus}</th>
+            <th>{T.adrDecision}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {body.decisions.map(d => (
+            <tr key={d.id}>
+              <td>{d.title}</td>
+              <td>{statusLabel(d.status)}</td>
+              <td>{d.decision}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="paper-sheets">
+        {body.decisions.map(d => (
+          <div className="paper-card" key={d.id}>
+            <h4>{d.title}</h4>
+            <p><b>{T.adrContext} :</b> {d.context}</p>
+            <p><b>{T.adrDecision} :</b> {d.decision}</p>
+            <p><b>{T.adrConsequences} :</b> {d.consequences}</p>
+          </div>
+        ))}
+      </div>
     </>
   );
 }

--- a/src/components/ArchitectureDiagramSurface.tsx
+++ b/src/components/ArchitectureDiagramSurface.tsx
@@ -1,0 +1,674 @@
+'use client';
+
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import {
+  DndContext, DragOverlay, PointerSensor, useSensor, useSensors,
+  useDraggable, useDroppable, type DragEndEvent, type DragStartEvent
+} from '@dnd-kit/core';
+import { Icon } from './Icon';
+import Inspector from './Inspector';
+import PlacementWizard from './editors/PlacementWizard';
+import { PALETTE, PALETTE_DARK, slugify } from '@/lib/defaults';
+import { displayLayerLabel } from '@/lib/layers';
+import { ensurePlacementScaffold, componentBrick } from '@/lib/lego/place';
+import { syncTechnologies } from '@/lib/lego/stack';
+import { loadLegoCatalog } from '@/lib/lego/client';
+import { addSuggestedDependency, matchesSuggestionTarget, matchingDependencyTarget, visibleDependencies } from '@/lib/lego/dependencies';
+import type { LegoCatalogSnapshot, LegoDependencySuggestion } from '@/lib/lego/types';
+import { dashFor, describeLink, kindsInUse, LINK_DASH, LINK_KIND_LABELS, linkOf } from '@/lib/links';
+import { protocolLabel, suggestedLinkForBrick } from '@/lib/lego/protocols';
+import { syncGatedPresetSections } from '@/lib/document/preset';
+import type { Architecture, Component } from '@/lib/types';
+
+type Patch = (fn: (d: Architecture) => Architecture) => void;
+
+/**
+ * Shared edit-mode architecture canvas: palette | graph | inspector.
+ * Used by the project Editor and admin template Diagram tabs — one implementation.
+ */
+export default function ArchitectureDiagramSurface({
+  doc,
+  patch,
+  readOnly = false,
+  initialSelected = null,
+}: {
+  doc: Architecture;
+  patch: Patch;
+  readOnly?: boolean;
+  /** Pre-select a component (e.g. project opened with ?new=1). */
+  initialSelected?: string | null;
+}) {
+  const [selected, setSelected] = useState<string | null>(initialSelected);
+  const [dragId, setDragId] = useState<string | null>(null);
+  const [link, setLink] = useState<{ from: string; x: number; y: number } | null>(null);
+  const [hoverTarget, setHoverTarget] = useState<string | null>(null);
+  const [catalog, setCatalog] = useState<LegoCatalogSnapshot | null>(null);
+  const [placementRequest, setPlacementRequest] = useState<{ callerId?: string; suggestion?: LegoDependencySuggestion } | null>(null);
+  const [suggestionCallerId, setSuggestionCallerId] = useState<string | null>(null);
+  const [suggestionError, setSuggestionError] = useState<string | null>(null);
+
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
+
+  useEffect(() => {
+    loadLegoCatalog(doc.meta.lang === 'fr' ? 'fr' : 'en').then(setCatalog).catch(() => setCatalog(null));
+  }, [doc.meta.lang]);
+
+  useEffect(() => {
+    if (!doc.components.some(c => c.id === selected)) setSelected(null);
+  }, [doc.components, selected]);
+
+  const addComponent = useCallback((layerId: string, index?: number) => {
+    if (readOnly) return null;
+    const id = slugify('component', doc.components.map(c => c.id));
+    const groupId = doc.groups[0]?.id || 'product';
+    const comp: Component = {
+      id, name: 'New component', group: groupId, layer: layerId,
+      icon: 'box', tech: [], features: [], notes: [], deps: []
+    };
+    patch(d => {
+      if (!d.groups.some(group => group.id === groupId)) {
+        d.groups.push({ id: groupId, name: 'Product', short: 'Product', color: PALETTE[0], colorDark: PALETTE_DARK[0] });
+      }
+      if (!d.layers.some(layer => layer.id === layerId)) {
+        d.layers.push({ id: layerId, name: displayLayerLabel(layerId) });
+      }
+      const list = [...d.components];
+      list.splice(index ?? list.length, 0, comp);
+      d.components = list;
+      return d;
+    });
+    setSelected(id);
+    return id;
+  }, [doc.components, doc.groups, patch, readOnly]);
+
+  const placeBrick = useCallback((component: Component) => {
+    if (readOnly || !catalog) return;
+    patch(d => {
+      ensurePlacementScaffold(component, d, catalog);
+      d.components.push(component);
+      syncTechnologies(d, catalog);
+      syncGatedPresetSections(d);
+      return d;
+    });
+    setSelected(component.id);
+  }, [catalog, patch, readOnly]);
+
+  const acceptSuggestedLink = useCallback((callerId: string, calleeId: string, suggestion: LegoDependencySuggestion) => {
+    if (readOnly) return;
+    patch(d => {
+      const caller = d.components.find(component => component.id === callerId);
+      if (caller) addSuggestedDependency(caller, calleeId, suggestion);
+      return d;
+    });
+  }, [patch, readOnly]);
+
+  const confirmPlacedBrick = useCallback((component: Component) => {
+    const request = placementRequest;
+    placeBrick(component);
+    if (request?.callerId && request.suggestion) {
+      if (matchesSuggestionTarget(component, request.suggestion)) {
+        acceptSuggestedLink(request.callerId, component.id, request.suggestion);
+        setSuggestionError(null);
+      } else {
+        const target = catalog?.bricks[request.suggestion.to]?.capabilityPhrase || request.suggestion.to;
+        setSuggestionError(doc.meta.lang === 'fr'
+          ? `La brique placée ne fournit pas ${target}. Choisis une variante proposée pour cette dépendance.`
+          : `The placed brick does not provide ${target}. Choose one of the variants offered for this dependency.`);
+      }
+      setSuggestionCallerId(request.callerId);
+    } else if (catalog && visibleDependencies(catalog, component).length) {
+      setSuggestionCallerId(component.id);
+      setSuggestionError(null);
+    }
+    setPlacementRequest(null);
+  }, [acceptSuggestedLink, catalog, doc.meta.lang, placeBrick, placementRequest]);
+
+  const moveComponent = useCallback((id: string, layerId: string, beforeId?: string) => {
+    if (readOnly) return;
+    patch(d => {
+      const i = d.components.findIndex(c => c.id === id);
+      if (i < 0) return d;
+      const [comp] = d.components.splice(i, 1);
+      comp.layer = layerId;
+      const at = beforeId ? d.components.findIndex(c => c.id === beforeId) : -1;
+      if (at >= 0) d.components.splice(at, 0, comp);
+      else d.components.push(comp);
+      return d;
+    });
+  }, [patch, readOnly]);
+
+  const addDep = useCallback((from: string, to: string) => {
+    if (readOnly || from === to) return;
+    patch(d => {
+      const c = d.components.find(x => x.id === from);
+      const callee = d.components.find(x => x.id === to);
+      if (!c) return d;
+      c.deps = c.deps || [];
+      if (c.deps.includes(to)) {
+        c.deps = c.deps.filter(x => x !== to);
+        c.links = (c.links || []).filter(link => link.to !== to);
+      } else {
+        c.deps.push(to);
+        const suggestion = suggestedLinkForBrick(componentBrick(callee || {}));
+        c.links = [...(c.links || []).filter(link => link.to !== to), { to, ...suggestion }];
+      }
+      return d;
+    });
+  }, [patch, readOnly]);
+
+  useEffect(() => {
+    if (!link || readOnly) return;
+    const move = (e: PointerEvent) => {
+      setLink(l => (l ? { ...l, x: e.clientX, y: e.clientY } : l));
+      const el = document.elementFromPoint(e.clientX, e.clientY) as HTMLElement | null;
+      const card = el?.closest('[data-comp]') as HTMLElement | null;
+      const id = card?.dataset.comp || null;
+      setHoverTarget(id && id !== link.from ? id : null);
+    };
+    const up = (e: PointerEvent) => {
+      const el = document.elementFromPoint(e.clientX, e.clientY) as HTMLElement | null;
+      const card = el?.closest('[data-comp]') as HTMLElement | null;
+      if (card?.dataset.comp) addDep(link.from, card.dataset.comp);
+      setLink(null); setHoverTarget(null);
+    };
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', up, { once: true });
+    return () => { window.removeEventListener('pointermove', move); window.removeEventListener('pointerup', up); };
+  }, [link, addDep, readOnly]);
+
+  function onDragEnd(e: DragEndEvent) {
+    setDragId(null);
+    if (readOnly) return;
+    const active = String(e.active.id);
+    const over = e.over ? String(e.over.id) : null;
+    if (!over) return;
+
+    const targetLayer = over.startsWith('layer:')
+      ? over.slice(6)
+      : doc.components.find(c => c.id === over)?.layer;
+    if (!targetLayer) return;
+    const beforeId = over.startsWith('layer:') ? undefined : over;
+
+    if (active === 'palette:new') {
+      const idx = beforeId ? doc.components.findIndex(c => c.id === beforeId) : undefined;
+      addComponent(targetLayer, idx);
+      return;
+    }
+    if (active !== beforeId) moveComponent(active, targetLayer, beforeId);
+  }
+
+  const selectedComp = doc.components.find(c => c.id === selected) || null;
+  const groupColor = useCallback((gid: string) => {
+    const i = doc.groups.findIndex(g => g.id === gid);
+    const g = doc.groups[i] || doc.groups[0];
+    return { light: g?.color || PALETTE[i % PALETTE.length], dark: g?.colorDark || PALETTE_DARK[i % PALETTE_DARK.length] };
+  }, [doc.groups]);
+
+  const effectivePatch: Patch = readOnly ? () => {} : patch;
+
+  return (
+    <DndContext id="archstudio-diagram-surface" sensors={sensors}
+      onDragStart={(e: DragStartEvent) => { if (!readOnly) setDragId(String(e.active.id)); }}
+      onDragEnd={onDragEnd} onDragCancel={() => setDragId(null)}>
+      <div className="editor-body" style={{ flex: 1, minHeight: 0 }}>
+        <Palette
+          doc={doc}
+          patch={effectivePatch}
+          readOnly={readOnly}
+          onOpenPlacement={() => { if (!readOnly) setPlacementRequest({}); }}
+        />
+
+        <div className="canvas-wrap">
+          <Canvas
+            doc={doc} selected={selected} setSelected={setSelected}
+            hoverTarget={hoverTarget} linking={!!link}
+            readOnly={readOnly}
+            onStartLink={(id, x, y) => { if (!readOnly) setLink({ from: id, x, y }); }}
+            groupColor={groupColor} patch={effectivePatch}
+          />
+        </div>
+
+        <Inspector
+          doc={doc} patch={effectivePatch} component={selectedComp}
+          onClose={() => setSelected(null)} onSelect={setSelected}
+        />
+      </div>
+
+      {!readOnly && (
+        <DragOverlay dropAnimation={null}>
+          {dragId && dragId !== 'palette:new' && (() => {
+            const c = doc.components.find(x => x.id === dragId);
+            if (!c) return null;
+            return (
+              <div className="ccard" style={{ ['--c' as string]: groupColor(c.group).light, cursor: 'grabbing', boxShadow: 'var(--shadow-lg)' }}>
+                <div className="nh"><span className="ic"><Icon name={c.icon || 'box'} size={13} /></span>
+                  <span className="nm">{c.name}</span></div>
+              </div>
+            );
+          })()}
+          {dragId === 'palette:new' && (
+            <div className="palette-item" style={{ background: 'var(--panel)', cursor: 'grabbing' }}>
+              <Icon name="plus" size={14} />New component
+            </div>
+          )}
+        </DragOverlay>
+      )}
+
+      {link && !readOnly && <LinkLine link={link} />}
+
+      {!readOnly && placementRequest && (
+        <PlacementWizard
+          existingIds={doc.components.map(component => component.id)}
+          groups={doc.groups}
+          lang={doc.meta.lang === 'fr' ? 'fr' : 'en'}
+          catalog={catalog}
+          initialBrick={placementRequest.suggestion?.to}
+          onPlace={confirmPlacedBrick}
+          onClose={() => {
+            if (placementRequest.callerId) setSuggestionCallerId(placementRequest.callerId);
+            setPlacementRequest(null);
+          }}
+        />
+      )}
+
+      {!readOnly && suggestionCallerId && catalog && (() => {
+        const caller = doc.components.find(component => component.id === suggestionCallerId);
+        return caller ? (
+          <DependencySuggestions
+            caller={caller}
+            components={doc.components}
+            catalog={catalog}
+            lang={doc.meta.lang === 'fr' ? 'fr' : 'en'}
+            error={suggestionError}
+            onLink={(targetId, suggestion) => acceptSuggestedLink(caller.id, targetId, suggestion)}
+            onAddAndLink={suggestion => {
+              setSuggestionCallerId(null);
+              setSuggestionError(null);
+              setPlacementRequest({ callerId: caller.id, suggestion });
+            }}
+            onClose={() => { setSuggestionCallerId(null); setSuggestionError(null); }}
+          />
+        ) : null;
+      })()}
+    </DndContext>
+  );
+}
+
+function DependencySuggestions({ caller, components, catalog, lang, error, onLink, onAddAndLink, onClose }: {
+  caller: Component;
+  components: readonly Component[];
+  catalog: LegoCatalogSnapshot;
+  lang: 'en' | 'fr';
+  error: string | null;
+  onLink: (targetId: string, suggestion: LegoDependencySuggestion) => void;
+  onAddAndLink: (suggestion: LegoDependencySuggestion) => void;
+  onClose: () => void;
+}) {
+  const [skipped, setSkipped] = useState<string[]>([]);
+  const suggestions = visibleDependencies(catalog, caller).filter(suggestion => !skipped.includes(suggestion.to));
+  const copy = lang === 'fr'
+    ? { title: 'Ce dont ça a souvent besoin', done: 'Déjà lié', link: 'Lier', add: 'Ajouter et lier', manual: 'Ajoute ce composant manuellement', skip: 'Passer', close: 'Terminé' }
+    : { title: 'What this usually needs', done: 'Already linked', link: 'Link', add: 'Add & link', manual: 'Add this component manually', skip: 'Skip', close: 'Done' };
+
+  return (
+    <div className="modal-scrim" onClick={onClose}>
+      <div className="modal dependency-sheet" onClick={event => event.stopPropagation()} role="dialog" aria-label={copy.title}>
+        <div className="modal-head"><div><h2>{copy.title}</h2></div></div>
+        {error && <div className="warnbox"><Icon name="alert" size={15} />{error}</div>}
+        {suggestions.map(suggestion => {
+          const target = matchingDependencyTarget(components, suggestion.to);
+          const linked = target && caller.deps?.includes(target.id);
+          const placeable = catalog.variants.some(variant => variant.maps_to === suggestion.to);
+          const label = catalog.bricks[suggestion.to]?.capabilityPhrase || suggestion.to;
+          return (
+            <article className="dependency-suggestion" key={suggestion.to}>
+              <div>
+                <b>{label}</b>
+                <p>{lang === 'fr' ? suggestion.why_fr : suggestion.why_en}</p>
+                <small>{protocolLabel(suggestion.protocol_id)} · {LINK_KIND_LABELS[suggestion.kind][lang]}</small>
+              </div>
+              <div className="dependency-actions">
+                {linked ? <span className="muted">{copy.done}{describeLink(linkOf(caller, target.id), lang) ? ` · ${describeLink(linkOf(caller, target.id), lang)}` : ''}</span>
+                  : target ? <button type="button" className="btn sm primary" onClick={() => onLink(target.id, suggestion)}>{copy.link}</button>
+                    : placeable ? <button type="button" className="btn sm primary" onClick={() => onAddAndLink(suggestion)}>{copy.add}</button>
+                      : <button type="button" className="btn sm" disabled title={lang === 'fr' ? 'Aucune variante du catalogue ne peut encore placer cette brique.' : 'No catalog variant can place this brick yet.'}>{copy.manual}</button>}
+                {!linked && <button type="button" className="btn sm ghost" onClick={() => setSkipped(values => [...values, suggestion.to])}>{copy.skip}</button>}
+              </div>
+            </article>
+          );
+        })}
+        {!suggestions.length && <p className="muted">{lang === 'fr' ? 'Aucune autre suggestion.' : 'No more suggestions.'}</p>}
+        <div className="modal-actions"><button type="button" className="btn ghost" onClick={onClose}>{copy.close}</button></div>
+      </div>
+    </div>
+  );
+}
+
+function LinkLine({ link }: { link: { from: string; x: number; y: number } }) {
+  const src = document.querySelector(`[data-comp="${CSS.escape(link.from)}"]`);
+  if (!src) return null;
+  const r = src.getBoundingClientRect();
+  const x1 = r.left + r.width / 2, y1 = r.bottom;
+  return (
+    <svg className="linkline">
+      <path d={`M${x1},${y1} C${x1},${y1 + 40} ${link.x},${link.y - 40} ${link.x},${link.y}`}
+        fill="none" stroke="var(--brand)" strokeWidth="2" strokeDasharray="4 4" strokeLinecap="round" />
+      <circle cx={x1} cy={y1} r="4" fill="var(--brand)" />
+      <circle cx={link.x} cy={link.y} r="3.5" style={{ fill: 'var(--panel)' }}
+        stroke="var(--brand)" strokeWidth="2" />
+    </svg>
+  );
+}
+
+function edgeGlyph(
+  x1: number, y1: number, k1: number, x2: number, y2: number, k2: number,
+  colour: string, opacity: number, width: number, dash = ''
+) {
+  return `<g opacity="${opacity}">`
+    + `<path d="M${x1},${y1} C${x1},${y1 + k1} ${x2},${y2 + k2} ${x2},${y2}" fill="none" `
+    + `stroke="${colour}" stroke-width="${width}" stroke-linecap="round"`
+    + `${dash ? ` stroke-dasharray="${dash}"` : ''}/>`
+    + `<circle cx="${x1}" cy="${y1}" r="3.5" fill="${colour}"/>`
+    + `<circle cx="${x2}" cy="${y2}" r="3" style="fill:var(--panel)" stroke="${colour}" stroke-width="1.5"/>`
+    + `</g>`;
+}
+
+function Canvas({ doc, selected, setSelected, hoverTarget, linking, onStartLink, groupColor, patch, readOnly }: {
+  doc: Architecture; selected: string | null; setSelected: (id: string | null) => void;
+  hoverTarget: string | null; linking: boolean; readOnly: boolean;
+  onStartLink: (id: string, x: number, y: number) => void;
+  groupColor: (id: string) => { light: string; dark: string };
+  patch: Patch;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [edges, setEdges] = useState<string>('');
+
+  const draw = useCallback(() => {
+    const host = ref.current;
+    if (!host) return;
+    const box = host.getBoundingClientRect();
+    const index = Object.fromEntries(doc.layers.map((l, i) => [l.id, i]));
+    const byId = Object.fromEntries(doc.components.map(c => [c.id, c]));
+    let out = '';
+    doc.components.forEach(c => (c.deps || []).forEach(dep => {
+      const a = host.querySelector(`[data-comp="${CSS.escape(c.id)}"]`);
+      const b = host.querySelector(`[data-comp="${CSS.escape(dep)}"]`);
+      if (!a || !b || !byId[dep]) return;
+      const ra = a.getBoundingClientRect(), rb = b.getBoundingClientRect();
+      const x1 = ra.left - box.left + ra.width / 2;
+      const x2 = rb.left - box.left + rb.width / 2;
+      const la = index[c.layer], lb = index[byId[dep].layer];
+      let y1: number, y2: number, k1: number, k2: number;
+      if (la === lb) {
+        y1 = ra.bottom - box.top; y2 = rb.bottom - box.top; k1 = 30; k2 = 30;
+      } else {
+        const up = la > lb;
+        y1 = (up ? ra.top : ra.bottom) - box.top;
+        y2 = (up ? rb.bottom : rb.top) - box.top;
+        const k = (up ? -1 : 1) * Math.max(24, Math.abs(y2 - y1) * .5);
+        k1 = k; k2 = -k;
+      }
+      const active = selected === c.id || selected === dep;
+      const colour = groupColor(c.group).light;
+      out += edgeGlyph(x1, y1, k1, x2, y2, k2, colour, active ? 1 : .34, active ? 2 : 1.2,
+        dashFor(linkOf(c, dep)?.kind));
+    }));
+    setEdges(out);
+  }, [doc, selected, groupColor]);
+
+  useLayoutEffect(() => { draw(); }, [draw]);
+  useEffect(() => {
+    const host = ref.current;
+    if (!host) return;
+    const ro = new ResizeObserver(() => draw());
+    ro.observe(host);
+    window.addEventListener('resize', draw);
+    return () => { ro.disconnect(); window.removeEventListener('resize', draw); };
+  }, [draw]);
+
+  return (
+    <div className={`canvas${linking ? ' linking' : ''}`} ref={ref}
+      onClick={e => { if (e.target === e.currentTarget) setSelected(null); }}>
+      <svg className="canvas-edges" dangerouslySetInnerHTML={{ __html: edges }} />
+      {doc.layers.length === 0 && (
+        <div className="warnbox" style={{ margin: 16 }}>
+          <Icon name="alert" size={15} />
+          No layers yet — add a layer in the palette, or place a brick (it creates the layer it needs).
+        </div>
+      )}
+      {doc.layers.map(layer => (
+        <LayerRow key={layer.id} layer={layer} doc={doc} patch={patch} readOnly={readOnly}
+          selected={selected} setSelected={setSelected} hoverTarget={hoverTarget}
+          onStartLink={onStartLink} groupColor={groupColor} />
+      ))}
+    </div>
+  );
+}
+
+function LayerRow({ layer, doc, patch, selected, setSelected, hoverTarget, onStartLink, groupColor, readOnly }: {
+  layer: { id: string; name: string; desc?: string };
+  doc: Architecture; patch: Patch; readOnly: boolean;
+  selected: string | null; setSelected: (id: string | null) => void; hoverTarget: string | null;
+  onStartLink: (id: string, x: number, y: number) => void;
+  groupColor: (id: string) => { light: string; dark: string };
+}) {
+  const { setNodeRef, isOver } = useDroppable({ id: `layer:${layer.id}`, disabled: readOnly });
+  const items = doc.components.filter(c => c.layer === layer.id);
+
+  return (
+    <div className={`layer${isOver ? ' over' : ''}`}>
+      <div className="layer-head">
+        <b>{displayLayerLabel(layer.name)}</b>
+        {layer.desc && <em>{layer.desc}</em>}
+        {!readOnly && (
+          <span className="layer-tools">
+            <button className="iconbtn" style={{ width: 24, height: 24 }} title="Rename layer"
+              onClick={() => {
+                const name = prompt('Layer name', layer.name);
+                if (name?.trim()) patch(d => {
+                  const l = d.layers.find(x => x.id === layer.id); if (l) l.name = name.trim(); return d;
+                });
+              }}><Icon name="cog" size={13} /></button>
+            <button className="iconbtn" style={{ width: 24, height: 24 }} title="Delete layer"
+              onClick={() => {
+                if (items.length && doc.layers.length <= 1) {
+                  alert('Keep at least one layer while components still use it.');
+                  return;
+                }
+                if (items.length && !confirm(`Delete "${layer.name}"? Its ${items.length} component(s) move to "${doc.layers.find(l => l.id !== layer.id)!.name}".`)) return;
+                if (!items.length && !confirm(`Delete empty layer "${layer.name}"?`)) return;
+                patch(d => {
+                  if (items.length) {
+                    const fallback = d.layers.find(l => l.id !== layer.id)!.id;
+                    d.components.forEach(c => { if (c.layer === layer.id) c.layer = fallback; });
+                  }
+                  d.layers = d.layers.filter(l => l.id !== layer.id);
+                  return d;
+                });
+              }}><Icon name="trash" size={13} /></button>
+          </span>
+        )}
+      </div>
+      <div ref={setNodeRef} className={`layer-drop${items.length ? '' : ' empty-hint'}`}>
+        {items.length === 0 && (readOnly ? 'Empty layer' : 'Drop a component here')}
+        {items.map(c => (
+          <ComponentCard key={c.id} comp={c} colour={groupColor(c.group).light}
+            selected={selected === c.id} isLinkTarget={hoverTarget === c.id}
+            readOnly={readOnly}
+            onSelect={() => setSelected(c.id)} onStartLink={onStartLink} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ComponentCard({ comp, colour, selected, isLinkTarget, onSelect, onStartLink, readOnly }: {
+  comp: Component; colour: string; selected: boolean; isLinkTarget: boolean; readOnly: boolean;
+  onSelect: () => void; onStartLink: (id: string, x: number, y: number) => void;
+}) {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({ id: comp.id, disabled: readOnly });
+  const { setNodeRef: dropRef } = useDroppable({ id: comp.id, disabled: readOnly });
+
+  return (
+    <div
+      ref={node => { setNodeRef(node); dropRef(node); }}
+      {...(readOnly ? {} : { ...listeners, ...attributes })}
+      data-comp={comp.id}
+      className={`ccard${selected ? ' selected' : ''}${isDragging ? ' dragging' : ''}${isLinkTarget ? ' linktarget' : ''}`}
+      style={{ ['--c' as string]: colour, ...(readOnly ? { cursor: 'pointer' } : {}) }}
+      onClick={e => { e.stopPropagation(); onSelect(); }}
+    >
+      {comp.badge && <span className="badge">{comp.badge}</span>}
+      <div className="nh">
+        <span className="ic"><Icon name={comp.icon || 'box'} size={13} /></span>
+        <span className="nm">{comp.name}</span>
+      </div>
+      {!!comp.tech?.length && (
+        <div className="tech">{comp.tech.slice(0, 3).map(t => <span key={t}>{t}</span>)}</div>
+      )}
+      {!!comp.deps?.length && <span className="depcount">{comp.deps.length} →</span>}
+      {!readOnly && (
+        <span
+          className="linkdot" title="Drag onto another component to create a dependency"
+          onPointerDown={e => {
+            e.stopPropagation(); e.preventDefault();
+            onStartLink(comp.id, e.clientX, e.clientY);
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function Palette({ doc, patch, onOpenPlacement, readOnly }: {
+  doc: Architecture; patch: Patch;
+  onOpenPlacement: () => void;
+  readOnly: boolean;
+}) {
+  const { attributes, listeners, setNodeRef } = useDraggable({ id: 'palette:new', disabled: readOnly });
+
+  return (
+    <aside className="palette">
+      {!readOnly && (
+        <>
+          <div className="sect-label">Add</div>
+          <div ref={setNodeRef} {...listeners} {...attributes} className="palette-item">
+            <Icon name="plus" size={14} />Drag me into a layer
+          </div>
+          <button type="button" className="btn sm" style={{ width: '100%', justifyContent: 'center' }}
+            onClick={onOpenPlacement}>
+            Add brick
+          </button>
+        </>
+      )}
+
+      <div className="sect-label">
+        Scopes<span className="spacer" />
+        {!readOnly && (
+          <button className="iconbtn" style={{ width: 20, height: 20 }} title="Add scope"
+            onClick={() => {
+              if (doc.groups.length >= PALETTE.length) {
+                alert(`${PALETTE.length} scopes is the maximum — a sixth would reuse the first colour.`);
+                return;
+              }
+              const name = prompt('Scope name');
+              if (!name?.trim()) return;
+              patch(d => {
+                const i = d.groups.length;
+                d.groups.push({
+                  id: slugify(name, d.groups.map(g => g.id)), name: name.trim(), short: name.trim(),
+                  color: PALETTE[i % PALETTE.length], colorDark: PALETTE_DARK[i % PALETTE_DARK.length]
+                });
+                return d;
+              });
+            }}><Icon name="plus" size={13} /></button>
+        )}
+      </div>
+      {doc.groups.map((g, i) => (
+        <div className="grouprow" key={g.id}>
+          <input type="color" className="swatch" value={g.color || PALETTE[i % PALETTE.length]}
+            title="Scope colour" disabled={readOnly}
+            onChange={e => patch(d => { const x = d.groups.find(y => y.id === g.id); if (x) x.color = e.target.value; return d; })} />
+          <input value={g.name} disabled={readOnly}
+            onChange={e => patch(d => { const x = d.groups.find(y => y.id === g.id); if (x) { x.name = e.target.value; x.short = e.target.value; } return d; })} />
+          {!readOnly && (doc.groups.length > 1 || !doc.components.some(c => c.group === g.id)) ? (
+            <button className="iconbtn" style={{ width: 22, height: 22 }} title="Delete scope"
+              onClick={() => {
+                const used = doc.components.filter(c => c.group === g.id).length;
+                if (used && doc.groups.length <= 1) {
+                  alert('Keep at least one scope while components still use it.');
+                  return;
+                }
+                if (used && !confirm(`${used} component(s) use this scope. They will move to "${doc.groups.find(x => x.id !== g.id)!.name}".`)) return;
+                patch(d => {
+                  if (used) {
+                    const fallback = d.groups.find(x => x.id !== g.id)!.id;
+                    d.components.forEach(c => { if (c.group === g.id) c.group = fallback; });
+                  }
+                  d.groups = d.groups.filter(x => x.id !== g.id);
+                  return d;
+                });
+              }}><Icon name="trash" size={12} /></button>
+          ) : null}
+        </div>
+      ))}
+
+      <div className="sect-label">
+        Layers<span className="spacer" />
+        {!readOnly && (
+          <button className="iconbtn" style={{ width: 20, height: 20 }} title="Add layer"
+            onClick={() => {
+              const name = prompt('Layer name');
+              if (!name?.trim()) return;
+              patch(d => {
+                d.layers.push({ id: slugify(name, d.layers.map(l => l.id)), name: name.trim() });
+                return d;
+              });
+            }}><Icon name="plus" size={13} /></button>
+        )}
+      </div>
+      {doc.layers.map((l, i) => (
+        <div className="grouprow" key={l.id}>
+          <input value={l.name} disabled={readOnly}
+            onChange={e => patch(d => { const x = d.layers.find(y => y.id === l.id); if (x) x.name = e.target.value; return d; })} />
+          {!readOnly && (
+            <>
+              <button className="iconbtn" style={{ width: 22, height: 22 }} disabled={i === 0} title="Move up"
+                onClick={() => patch(d => {
+                  const arr = d.layers; [arr[i - 1], arr[i]] = [arr[i], arr[i - 1]]; return d;
+                })}><Icon name="chevron" size={12} style={{ transform: 'rotate(-90deg)' }} /></button>
+              <button className="iconbtn" style={{ width: 22, height: 22 }} disabled={i === doc.layers.length - 1} title="Move down"
+                onClick={() => patch(d => {
+                  const arr = d.layers; [arr[i + 1], arr[i]] = [arr[i], arr[i + 1]]; return d;
+                })}><Icon name="chevron" size={12} style={{ transform: 'rotate(90deg)' }} /></button>
+            </>
+          )}
+        </div>
+      ))}
+
+      <EdgeLegend doc={doc} />
+    </aside>
+  );
+}
+
+function EdgeLegend({ doc }: { doc: Architecture }) {
+  const kinds = kindsInUse(doc.components);
+  if (!kinds.length) return null;
+
+  return (
+    <>
+      <div className="sect-label">Dependencies</div>
+      <div className="edgekey">
+        {kinds.map(k => (
+          <span key={k}>
+            <svg viewBox="0 0 34 8" aria-hidden="true">
+              <path d="M1 4h32" fill="none" stroke="currentColor" strokeWidth="1.6"
+                strokeLinecap="round" strokeDasharray={LINK_DASH[k] || undefined} />
+            </svg>
+            {LINK_KIND_LABELS[k].en}
+          </span>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -1,27 +1,15 @@
 'use client';
 
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import {
-  DndContext, DragOverlay, PointerSensor, useSensor, useSensors,
-  useDraggable, useDroppable, type DragEndEvent, type DragStartEvent
-} from '@dnd-kit/core';
 import { Icon } from './Icon';
-import Inspector from './Inspector';
+import ArchitectureDiagramSurface from './ArchitectureDiagramSurface';
 import ContentEditor from './ContentEditor';
 import History from './History';
-import PlacementWizard from './editors/PlacementWizard';
 import { EnrichDialog, useAiStatus } from './Analyse';
-import { PALETTE, PALETTE_DARK, slugify } from '@/lib/defaults';
-import { displayLayerLabel } from '@/lib/layers';
-import { ensurePlacementScaffold, componentBrick } from '@/lib/lego/place';
-import { syncTechnologies } from '@/lib/lego/stack';
 import { loadLegoCatalog } from '@/lib/lego/client';
-import { addSuggestedDependency, matchesSuggestionTarget, matchingDependencyTarget, visibleDependencies } from '@/lib/lego/dependencies';
-import type { LegoCatalogSnapshot, LegoDependencySuggestion } from '@/lib/lego/types';
-import { dashFor, describeLink, kindsInUse, LINK_DASH, LINK_KIND_LABELS, linkOf } from '@/lib/links';
-import { protocolLabel, suggestedLinkForBrick } from '@/lib/lego/protocols';
-import type { Architecture, Component, ProjectWithData } from '@/lib/types';
+import type { LegoCatalogSnapshot } from '@/lib/lego/types';
+import type { Architecture, ProjectWithData } from '@/lib/types';
 
 type SaveState = 'saved' | 'dirty' | 'saving' | 'error';
 type Mode = 'edit' | 'content' | 'preview';
@@ -31,21 +19,14 @@ export default function Editor({ project }: { project: ProjectWithData }) {
   const [doc, setDoc] = useState<Architecture>(project.data);
   const [name, setName] = useState(project.name);
   const [save, setSave] = useState<SaveState>('saved');
-  const [selected, setSelected] = useState<string | null>(null);
   const [mode, setMode] = useState<Mode>('edit');
-  const [dragId, setDragId] = useState<string | null>(null);
-  const [link, setLink] = useState<{ from: string; x: number; y: number } | null>(null);
-  const [hoverTarget, setHoverTarget] = useState<string | null>(null);
   const [history, setHistory] = useState(false);
   const [enrich, setEnrich] = useState(false);
   const [catalog, setCatalog] = useState<LegoCatalogSnapshot | null>(null);
-  const [placementRequest, setPlacementRequest] = useState<{ callerId?: string; suggestion?: LegoDependencySuggestion } | null>(null);
-  const [suggestionCallerId, setSuggestionCallerId] = useState<string | null>(null);
-  const [suggestionError, setSuggestionError] = useState<string | null>(null);
   const ai = useAiStatus();
 
-  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
   const first = useRef(true);
+  const [initialSelected, setInitialSelected] = useState<string | null>(null);
 
   useEffect(() => {
     loadLegoCatalog(doc.meta.lang === 'fr' ? 'fr' : 'en').then(setCatalog).catch(() => setCatalog(null));
@@ -56,7 +37,7 @@ export default function Editor({ project }: { project: ProjectWithData }) {
    * is dropped from the URL so a reload does not re-select. */
   useEffect(() => {
     if (new URLSearchParams(window.location.search).get('new') !== '1') return;
-    setSelected(project.data.components[0]?.id ?? null);
+    setInitialSelected(project.data.components[0]?.id ?? null);
     window.history.replaceState(null, '', `/projects/${project.id}`);
   }, [project.id, project.data.components]);
 
@@ -89,287 +70,68 @@ export default function Editor({ project }: { project: ProjectWithData }) {
     setDoc(d => fn(structuredClone(d)));
   }, []);
 
-  /* ------------------------------------------------------------ mutations */
-  const addComponent = useCallback((layerId: string, index?: number) => {
-    const id = slugify('component', doc.components.map(c => c.id));
-    const groupId = doc.groups[0]?.id || 'product';
-    const comp: Component = {
-      id, name: 'New component', group: groupId, layer: layerId,
-      icon: 'box', tech: [], features: [], notes: [], deps: []
-    };
-    patch(d => {
-      if (!d.groups.some(group => group.id === groupId)) {
-        d.groups.push({ id: groupId, name: 'Product', short: 'Product', color: PALETTE[0], colorDark: PALETTE_DARK[0] });
-      }
-      if (!d.layers.some(layer => layer.id === layerId)) {
-        d.layers.push({ id: layerId, name: displayLayerLabel(layerId) });
-      }
-      const list = [...d.components];
-      list.splice(index ?? list.length, 0, comp);
-      d.components = list;
-      return d;
-    });
-    setSelected(id);
-    return id;
-  }, [doc.components, doc.groups, patch]);
-
-  const placeBrick = useCallback((component: Component) => {
-    if (!catalog) return;
-    patch(d => {
-      ensurePlacementScaffold(component, d, catalog);
-      d.components.push(component);
-      syncTechnologies(d, catalog);
-      return d;
-    });
-    setSelected(component.id);
-  }, [catalog, patch]);
-
-  const acceptSuggestedLink = useCallback((callerId: string, calleeId: string, suggestion: LegoDependencySuggestion) => {
-    patch(d => {
-      const caller = d.components.find(component => component.id === callerId);
-      if (caller) addSuggestedDependency(caller, calleeId, suggestion);
-      return d;
-    });
-  }, [patch]);
-
-  const confirmPlacedBrick = useCallback((component: Component) => {
-    const request = placementRequest;
-    placeBrick(component);
-    if (request?.callerId && request.suggestion) {
-      if (matchesSuggestionTarget(component, request.suggestion)) {
-        acceptSuggestedLink(request.callerId, component.id, request.suggestion);
-        setSuggestionError(null);
-      } else {
-        const target = catalog?.bricks[request.suggestion.to]?.capabilityPhrase || request.suggestion.to;
-        setSuggestionError(doc.meta.lang === 'fr'
-          ? `La brique placée ne fournit pas ${target}. Choisis une variante proposée pour cette dépendance.`
-          : `The placed brick does not provide ${target}. Choose one of the variants offered for this dependency.`);
-      }
-      setSuggestionCallerId(request.callerId);
-    } else if (catalog && visibleDependencies(catalog, component).length) {
-      setSuggestionCallerId(component.id);
-      setSuggestionError(null);
-    }
-    setPlacementRequest(null);
-  }, [acceptSuggestedLink, catalog, doc.meta.lang, placeBrick, placementRequest]);
-
-  const moveComponent = useCallback((id: string, layerId: string, beforeId?: string) => {
-    patch(d => {
-      const i = d.components.findIndex(c => c.id === id);
-      if (i < 0) return d;
-      const [comp] = d.components.splice(i, 1);
-      comp.layer = layerId;
-      const at = beforeId ? d.components.findIndex(c => c.id === beforeId) : -1;
-      if (at >= 0) d.components.splice(at, 0, comp);
-      else d.components.push(comp);
-      return d;
-    });
-  }, [patch]);
-
-  const addDep = useCallback((from: string, to: string) => {
-    if (from === to) return;
-    patch(d => {
-      const c = d.components.find(x => x.id === from);
-      const callee = d.components.find(x => x.id === to);
-      if (!c) return d;
-      c.deps = c.deps || [];
-      if (c.deps.includes(to)) {
-        c.deps = c.deps.filter(x => x !== to);
-        c.links = (c.links || []).filter(link => link.to !== to);
-      } else {
-        c.deps.push(to);
-        const suggestion = suggestedLinkForBrick(componentBrick(callee || {}));
-        c.links = [...(c.links || []).filter(link => link.to !== to), { to, ...suggestion }];
-      }
-      return d;
-    });
-  }, [patch]);
-
-  /* -------------------------------------------------------------- linking */
-  useEffect(() => {
-    if (!link) return;
-    const move = (e: PointerEvent) => {
-      setLink(l => (l ? { ...l, x: e.clientX, y: e.clientY } : l));
-      const el = document.elementFromPoint(e.clientX, e.clientY) as HTMLElement | null;
-      const card = el?.closest('[data-comp]') as HTMLElement | null;
-      const id = card?.dataset.comp || null;
-      setHoverTarget(id && id !== link.from ? id : null);
-    };
-    const up = (e: PointerEvent) => {
-      const el = document.elementFromPoint(e.clientX, e.clientY) as HTMLElement | null;
-      const card = el?.closest('[data-comp]') as HTMLElement | null;
-      if (card?.dataset.comp) addDep(link.from, card.dataset.comp);
-      setLink(null); setHoverTarget(null);
-    };
-    window.addEventListener('pointermove', move);
-    window.addEventListener('pointerup', up, { once: true });
-    return () => { window.removeEventListener('pointermove', move); window.removeEventListener('pointerup', up); };
-  }, [link, addDep]);
-
-  /* ----------------------------------------------------------------- dnd */
-  function onDragEnd(e: DragEndEvent) {
-    setDragId(null);
-    const active = String(e.active.id);
-    const over = e.over ? String(e.over.id) : null;
-    if (!over) return;
-
-    const targetLayer = over.startsWith('layer:')
-      ? over.slice(6)
-      : doc.components.find(c => c.id === over)?.layer;
-    if (!targetLayer) return;
-    const beforeId = over.startsWith('layer:') ? undefined : over;
-
-    if (active === 'palette:new') {
-      const idx = beforeId ? doc.components.findIndex(c => c.id === beforeId) : undefined;
-      addComponent(targetLayer, idx);
-      return;
-    }
-    if (active !== beforeId) moveComponent(active, targetLayer, beforeId);
-  }
-
-  const selectedComp = doc.components.find(c => c.id === selected) || null;
-  const groupColor = useCallback((gid: string) => {
-    const i = doc.groups.findIndex(g => g.id === gid);
-    const g = doc.groups[i] || doc.groups[0];
-    return { light: g?.color || PALETTE[i % PALETTE.length], dark: g?.colorDark || PALETTE_DARK[i % PALETTE_DARK.length] };
-  }, [doc.groups]);
-
   return (
-    <DndContext sensors={sensors}
-      onDragStart={(e: DragStartEvent) => setDragId(String(e.active.id))}
-      onDragEnd={onDragEnd} onDragCancel={() => setDragId(null)}>
-      <div className="shell">
-        <div className="editor">
-          <div className="topbar">
-            <button className="iconbtn" onClick={() => router.push('/')} title="Back to projects">
-              <Icon name="back" size={16} />
-            </button>
-            <input className="name" value={name} onChange={e => setName(e.target.value)}
-              aria-label="Project name" />
-            <SaveFlag state={save} />
+    <div className="shell">
+      <div className="editor">
+        <div className="topbar">
+          <button className="iconbtn" onClick={() => router.push('/')} title="Back to projects">
+            <Icon name="back" size={16} />
+          </button>
+          <input className="name" value={name} onChange={e => setName(e.target.value)}
+            aria-label="Project name" />
+          <SaveFlag state={save} />
 
-            <div style={{ flex: 1 }} />
+          <div style={{ flex: 1 }} />
 
-            <div className="segmented">
-              <button aria-pressed={mode === 'edit'} onClick={() => setMode('edit')}>Diagram</button>
-              <button aria-pressed={mode === 'content'} onClick={() => setMode('content')}>Content</button>
-              <button aria-pressed={mode === 'preview'} onClick={() => setMode('preview')}>Preview</button>
-            </div>
-
-            {ai?.enabled && (
-              <button className="btn" onClick={() => setEnrich(true)}
-                title="Read a document against this project and add what it is missing">
-                <Icon name="ai" size={15} />Enrich
-              </button>
-            )}
-
-            <button className="btn" onClick={() => setHistory(true)}
-              title="Earlier versions, and what changed since each one">
-              <Icon name="clock" size={15} />History
-            </button>
-
-            <a className="btn" href={`/projects/${project.id}/document`} target="_blank" rel="noreferrer"
-              title="The same document, linear and numbered — print it to PDF from there">
-              <Icon name="file" size={15} />Document
-            </a>
-            <a className="btn" href={`/api/projects/${project.id}/export?format=html`}>
-              <Icon name="download" size={15} />HTML
-            </a>
-            <a className="btn" href={`/api/projects/${project.id}/export?format=json`}>
-              <Icon name="download" size={15} />JSON
-            </a>
+          <div className="segmented">
+            <button aria-pressed={mode === 'edit'} onClick={() => setMode('edit')}>Diagram</button>
+            <button aria-pressed={mode === 'content'} onClick={() => setMode('content')}>Content</button>
+            <button aria-pressed={mode === 'preview'} onClick={() => setMode('preview')}>Preview</button>
           </div>
 
-          {mode === 'preview' ? (
-            <PreviewPane projectId={project.id} version={doc} saveState={save} />
-          ) : mode === 'content' ? (
-            <ContentEditor doc={doc} patch={patch} catalog={catalog} />
-          ) : (
-            <div className="editor-body">
-              <Palette doc={doc} patch={patch} catalog={catalog} onOpenPlacement={() => setPlacementRequest({})} />
-
-              <div className="canvas-wrap">
-                <Canvas
-                  doc={doc} selected={selected} setSelected={setSelected}
-                  hoverTarget={hoverTarget} linking={!!link}
-                  onStartLink={(id, x, y) => setLink({ from: id, x, y })}
-                  groupColor={groupColor} patch={patch}
-                />
-              </div>
-
-              <Inspector
-                doc={doc} patch={patch} component={selectedComp}
-                onClose={() => setSelected(null)} onSelect={setSelected}
-              />
-            </div>
+          {ai?.enabled && (
+            <button className="btn" onClick={() => setEnrich(true)}
+              title="Read a document against this project and add what it is missing">
+              <Icon name="ai" size={15} />Enrich
+            </button>
           )}
+
+          <button className="btn" onClick={() => setHistory(true)}
+            title="Earlier versions, and what changed since each one">
+            <Icon name="clock" size={15} />History
+          </button>
+
+          <a className="btn" href={`/projects/${project.id}/document`} target="_blank" rel="noreferrer"
+            title="The same document, linear and numbered — print it to PDF from there">
+            <Icon name="file" size={15} />Document
+          </a>
+          <a className="btn" href={`/api/projects/${project.id}/export?format=html`}>
+            <Icon name="download" size={15} />HTML
+          </a>
+          <a className="btn" href={`/api/projects/${project.id}/export?format=json`}>
+            <Icon name="download" size={15} />JSON
+          </a>
         </div>
-      </div>
 
-      <DragOverlay dropAnimation={null}>
-        {dragId && dragId !== 'palette:new' && (() => {
-          const c = doc.components.find(x => x.id === dragId);
-          if (!c) return null;
-          return (
-            <div className="ccard" style={{ ['--c' as string]: groupColor(c.group).light, cursor: 'grabbing', boxShadow: 'var(--shadow-lg)' }}>
-              <div className="nh"><span className="ic"><Icon name={c.icon || 'box'} size={13} /></span>
-                <span className="nm">{c.name}</span></div>
-            </div>
-          );
-        })()}
-        {dragId === 'palette:new' && (
-          <div className="palette-item" style={{ background: 'var(--panel)', cursor: 'grabbing' }}>
-            <Icon name="plus" size={14} />New component
-          </div>
-        )}
-      </DragOverlay>
-
-      {link && <LinkLine link={link} />}
-
-      {placementRequest && (
-        <PlacementWizard
-          existingIds={doc.components.map(component => component.id)}
-          groups={doc.groups}
-          lang={doc.meta.lang === 'fr' ? 'fr' : 'en'}
-          catalog={catalog}
-          initialBrick={placementRequest.suggestion?.to}
-          onPlace={confirmPlacedBrick}
-          onClose={() => {
-            if (placementRequest.callerId) setSuggestionCallerId(placementRequest.callerId);
-            setPlacementRequest(null);
-          }}
-        />
-      )}
-
-      {suggestionCallerId && catalog && (() => {
-        const caller = doc.components.find(component => component.id === suggestionCallerId);
-        return caller ? (
-          <DependencySuggestions
-            caller={caller}
-            components={doc.components}
-            catalog={catalog}
-            lang={doc.meta.lang === 'fr' ? 'fr' : 'en'}
-            error={suggestionError}
-            onLink={(targetId, suggestion) => acceptSuggestedLink(caller.id, targetId, suggestion)}
-            onAddAndLink={suggestion => {
-              setSuggestionCallerId(null);
-              setSuggestionError(null);
-              setPlacementRequest({ callerId: caller.id, suggestion });
-            }}
-            onClose={() => { setSuggestionCallerId(null); setSuggestionError(null); }}
+        {mode === 'preview' ? (
+          <PreviewPane projectId={project.id} version={doc} saveState={save} />
+        ) : mode === 'content' ? (
+          <ContentEditor doc={doc} patch={patch} catalog={catalog} />
+        ) : (
+          <ArchitectureDiagramSurface
+            key={initialSelected ?? 'diagram'}
+            doc={doc}
+            patch={patch}
+            initialSelected={initialSelected}
           />
-        ) : null;
-      })()}
+        )}
+      </div>
 
       {history && (
         <History projectId={project.id} doc={doc} dirty={save !== 'saved'}
           onClose={() => setHistory(false)}
           onRestore={data => {
-            /* The restore already wrote the document server-side. Adopting it
-             * here keeps the canvas, the inspector and the preview in step —
-             * the autosave that follows is a no-op against what is on disk. */
             setDoc(data);
-            setSelected(s => (data.components.some(c => c.id === s) ? s : null));
           }} />
       )}
 
@@ -377,18 +139,13 @@ export default function Editor({ project }: { project: ProjectWithData }) {
         <EnrichDialog projectId={project.id} doc={doc}
           onClose={() => setEnrich(false)}
           onApply={merged => {
-            /* Adopted like a restore: the dialog has already checkpointed the
-             * document, and the autosave that follows this state change is the
-             * one and only write. */
             setDoc(merged);
             setEnrich(false);
           }} />
       )}
-    </DndContext>
+    </div>
   );
 }
-
-/* ------------------------------------------------------------------ pieces */
 
 function SaveFlag({ state }: { state: SaveState }) {
   const label = { saved: 'Saved', dirty: 'Editing…', saving: 'Saving…', error: 'Not saved' }[state];
@@ -399,400 +156,6 @@ function SaveFlag({ state }: { state: SaveState }) {
   );
 }
 
-function DependencySuggestions({ caller, components, catalog, lang, error, onLink, onAddAndLink, onClose }: {
-  caller: Component;
-  components: readonly Component[];
-  catalog: LegoCatalogSnapshot;
-  lang: 'en' | 'fr';
-  error: string | null;
-  onLink: (targetId: string, suggestion: LegoDependencySuggestion) => void;
-  onAddAndLink: (suggestion: LegoDependencySuggestion) => void;
-  onClose: () => void;
-}) {
-  const [skipped, setSkipped] = useState<string[]>([]);
-  const suggestions = visibleDependencies(catalog, caller).filter(suggestion => !skipped.includes(suggestion.to));
-  const copy = lang === 'fr'
-    ? { title: 'Ce dont ça a souvent besoin', done: 'Déjà lié', link: 'Lier', add: 'Ajouter et lier', manual: 'Ajoute ce composant manuellement', skip: 'Passer', close: 'Terminé' }
-    : { title: 'What this usually needs', done: 'Already linked', link: 'Link', add: 'Add & link', manual: 'Add this component manually', skip: 'Skip', close: 'Done' };
-
-  return (
-    <div className="modal-scrim" onClick={onClose}>
-      <div className="modal dependency-sheet" onClick={event => event.stopPropagation()} role="dialog" aria-label={copy.title}>
-        <div className="modal-head"><div><h2>{copy.title}</h2></div></div>
-        {error && <div className="warnbox"><Icon name="alert" size={15} />{error}</div>}
-        {suggestions.map(suggestion => {
-          const target = matchingDependencyTarget(components, suggestion.to);
-          const linked = target && caller.deps?.includes(target.id);
-          const placeable = catalog.variants.some(variant => variant.maps_to === suggestion.to);
-          const label = catalog.bricks[suggestion.to]?.capabilityPhrase || suggestion.to;
-          return (
-            <article className="dependency-suggestion" key={suggestion.to}>
-              <div>
-                <b>{label}</b>
-                <p>{lang === 'fr' ? suggestion.why_fr : suggestion.why_en}</p>
-                <small>{protocolLabel(suggestion.protocol_id)} · {LINK_KIND_LABELS[suggestion.kind][lang]}</small>
-              </div>
-              <div className="dependency-actions">
-                {linked ? <span className="muted">{copy.done}{describeLink(linkOf(caller, target.id), lang) ? ` · ${describeLink(linkOf(caller, target.id), lang)}` : ''}</span>
-                  : target ? <button type="button" className="btn sm primary" onClick={() => onLink(target.id, suggestion)}>{copy.link}</button>
-                    : placeable ? <button type="button" className="btn sm primary" onClick={() => onAddAndLink(suggestion)}>{copy.add}</button>
-                      : <button type="button" className="btn sm" disabled title={lang === 'fr' ? 'Aucune variante du catalogue ne peut encore placer cette brique.' : 'No catalog variant can place this brick yet.'}>{copy.manual}</button>}
-                {!linked && <button type="button" className="btn sm ghost" onClick={() => setSkipped(values => [...values, suggestion.to])}>{copy.skip}</button>}
-              </div>
-            </article>
-          );
-        })}
-        {!suggestions.length && <p className="muted">{lang === 'fr' ? 'Aucune autre suggestion.' : 'No more suggestions.'}</p>}
-        <div className="modal-actions"><button type="button" className="btn ghost" onClick={onClose}>{copy.close}</button></div>
-      </div>
-    </div>
-  );
-}
-
-function LinkLine({ link }: { link: { from: string; x: number; y: number } }) {
-  const src = document.querySelector(`[data-comp="${CSS.escape(link.from)}"]`);
-  if (!src) return null;
-  const r = src.getBoundingClientRect();
-  const x1 = r.left + r.width / 2, y1 = r.bottom;
-  return (
-    /* The edge you are dragging, in the grammar it will settle into: you are
-       holding the caller, and the open end is looking for something to answer. */
-    <svg className="linkline">
-      <path d={`M${x1},${y1} C${x1},${y1 + 40} ${link.x},${link.y - 40} ${link.x},${link.y}`}
-        fill="none" stroke="var(--brand)" strokeWidth="2" strokeDasharray="4 4" strokeLinecap="round" />
-      <circle cx={x1} cy={y1} r="4" fill="var(--brand)" />
-      <circle cx={link.x} cy={link.y} r="3.5" style={{ fill: 'var(--panel)' }}
-        stroke="var(--brand)" strokeWidth="2" />
-    </svg>
-  );
-}
-
-/* One dependency, drawn the way the mark draws it: a filled disc where the
- * caller is, an open circle where the callee answers. The direction of an
- * edge is the only thing a curve cannot say by itself, and an arrowhead in a
- * diagram this dense turns into lint — this reads at a glance and survives
- * printing at 67 %.
- *
- * The stroke carries the second question: `dash` is empty for a synchronous or
- * unannotated call, and breaks the line for one that is queued or batched. It
- * is the stroke and not the colour because colour already means scope, and a
- * dash still reads in monochrome. The endpoints stay solid — direction must
- * not get quieter just because the call is asynchronous.
- *
- * The group is faded as a unit rather than per shape: compositing the group
- * first is what lets the open circle's paper fill still punch through the
- * line inside it, which is the whole point of the open circle.
- *
- * Kept in step with `drawEdges` in viewer/engine.js and `PaperDiagram` in the
- * document renderer — three surfaces, one grammar, one table in lib/links.ts. */
-function edgeGlyph(
-  x1: number, y1: number, k1: number, x2: number, y2: number, k2: number,
-  colour: string, opacity: number, width: number, dash = ''
-) {
-  return `<g opacity="${opacity}">`
-    + `<path d="M${x1},${y1} C${x1},${y1 + k1} ${x2},${y2 + k2} ${x2},${y2}" fill="none" `
-    + `stroke="${colour}" stroke-width="${width}" stroke-linecap="round"`
-    + `${dash ? ` stroke-dasharray="${dash}"` : ''}/>`
-    + `<circle cx="${x1}" cy="${y1}" r="3.5" fill="${colour}"/>`
-    + `<circle cx="${x2}" cy="${y2}" r="3" style="fill:var(--panel)" stroke="${colour}" stroke-width="1.5"/>`
-    + `</g>`;
-}
-
-/* -------------------------------------------------------------------- canvas */
-
-function Canvas({ doc, selected, setSelected, hoverTarget, linking, onStartLink, groupColor, patch }: {
-  doc: Architecture; selected: string | null; setSelected: (id: string | null) => void;
-  hoverTarget: string | null; linking: boolean;
-  onStartLink: (id: string, x: number, y: number) => void;
-  groupColor: (id: string) => { light: string; dark: string };
-  patch: (fn: (d: Architecture) => Architecture) => void;
-}) {
-  const ref = useRef<HTMLDivElement>(null);
-  const [edges, setEdges] = useState<string>('');
-
-  const draw = useCallback(() => {
-    const host = ref.current;
-    if (!host) return;
-    const box = host.getBoundingClientRect();
-    const index = Object.fromEntries(doc.layers.map((l, i) => [l.id, i]));
-    const byId = Object.fromEntries(doc.components.map(c => [c.id, c]));
-    let out = '';
-    doc.components.forEach(c => (c.deps || []).forEach(dep => {
-      const a = host.querySelector(`[data-comp="${CSS.escape(c.id)}"]`);
-      const b = host.querySelector(`[data-comp="${CSS.escape(dep)}"]`);
-      if (!a || !b || !byId[dep]) return;
-      const ra = a.getBoundingClientRect(), rb = b.getBoundingClientRect();
-      const x1 = ra.left - box.left + ra.width / 2;
-      const x2 = rb.left - box.left + rb.width / 2;
-      const la = index[c.layer], lb = index[byId[dep].layer];
-      let y1: number, y2: number, k1: number, k2: number;
-      if (la === lb) {
-        y1 = ra.bottom - box.top; y2 = rb.bottom - box.top; k1 = 30; k2 = 30;
-      } else {
-        const up = la > lb;
-        y1 = (up ? ra.top : ra.bottom) - box.top;
-        y2 = (up ? rb.bottom : rb.top) - box.top;
-        const k = (up ? -1 : 1) * Math.max(24, Math.abs(y2 - y1) * .5);
-        k1 = k; k2 = -k;
-      }
-      const active = selected === c.id || selected === dep;
-      const colour = groupColor(c.group).light;
-      out += edgeGlyph(x1, y1, k1, x2, y2, k2, colour, active ? 1 : .34, active ? 2 : 1.2,
-        dashFor(linkOf(c, dep)?.kind));
-    }));
-    setEdges(out);
-  }, [doc, selected, groupColor]);
-
-  useLayoutEffect(() => { draw(); }, [draw]);
-  useEffect(() => {
-    const host = ref.current;
-    if (!host) return;
-    const ro = new ResizeObserver(() => draw());
-    ro.observe(host);
-    window.addEventListener('resize', draw);
-    return () => { ro.disconnect(); window.removeEventListener('resize', draw); };
-  }, [draw]);
-
-  return (
-    <div className={`canvas${linking ? ' linking' : ''}`} ref={ref}
-      onClick={e => { if (e.target === e.currentTarget) setSelected(null); }}>
-      <svg className="canvas-edges" dangerouslySetInnerHTML={{ __html: edges }} />
-      {doc.layers.length === 0 && (
-        <div className="warnbox" style={{ margin: 16 }}>
-          <Icon name="alert" size={15} />
-          No layers yet — add a layer in the palette, or place a brick (it creates the layer it needs).
-        </div>
-      )}
-      {doc.layers.map(layer => (
-        <LayerRow key={layer.id} layer={layer} doc={doc} patch={patch}
-          selected={selected} setSelected={setSelected} hoverTarget={hoverTarget}
-          onStartLink={onStartLink} groupColor={groupColor} />
-      ))}
-    </div>
-  );
-}
-
-function LayerRow({ layer, doc, patch, selected, setSelected, hoverTarget, onStartLink, groupColor }: {
-  layer: { id: string; name: string; desc?: string };
-  doc: Architecture; patch: (fn: (d: Architecture) => Architecture) => void;
-  selected: string | null; setSelected: (id: string | null) => void; hoverTarget: string | null;
-  onStartLink: (id: string, x: number, y: number) => void;
-  groupColor: (id: string) => { light: string; dark: string };
-}) {
-  const { setNodeRef, isOver } = useDroppable({ id: `layer:${layer.id}` });
-  const items = doc.components.filter(c => c.layer === layer.id);
-
-  return (
-    <div className={`layer${isOver ? ' over' : ''}`}>
-      <div className="layer-head">
-        <b>{displayLayerLabel(layer.name)}</b>
-        {layer.desc && <em>{layer.desc}</em>}
-        <span className="layer-tools">
-          <button className="iconbtn" style={{ width: 24, height: 24 }} title="Rename layer"
-            onClick={() => {
-              const name = prompt('Layer name', layer.name);
-              if (name?.trim()) patch(d => {
-                const l = d.layers.find(x => x.id === layer.id); if (l) l.name = name.trim(); return d;
-              });
-            }}><Icon name="cog" size={13} /></button>
-          <button className="iconbtn" style={{ width: 24, height: 24 }} title="Delete layer"
-            onClick={() => {
-              if (items.length && doc.layers.length <= 1) {
-                alert('Keep at least one layer while components still use it.');
-                return;
-              }
-              if (items.length && !confirm(`Delete "${layer.name}"? Its ${items.length} component(s) move to "${doc.layers.find(l => l.id !== layer.id)!.name}".`)) return;
-              if (!items.length && !confirm(`Delete empty layer "${layer.name}"?`)) return;
-              patch(d => {
-                if (items.length) {
-                  const fallback = d.layers.find(l => l.id !== layer.id)!.id;
-                  d.components.forEach(c => { if (c.layer === layer.id) c.layer = fallback; });
-                }
-                d.layers = d.layers.filter(l => l.id !== layer.id);
-                return d;
-              });
-            }}><Icon name="trash" size={13} /></button>
-        </span>
-      </div>
-      <div ref={setNodeRef} className={`layer-drop${items.length ? '' : ' empty-hint'}`}>
-        {items.length === 0 && 'Drop a component here'}
-        {items.map(c => (
-          <ComponentCard key={c.id} comp={c} colour={groupColor(c.group).light}
-            selected={selected === c.id} isLinkTarget={hoverTarget === c.id}
-            onSelect={() => setSelected(c.id)} onStartLink={onStartLink} />
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function ComponentCard({ comp, colour, selected, isLinkTarget, onSelect, onStartLink }: {
-  comp: Component; colour: string; selected: boolean; isLinkTarget: boolean;
-  onSelect: () => void; onStartLink: (id: string, x: number, y: number) => void;
-}) {
-  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({ id: comp.id });
-  const { setNodeRef: dropRef } = useDroppable({ id: comp.id });
-
-  return (
-    <div
-      ref={node => { setNodeRef(node); dropRef(node); }}
-      {...listeners} {...attributes}
-      data-comp={comp.id}
-      className={`ccard${selected ? ' selected' : ''}${isDragging ? ' dragging' : ''}${isLinkTarget ? ' linktarget' : ''}`}
-      style={{ ['--c' as string]: colour }}
-      onClick={e => { e.stopPropagation(); onSelect(); }}
-    >
-      {comp.badge && <span className="badge">{comp.badge}</span>}
-      <div className="nh">
-        <span className="ic"><Icon name={comp.icon || 'box'} size={13} /></span>
-        <span className="nm">{comp.name}</span>
-      </div>
-      {!!comp.tech?.length && (
-        <div className="tech">{comp.tech.slice(0, 3).map(t => <span key={t}>{t}</span>)}</div>
-      )}
-      {!!comp.deps?.length && <span className="depcount">{comp.deps.length} →</span>}
-      <span
-        className="linkdot" title="Drag onto another component to create a dependency"
-        onPointerDown={e => {
-          e.stopPropagation(); e.preventDefault();
-          onStartLink(comp.id, e.clientX, e.clientY);
-        }}
-      />
-    </div>
-  );
-}
-
-/* ------------------------------------------------------------------ palette */
-
-function Palette({ doc, patch, catalog, onOpenPlacement }: {
-  doc: Architecture; patch: (fn: (d: Architecture) => Architecture) => void;
-  catalog: LegoCatalogSnapshot | null;
-  onOpenPlacement: () => void;
-}) {
-  const { attributes, listeners, setNodeRef } = useDraggable({ id: 'palette:new' });
-
-  return (
-    <aside className="palette">
-      <div className="sect-label">Add</div>
-      <div ref={setNodeRef} {...listeners} {...attributes} className="palette-item">
-        <Icon name="plus" size={14} />Drag me into a layer
-      </div>
-      <button type="button" className="btn sm" style={{ width: '100%', justifyContent: 'center' }}
-        onClick={onOpenPlacement}>
-        Add brick
-      </button>
-
-      <div className="sect-label">
-        Scopes<span className="spacer" />
-        <button className="iconbtn" style={{ width: 20, height: 20 }} title="Add scope"
-          onClick={() => {
-            /* Derived from the palette, not typed as a literal: there are five
-             * hues, and a sixth scope would be handed `PALETTE[0]` again —
-             * two scopes with one colour, which is the thing the palette is
-             * built to prevent. */
-            if (doc.groups.length >= PALETTE.length) {
-              alert(`${PALETTE.length} scopes is the maximum — a sixth would reuse the first colour.`);
-              return;
-            }
-            const name = prompt('Scope name');
-            if (!name?.trim()) return;
-            patch(d => {
-              const i = d.groups.length;
-              d.groups.push({
-                id: slugify(name, d.groups.map(g => g.id)), name: name.trim(), short: name.trim(),
-                color: PALETTE[i % PALETTE.length], colorDark: PALETTE_DARK[i % PALETTE_DARK.length]
-              });
-              return d;
-            });
-          }}><Icon name="plus" size={13} /></button>
-      </div>
-      {doc.groups.map((g, i) => (
-        <div className="grouprow" key={g.id}>
-          <input type="color" className="swatch" value={g.color || PALETTE[i % PALETTE.length]}
-            title="Scope colour"
-            onChange={e => patch(d => { const x = d.groups.find(y => y.id === g.id); if (x) x.color = e.target.value; return d; })} />
-          <input value={g.name}
-            onChange={e => patch(d => { const x = d.groups.find(y => y.id === g.id); if (x) { x.name = e.target.value; x.short = e.target.value; } return d; })} />
-          {doc.groups.length > 1 || !doc.components.some(c => c.group === g.id) ? (
-            <button className="iconbtn" style={{ width: 22, height: 22 }} title="Delete scope"
-              onClick={() => {
-                const used = doc.components.filter(c => c.group === g.id).length;
-                if (used && doc.groups.length <= 1) {
-                  alert('Keep at least one scope while components still use it.');
-                  return;
-                }
-                if (used && !confirm(`${used} component(s) use this scope. They will move to "${doc.groups.find(x => x.id !== g.id)!.name}".`)) return;
-                patch(d => {
-                  if (used) {
-                    const fallback = d.groups.find(x => x.id !== g.id)!.id;
-                    d.components.forEach(c => { if (c.group === g.id) c.group = fallback; });
-                  }
-                  d.groups = d.groups.filter(x => x.id !== g.id);
-                  return d;
-                });
-              }}><Icon name="trash" size={12} /></button>
-          ) : null}
-        </div>
-      ))}
-
-      <div className="sect-label">
-        Layers<span className="spacer" />
-        <button className="iconbtn" style={{ width: 20, height: 20 }} title="Add layer"
-          onClick={() => {
-            const name = prompt('Layer name');
-            if (!name?.trim()) return;
-            patch(d => {
-              d.layers.push({ id: slugify(name, d.layers.map(l => l.id)), name: name.trim() });
-              return d;
-            });
-          }}><Icon name="plus" size={13} /></button>
-      </div>
-      {doc.layers.map((l, i) => (
-        <div className="grouprow" key={l.id}>
-          <input value={l.name}
-            onChange={e => patch(d => { const x = d.layers.find(y => y.id === l.id); if (x) x.name = e.target.value; return d; })} />
-          <button className="iconbtn" style={{ width: 22, height: 22 }} disabled={i === 0} title="Move up"
-            onClick={() => patch(d => {
-              const arr = d.layers; [arr[i - 1], arr[i]] = [arr[i], arr[i - 1]]; return d;
-            })}><Icon name="chevron" size={12} style={{ transform: 'rotate(-90deg)' }} /></button>
-          <button className="iconbtn" style={{ width: 22, height: 22 }} disabled={i === doc.layers.length - 1} title="Move down"
-            onClick={() => patch(d => {
-              const arr = d.layers; [arr[i + 1], arr[i]] = [arr[i], arr[i + 1]]; return d;
-            })}><Icon name="chevron" size={12} style={{ transform: 'rotate(90deg)' }} /></button>
-        </div>
-      ))}
-
-      <EdgeLegend doc={doc} />
-    </aside>
-  );
-}
-
-/* Only drawn once the document actually annotates an edge. A legend explaining
- * three line styles on a diagram that uses one is furniture. */
-function EdgeLegend({ doc }: { doc: Architecture }) {
-  const kinds = kindsInUse(doc.components);
-  if (!kinds.length) return null;
-
-  return (
-    <>
-      <div className="sect-label">Dependencies</div>
-      <div className="edgekey">
-        {kinds.map(k => (
-          <span key={k}>
-            <svg viewBox="0 0 34 8" aria-hidden="true">
-              <path d="M1 4h32" fill="none" stroke="currentColor" strokeWidth="1.6"
-                strokeLinecap="round" strokeDasharray={LINK_DASH[k] || undefined} />
-            </svg>
-            {LINK_KIND_LABELS[k].en}
-          </span>
-        ))}
-      </div>
-    </>
-  );
-}
-
-/* ------------------------------------------------------------------ preview */
-
 function PreviewPane({ projectId, version, saveState }: {
   projectId: string; version: Architecture; saveState: SaveState;
 }) {
@@ -800,7 +163,6 @@ function PreviewPane({ projectId, version, saveState }: {
   const key = useMemo(() => JSON.stringify(version).length + ':' + saveState, [version, saveState]);
 
   useEffect(() => {
-    /* wait for the autosave to land, then render the real export */
     if (saveState !== 'saved') return;
     let alive = true;
     fetch(`/api/projects/${projectId}/export?format=html&inline=1`)

--- a/src/components/Workspace.tsx
+++ b/src/components/Workspace.tsx
@@ -130,7 +130,7 @@ export default function Workspace({
   const roots = folders.filter(f => !f.parentId);
 
   return (
-    <DndContext
+    <DndContext id="archstudio-workspace-dnd"
       sensors={sensors}
       onDragStart={(e: DragStartEvent) => setDragging(projects.find(p => p.id === String(e.active.id)) || null)}
       onDragEnd={onDragEnd}
@@ -448,7 +448,8 @@ function NewProjectDialog({ folderId, busy, setBusy, onClose, onCreated }: {
 
   const chosen = templates?.find(t => t.id === pick) ?? null;
   const detail = templates?.find(t => t.id === (hover ?? pick)) ?? null;
-  const targets = chosen ? TARGETS.filter(t => chosen.supportedTargets.includes(t)) : [];
+  const isProjectTemplate = chosen?.kind === 'project';
+  const targets = chosen && !isProjectTemplate ? TARGETS.filter(t => chosen.supportedTargets.includes(t)) : [];
 
   async function submit() {
     if (!name.trim()) { setError('Give it a name first.'); return; }
@@ -460,7 +461,11 @@ function NewProjectDialog({ folderId, busy, setBusy, onClose, onCreated }: {
           name: name.trim(),
           description: description.trim() || undefined,
           folderId,
-          ...(chosen ? { templateId: chosen.id, target, lang } : {})
+          ...(chosen
+            ? chosen.kind === 'project'
+              ? { projectTemplateId: chosen.id }
+              : { templateId: chosen.id, target, lang }
+            : {})
         })
       });
       onCreated(p.id);
@@ -499,9 +504,30 @@ function NewProjectDialog({ folderId, busy, setBusy, onClose, onCreated }: {
               <div className="hint">No template available — a blank project still works.</div>
             ) : (
               <>
-                <div className="sect-label" style={{ marginTop: 6 }}>Or start from a template</div>
+                {templates.some(t => t.kind === 'project') && (
+                  <>
+                    <div className="sect-label" style={{ marginTop: 6 }}>Reference projects</div>
+                    <div className="tpl-grid">
+                      {templates.filter(t => t.kind === 'project').map(t => (
+                        <button key={t.id}
+                          className={`tpl-card${pick === t.id ? ' on' : ''}`}
+                          style={{ ['--tpl' as string]: t.accent }}
+                          onClick={() => setPick(t.id)}
+                          onDoubleClick={() => { setPick(t.id); setStep(2); }}
+                          onMouseEnter={() => setHover(t.id)} onMouseLeave={() => setHover(null)}
+                          onFocus={() => setHover(t.id)} onBlur={() => setHover(null)}>
+                          <span className="dot"><Icon name={t.icon} size={15} /></span>
+                          <b>{t.name[lang]}</b>
+                          <em>{t.tagline[lang]}</em>
+                          <span className="n">{t.counts.agnostic} components</span>
+                        </button>
+                      ))}
+                    </div>
+                  </>
+                )}
+                <div className="sect-label" style={{ marginTop: 6 }}>Architecture templates</div>
                 <div className="tpl-grid">
-                  {templates.map(t => (
+                  {templates.filter(t => t.kind !== 'project').map(t => (
                     <button key={t.id}
                       className={`tpl-card${pick === t.id ? ' on' : ''}`}
                       style={{ ['--tpl' as string]: t.accent }}
@@ -569,7 +595,7 @@ function NewProjectDialog({ folderId, busy, setBusy, onClose, onCreated }: {
                 placeholder={chosen ? chosen.tagline[lang] : 'What this system does, in one line'} />
             </label>
 
-            {chosen && (
+            {chosen && !isProjectTemplate && (
               <>
                 <div className="field"><span>Deployment target</span>
                   <div className="radio-row">

--- a/src/components/admin/AdminEmpty.tsx
+++ b/src/components/admin/AdminEmpty.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+export function AdminEmpty({ children }: { children: ReactNode }) {
+  return <div className="empty">{children}</div>;
+}

--- a/src/components/admin/AdminEntityGrid.tsx
+++ b/src/components/admin/AdminEntityGrid.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import Link from 'next/link';
+import type { ReactNode } from 'react';
+import { Icon } from '@/components/Icon';
+
+export type AdminGridItem = {
+  href: string;
+  icon: string;
+  accent?: string;
+  title: string;
+  description?: string;
+  count?: string | number;
+  badge?: ReactNode;
+};
+
+export function AdminEntityGrid({ items }: { items: AdminGridItem[] }) {
+  return (
+    <div className="pgrid">
+      {items.map(item => (
+        <Link
+          key={item.href}
+          href={item.href}
+          className="pcard"
+          style={{ textDecoration: 'none', color: 'inherit' }}
+        >
+          <div className="accent" style={{ background: item.accent ?? 'var(--brand)' }}>
+            <Icon name={item.icon} size={14} style={{ stroke: 'var(--on-fill)' }} />
+          </div>
+          <b>{item.title}</b>
+          {item.description && <p>{item.description}</p>}
+          <div className="foot">
+            {item.count !== undefined && <span className="mono">{item.count}</span>}
+            {item.badge}
+          </div>
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/src/components/admin/AdminIssuePanel.tsx
+++ b/src/components/admin/AdminIssuePanel.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import type { CatalogIssue } from '@/lib/lego/admin-catalog';
+import { IssueList } from './IssueList';
+
+type IssueInput = CatalogIssue | string;
+
+export function AdminIssuePanel({
+  title = 'Validation',
+  issues,
+}: {
+  title?: string;
+  issues: IssueInput[];
+}) {
+  if (issues.length === 0) return null;
+
+  const catalogIssues: CatalogIssue[] = issues.map((issue, i) =>
+    typeof issue === 'string'
+      ? { code: `msg-${i}`, message: issue }
+      : issue,
+  );
+
+  return (
+    <div style={{ marginBottom: 14 }}>
+      <IssueList issues={catalogIssues} title={title} clickable={false} />
+    </div>
+  );
+}

--- a/src/components/admin/AdminPageHeader.tsx
+++ b/src/components/admin/AdminPageHeader.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { type ReactNode } from 'react';
+import { Icon } from '@/components/Icon';
+
+export type AdminPageSearch = {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+};
+
+/**
+ * Body toolbar under the shell topbar.
+ * Chrome title lives in layout `.topbar .name` — never render a competing H1 here.
+ */
+export function AdminPageHeader({
+  lede,
+  search,
+  actions,
+}: {
+  lede?: string;
+  search?: AdminPageSearch;
+  actions?: ReactNode;
+}) {
+  const tools = (search || actions) ? (
+    <div className="ws-head-tools">
+      {search && (
+        <div className="ws-search">
+          <Icon name="search" size={14} />
+          <input
+            className="input"
+            value={search.value}
+            placeholder={search.placeholder}
+            onChange={e => search.onChange(e.target.value)}
+          />
+        </div>
+      )}
+      {actions}
+    </div>
+  ) : null;
+
+  if (!lede && !tools) return null;
+
+  return (
+    <div className={`ws-head admin-head${!lede ? ' admin-head-compact' : ''}`}>
+      <div className="ws-head-row">
+        {lede && <p className="ws-head-lede">{lede}</p>}
+        {tools}
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/AdminWorkspace.tsx
+++ b/src/components/admin/AdminWorkspace.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { useEffect, useState, type CSSProperties, type ReactNode } from 'react';
+import { AdminIssuePanel } from './AdminIssuePanel';
+import { AdminPageHeader, type AdminPageSearch } from './AdminPageHeader';
+import type { CatalogIssue } from '@/lib/lego/admin-catalog';
+
+export type AdminLocale = 'en' | 'fr';
+
+const LOCALE_EVENT = 'admin-locale';
+
+/** Read admin content locale; stays in sync with layout topbar switcher. */
+export function useAdminLocale(propLocale?: AdminLocale): AdminLocale {
+  const [locale, setLocale] = useState<AdminLocale>(propLocale ?? 'en');
+
+  useEffect(() => {
+    if (propLocale) {
+      setLocale(propLocale);
+      return;
+    }
+    const read = () => {
+      try {
+        const stored = localStorage.getItem('admin-locale');
+        if (stored === 'en' || stored === 'fr') setLocale(stored);
+      } catch { /* private mode */ }
+    };
+    read();
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === 'admin-locale') read();
+    };
+    window.addEventListener('storage', onStorage);
+    window.addEventListener(LOCALE_EVENT, read);
+    window.addEventListener('focus', read);
+    return () => {
+      window.removeEventListener('storage', onStorage);
+      window.removeEventListener(LOCALE_EVENT, read);
+      window.removeEventListener('focus', read);
+    };
+  }, [propLocale]);
+
+  return propLocale ?? locale;
+}
+
+export function dispatchAdminLocaleChange() {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new Event(LOCALE_EVENT));
+}
+
+export function AdminWorkspace({
+  lede,
+  search,
+  actions,
+  error,
+  issues,
+  bodyStyle,
+  children,
+}: {
+  /** Optional body lede — page title is owned by layout topbar. */
+  lede?: string;
+  search?: AdminPageSearch;
+  actions?: ReactNode;
+  error?: string | null;
+  issues?: CatalogIssue[] | string[];
+  bodyStyle?: CSSProperties;
+  children: ReactNode;
+}) {
+  return (
+    <div className="workspace">
+      <AdminPageHeader lede={lede} search={search} actions={actions} />
+      <div className="ws-body" style={bodyStyle}>
+        {error && <div className="warnbox" style={{ marginBottom: 14 }}>{error}</div>}
+        {issues && issues.length > 0 && <AdminIssuePanel issues={issues} />}
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/ArchitectureTemplateEditor.tsx
+++ b/src/components/admin/ArchitectureTemplateEditor.tsx
@@ -1,0 +1,253 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
+import { CatalogSaveFlag, type CatalogSaveState } from '@/components/admin/CatalogList';
+import { TemplateAddPanel } from '@/components/admin/TemplateAddPanel';
+import { TemplateDiagramPanel } from '@/components/admin/TemplateDiagramPanel';
+import {
+  ARCHITECTURE_EDITOR_TABS,
+  TemplateEditorShell,
+  type TemplateEditorTab,
+} from '@/components/admin/TemplateEditorShell';
+import { TemplateFlowsPanel } from '@/components/admin/TemplateFlowsPanel';
+import { TemplatePreviewPane } from '@/components/admin/TemplatePreviewPane';
+import { Area, Group, Text } from '@/components/editors/Fields';
+import { normalizeArchitecture } from '@/lib/defaults';
+import { updateTemplate, type ArchitectureTemplateDetail } from '@/lib/admin/templates';
+import type { Architecture } from '@/lib/types';
+
+type Patch = (fn: (d: Architecture) => Architecture) => void;
+
+export function ArchitectureTemplateEditor({
+  tpl,
+  title,
+  subtitle,
+  specText,
+  saveState,
+  error,
+  actions,
+  onTplChange,
+  onSaveMeta,
+  onSpecChange,
+  onSaveSpec,
+  onSnapshotError,
+}: {
+  tpl: ArchitectureTemplateDetail;
+  title?: string;
+  subtitle?: string;
+  specText: string;
+  saveState: CatalogSaveState;
+  error?: string | null;
+  actions: ReactNode;
+  onTplChange: (next: ArchitectureTemplateDetail) => void;
+  onSaveMeta: (patch: {
+    nameEn?: string;
+    nameFr?: string;
+    meta?: Partial<ArchitectureTemplateDetail['meta']>;
+  }) => void;
+  onSpecChange: (value: string) => void;
+  onSaveSpec: () => void;
+  onSnapshotError?: (message: string) => void;
+}) {
+  const [snapshot, setSnapshot] = useState<Architecture | null>(tpl.snapshot ?? null);
+  const [snapshotSave, setSnapshotSave] = useState<CatalogSaveState>('idle');
+  const dirtyRef = useRef(false);
+  const syncingRef = useRef(false);
+
+  useEffect(() => {
+    syncingRef.current = true;
+    setSnapshot(tpl.snapshot ?? null);
+    dirtyRef.current = false;
+    const t = setTimeout(() => { syncingRef.current = false; }, 0);
+    return () => clearTimeout(t);
+  }, [tpl.id]);
+
+  const patch: Patch = useCallback((fn) => {
+    setSnapshot(prev => {
+      if (!prev) return prev;
+      dirtyRef.current = true;
+      return normalizeArchitecture(fn(structuredClone(prev)));
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!snapshot || !dirtyRef.current || syncingRef.current) return;
+    setSnapshotSave('saving');
+    const t = setTimeout(async () => {
+      try {
+        /* Forge accepts snapshot→spec on architecture PATCH in parallel; same
+         * client shape as project templates. */
+        await updateTemplate(tpl.id, { snapshot });
+        dirtyRef.current = false;
+        setSnapshotSave('saved');
+        setTimeout(() => setSnapshotSave('idle'), 1200);
+      } catch (e) {
+        setSnapshotSave('error');
+        onSnapshotError?.((e as Error).message);
+      }
+    }, 700);
+    return () => clearTimeout(t);
+  }, [snapshot, tpl.id, onSnapshotError]);
+
+  const displaySave: CatalogSaveState =
+    snapshotSave === 'saving' || snapshotSave === 'error' || snapshotSave === 'dirty'
+      ? snapshotSave
+      : snapshotSave === 'saved' && saveState === 'idle'
+        ? 'saved'
+        : saveState;
+
+  const counts = snapshot
+    ? {
+        components: snapshot.components?.length ?? 0,
+        sections: snapshot.sections?.length ?? 0,
+        flows: snapshot.flows?.length ?? 0,
+      }
+    : {
+        components: tpl.outline.componentCount,
+        sections: tpl.outline.sectionIds.length,
+        flows: tpl.outline.flowCount,
+      };
+
+  const snapshotPanels: Partial<Record<TemplateEditorTab, ReactNode>> = snapshot
+    ? {
+        diagram: (
+          <TemplateDiagramPanel doc={snapshot} patch={patch} />
+        ),
+        flows: (
+          <TemplateFlowsPanel doc={snapshot} patch={patch} />
+        ),
+        add: (
+          <TemplateAddPanel doc={snapshot} patch={patch} onError={onSnapshotError} />
+        ),
+        preview: (
+          <TemplatePreviewPane
+            templateId={tpl.id}
+            snapshot={snapshot}
+            saveState={displaySave}
+            variant="full"
+          />
+        ),
+      }
+    : {
+        diagram: <div className="empty">No agnostic snapshot loaded.</div>,
+        flows: <div className="empty">No agnostic snapshot loaded.</div>,
+        add: <div className="empty">No agnostic snapshot loaded.</div>,
+        preview: <div className="empty">No agnostic snapshot to preview.</div>,
+      };
+
+  return (
+    <TemplateEditorShell
+      templateId={tpl.id}
+      title={title ?? tpl.nameEn}
+      subtitle={subtitle || tpl.meta.taglineEn || 'Hyperscaler pattern — spec stays per-cloud.'}
+      badge={<span className="count">Architecture</span>}
+      actions={(
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+          <CatalogSaveFlag state={displaySave} />
+          {actions}
+        </div>
+      )}
+      counts={counts}
+      tabs={ARCHITECTURE_EDITOR_TABS}
+      railHint="Diagram · Flows · ADD edit the agnostic snapshot. Per-cloud overrides stay under Advanced JSON."
+      metadata={(
+        <>
+          {error && <div className="warnbox" style={{ marginBottom: 14 }}>{error}</div>}
+          <Group title="Identity">
+            <div className="field"><span>Template ID</span><div className="mono">{tpl.id}</div></div>
+            <Text
+              label="Name (EN)"
+              value={tpl.nameEn}
+              onChange={v => onTplChange({ ...tpl, nameEn: v })}
+              onBlur={() => onSaveMeta({ nameEn: tpl.nameEn })}
+            />
+            <Text
+              label="Name (FR)"
+              value={tpl.nameFr}
+              onChange={v => onTplChange({ ...tpl, nameFr: v })}
+              onBlur={() => onSaveMeta({ nameFr: tpl.nameFr })}
+            />
+            <div className="field">
+              <span>Targets</span>
+              <div className="mono">{tpl.supportedTargets.join(', ') || '—'}</div>
+            </div>
+          </Group>
+          <Group title="Picker copy">
+            <Area
+              label="Tagline (EN)"
+              value={tpl.meta.taglineEn}
+              onChange={v => onTplChange({ ...tpl, meta: { ...tpl.meta, taglineEn: v } })}
+              onBlur={() => onSaveMeta({ meta: { taglineEn: tpl.meta.taglineEn } })}
+            />
+            <Area
+              label="Tagline (FR)"
+              value={tpl.meta.taglineFr}
+              onChange={v => onTplChange({ ...tpl, meta: { ...tpl.meta, taglineFr: v } })}
+              onBlur={() => onSaveMeta({ meta: { taglineFr: tpl.meta.taglineFr } })}
+            />
+            <div className="frow">
+              <Text
+                label="Accent"
+                value={tpl.meta.accent}
+                mono
+                onChange={v => onTplChange({ ...tpl, meta: { ...tpl.meta, accent: v } })}
+                onBlur={() => onSaveMeta({ meta: { accent: tpl.meta.accent } })}
+              />
+              <Text
+                label="Icon key"
+                value={tpl.meta.icon}
+                mono
+                onChange={v => onTplChange({ ...tpl, meta: { ...tpl.meta, icon: v } })}
+                onBlur={() => onSaveMeta({ meta: { icon: tpl.meta.icon } })}
+              />
+            </div>
+          </Group>
+          <Group title="Outline">
+            <div className="frow">
+              <div className="field"><span>Components</span><div className="mono">{counts.components}</div></div>
+              <div className="field"><span>Flows</span><div className="mono">{counts.flows}</div></div>
+            </div>
+            <div className="field">
+              <span>Sections</span>
+              <div className="mono">{tpl.outline.sectionIds.join(', ') || '—'}</div>
+            </div>
+          </Group>
+        </>
+      )}
+      panels={{
+        ...snapshotPanels,
+        advanced: (
+          <>
+            {error && <div className="warnbox" style={{ marginBottom: 14 }}>{error}</div>}
+            <Group title="Template spec">
+              <p className="hint" style={{ marginBottom: 10 }}>
+                Full JSON including per-cloud overrides. Saving here does not go through the project canvas.
+              </p>
+              <Area
+                label="Spec"
+                value={specText}
+                minHeight={320}
+                onChange={onSpecChange}
+              />
+              <button type="button" className="btn primary sm" onClick={onSaveSpec}>
+                Save spec
+              </button>
+            </Group>
+          </>
+        ),
+      }}
+      inspectorPreview={
+        snapshot ? (
+          <div className="inspector-preview">
+            <TemplatePreviewPane
+              templateId={tpl.id}
+              snapshot={snapshot}
+              saveState={displaySave}
+              variant="compact"
+            />
+          </div>
+        ) : undefined
+      }
+    />
+  );
+}

--- a/src/components/admin/BlocksDrawer.tsx
+++ b/src/components/admin/BlocksDrawer.tsx
@@ -1,0 +1,216 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { Icon } from '@/components/Icon';
+import { SECTION_TYPES } from '@/lib/defaults';
+import { fetchSections, type AdminSectionListItem } from '@/lib/admin/sections';
+import type { SectionType } from '@/lib/types';
+
+const TYPE_ICONS: Record<SectionType, string> = {
+  cards: 'card',
+  text: 'file',
+  timeline: 'clock',
+  table: 'chart',
+  compare: 'layers',
+};
+
+const TYPE_ORDER: SectionType[] = ['cards', 'text', 'timeline', 'table', 'compare'];
+
+function sectionTitle(item: AdminSectionListItem, locale: 'en' | 'fr'): string {
+  return locale === 'fr' ? (item.titleFr || item.id) : (item.titleEn || item.id);
+}
+
+function sectionTab(item: AdminSectionListItem, locale: 'en' | 'fr'): string | undefined {
+  return locale === 'fr' ? item.tabFr : item.tabEn;
+}
+
+export function BlocksDrawer({
+  open,
+  onClose,
+  onPick,
+  locale = 'en',
+}: {
+  open: boolean;
+  onClose: () => void;
+  onPick: (sectionId: string) => void;
+  locale?: 'en' | 'fr';
+}) {
+  const [sections, setSections] = useState<AdminSectionListItem[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState('');
+  const [typeFilter, setTypeFilter] = useState<SectionType | 'all'>('all');
+
+  const reload = useCallback(async () => {
+    try {
+      const data = await fetchSections();
+      setSections(data.sections);
+      setError(null);
+    } catch (e) {
+      setError((e as Error).message);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    setQuery('');
+    setTypeFilter('all');
+    reload();
+  }, [open, reload]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  const filtered = useMemo(() => {
+    if (!sections) return [];
+    const q = query.trim().toLowerCase();
+    return sections.filter(item => {
+      if (typeFilter !== 'all' && item.type !== typeFilter) return false;
+      if (!q) return true;
+      const hay = [
+        item.id,
+        item.type,
+        item.titleEn,
+        item.titleFr,
+        item.tabEn,
+        item.tabFr,
+        item.subtitleEn,
+        item.subtitleFr,
+      ].filter(Boolean).join(' ').toLowerCase();
+      return hay.includes(q);
+    });
+  }, [sections, query, typeFilter]);
+
+  const grouped = useMemo(() => {
+    const buckets = new Map<SectionType, AdminSectionListItem[]>();
+    for (const type of TYPE_ORDER) buckets.set(type, []);
+    for (const item of filtered) {
+      const list = buckets.get(item.type);
+      if (list) list.push(item);
+    }
+    return TYPE_ORDER
+      .map(type => ({ type, items: buckets.get(type) ?? [] }))
+      .filter(g => g.items.length > 0);
+  }, [filtered]);
+
+  if (!open) return null;
+
+  return (
+    <div className="modal-scrim" onClick={onClose} role="presentation">
+      <div
+        className="modal wide"
+        onClick={e => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="blocks-drawer-title"
+      >
+        <div className="modal-head">
+          <div>
+            <h2 id="blocks-drawer-title">Section library</h2>
+            <p className="lede">
+              Pick a reusable ADD block — cards and text are the v1 priority.
+            </p>
+          </div>
+          <button type="button" className="btn sm" onClick={onClose}>
+            Close
+          </button>
+        </div>
+
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 14 }}>
+          <div className="ws-search inline">
+            <Icon name="search" size={14} />
+            <input
+              className="input"
+              placeholder="Filter sections…"
+              value={query}
+              onChange={e => setQuery(e.target.value)}
+              autoFocus
+            />
+          </div>
+          <div className="segmented" role="group" aria-label="Filter by type">
+            <button
+              type="button"
+              aria-pressed={typeFilter === 'all'}
+              onClick={() => setTypeFilter('all')}
+            >
+              All
+            </button>
+            {(['cards', 'text'] as const).map(type => (
+              <button
+                key={type}
+                type="button"
+                aria-pressed={typeFilter === type}
+                onClick={() => setTypeFilter(type)}
+              >
+                {SECTION_TYPES.find(t => t.type === type)?.label ?? type}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {error && <div className="warnbox" style={{ marginBottom: 12 }}>{error}</div>}
+        {!sections && !error && <div className="empty">Loading library…</div>}
+        {sections && filtered.length === 0 && (
+          <div className="empty">
+            {query || typeFilter !== 'all' ? 'No section matches this filter.' : 'Library is empty.'}
+          </div>
+        )}
+
+        <div style={{ maxHeight: 'min(60vh, 520px)', overflow: 'auto', paddingRight: 4 }}>
+          {grouped.map(({ type, items }) => {
+            const meta = SECTION_TYPES.find(t => t.type === type);
+            return (
+              <div key={type} style={{ marginBottom: 20 }}>
+                <div className="sect-label" style={{ marginBottom: 8 }}>
+                  {meta?.label ?? type} · {items.length}
+                </div>
+                <div className="cardlist">
+                  {items.map(item => (
+                    <button
+                      key={item.id}
+                      type="button"
+                      className="pcard"
+                      style={{
+                        width: '100%',
+                        textAlign: 'left',
+                        cursor: 'pointer',
+                        border: '1px solid var(--line)',
+                        background: 'var(--panel)',
+                      }}
+                      onClick={() => onPick(item.id)}
+                    >
+                      <div className="accent" style={{ background: 'var(--brand)' }}>
+                        <Icon name={TYPE_ICONS[item.type]} size={14} style={{ stroke: 'var(--on-fill)' }} />
+                      </div>
+                      <b>{sectionTitle(item, locale)}</b>
+                      <p>{sectionTab(item, locale) || item.id}</p>
+                      <div className="foot">
+                        <span className="mono">{item.id}</span>
+                        <span className="count">{item.type}</span>
+                        {item.itemCount !== undefined && (
+                          <span className="count">{item.itemCount} items</span>
+                        )}
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <div style={{ marginTop: 16, paddingTop: 12, borderTop: '1px solid var(--line)' }}>
+          <Link href="/admin/sections" className="btn sm" onClick={onClose}>
+            Manage library
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/BrickEditor.tsx
+++ b/src/components/admin/BrickEditor.tsx
@@ -1,0 +1,456 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import Link from 'next/link';
+import { Icon } from '@/components/Icon';
+import { Area, Choice, IconPicker, Group } from '@/components/editors/Fields';
+import { BrickPreviewPane } from '@/components/admin/BrickPreviewPane';
+import { PublishBadge } from '@/components/admin/PublishBadge';
+import { STARTER_LAYERS } from '@/lib/defaults';
+import { TAG_TO_PRESET, type ConcernTag } from '@/lib/document/concerns';
+import {
+  fetchCatalogState,
+  patchBrick,
+  publishCatalog,
+  type CatalogIssue,
+  type CatalogState
+} from '@/lib/admin/catalog';
+import { deleteBrick } from '@/lib/admin/catalog-entities';
+import { invalidateLegoCatalogCache, loadLegoCatalog } from '@/lib/lego/client';
+import type { LegoBrick, LegoCatalogSnapshot } from '@/lib/lego/types';
+
+const ALL_CONCERN_TAGS = Object.keys(TAG_TO_PRESET) as ConcernTag[];
+
+type ContentLocale = 'en' | 'fr';
+type SaveState = 'idle' | 'dirty' | 'saving' | 'saved' | 'error';
+
+type BrickDraft = {
+  icon: string;
+  layer: string;
+  defaultScope: string;
+  concernTags: ConcernTag[];
+  purposeEn: string;
+  purposeFr: string;
+  roleEn: string;
+  roleFr: string;
+};
+
+function draftFromCatalog(en: LegoBrick, fr: LegoBrick): BrickDraft {
+  return {
+    icon: en.icon,
+    layer: en.layer,
+    defaultScope: en.defaultScope,
+    concernTags: [...en.concernTags],
+    purposeEn: en.purpose || en.role,
+    purposeFr: fr.purpose || fr.role,
+    roleEn: en.role,
+    roleFr: fr.role
+  };
+}
+
+function SaveFlag({ state }: { state: SaveState }) {
+  if (state === 'idle') return null;
+  const label = { saving: 'Saving…', saved: 'Saved', error: 'Not saved', dirty: 'Editing…' }[state];
+  return (
+    <span className={`saveflag${state === 'saving' || state === 'dirty' ? ' dirty' : ''}${state === 'error' ? ' error' : ''}`}>
+      <i />{label}
+    </span>
+  );
+}
+
+function layerOptions(catalog: LegoCatalogSnapshot) {
+  const fromBricks = new Set(Object.values(catalog.bricks).map(b => b.layer));
+  for (const layer of STARTER_LAYERS) fromBricks.add(layer.id);
+  return [...fromBricks].sort().map(id => {
+    const starter = STARTER_LAYERS.find(l => l.id === id);
+    return { value: id, label: starter ? `${id} — ${starter.name}` : id };
+  });
+}
+
+function IssuesBox({ issues }: { issues: CatalogIssue[] }) {
+  if (issues.length === 0) return null;
+  return (
+    <div className="warnbox" style={{ margin: '0 0 12px' }}>
+      <ul style={{ margin: 0, paddingLeft: 18 }}>
+        {issues.map((issue, i) => (
+          <li key={`${issue.code}-${i}`}>
+            {issue.message}
+            {issue.field && <span className="hint"> — field: {issue.field}</span>}
+            {issue.entityId && <span className="mono" style={{ fontSize: 11 }}> ({issue.entityId})</span>}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default function BrickEditor({ brickId }: { brickId: string }) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const focusField = searchParams.get('field');
+  const [enCatalog, setEnCatalog] = useState<LegoCatalogSnapshot | null>(null);
+  const [frCatalog, setFrCatalog] = useState<LegoCatalogSnapshot | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [draft, setDraft] = useState<BrickDraft | null>(null);
+  const [contentLocale, setContentLocale] = useState<ContentLocale>('en');
+  useEffect(() => {
+    if (!focusField || !draft) return;
+    if (focusField === 'roleFr' || focusField === 'purposeFr') setContentLocale('fr');
+    if (focusField === 'roleEn' || focusField === 'purposeEn') setContentLocale('en');
+    const t = window.setTimeout(() => {
+      const root = document.querySelector(`[data-admin-field="${focusField}"]`);
+      if (!(root instanceof HTMLElement)) return;
+      root.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      root.style.outline = '2px solid var(--brand)';
+      root.style.outlineOffset = '2px';
+      const input = root.querySelector('textarea, input, select, button.tagchip');
+      if (input instanceof HTMLElement) input.focus();
+    }, 120);
+    return () => window.clearTimeout(t);
+  }, [focusField, draft]);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [saveState, setSaveState] = useState<SaveState>('idle');
+  const [catalogState, setCatalogState] = useState<CatalogState | null>(null);
+  const [publishIssues, setPublishIssues] = useState<CatalogIssue[]>([]);
+  const [busy, setBusy] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  const reloadCatalogs = useCallback(async () => {
+    invalidateLegoCatalogCache();
+    const [en, fr] = await Promise.all([loadLegoCatalog('en'), loadLegoCatalog('fr')]);
+    setEnCatalog(en);
+    setFrCatalog(fr);
+    const enBrick = en.bricks[brickId];
+    const frBrick = fr.bricks[brickId];
+    if (enBrick && frBrick) setDraft(draftFromCatalog(enBrick, frBrick));
+  }, [brickId]);
+
+  const reloadCatalogState = useCallback(async () => {
+    try {
+      setCatalogState(await fetchCatalogState());
+    } catch {
+      /* API may not be ready yet — badge falls back to Published */
+    }
+  }, []);
+
+  useEffect(() => {
+    Promise.all([loadLegoCatalog('en'), loadLegoCatalog('fr')])
+      .then(([en, fr]) => {
+        setEnCatalog(en);
+        setFrCatalog(fr);
+        const enBrick = en.bricks[brickId];
+        const frBrick = fr.bricks[brickId];
+        if (!enBrick || !frBrick) return;
+        setDraft(draftFromCatalog(enBrick, frBrick));
+      })
+      .catch(err => setError(err instanceof Error ? err.message : 'Failed to load catalog'));
+    reloadCatalogState();
+  }, [brickId, reloadCatalogState]);
+
+  const enBrick = enCatalog?.bricks[brickId];
+  const layerOpts = useMemo(
+    () => (enCatalog ? layerOptions(enCatalog) : []),
+    [enCatalog]
+  );
+  const scopeOpts = useMemo(
+    () => (enCatalog?.scopes ?? []).map(s => ({ value: s.id, label: s.label })),
+    [enCatalog]
+  );
+
+  const jsonPreview = useMemo(() => {
+    if (!draft || !enBrick) return '';
+    const merged: LegoBrick = {
+      ...enBrick,
+      icon: draft.icon,
+      layer: draft.layer,
+      defaultScope: draft.defaultScope,
+      concernTags: draft.concernTags,
+      purpose: draft.purposeEn,
+      role: draft.roleEn
+    };
+    return JSON.stringify(merged, null, 2);
+  }, [draft, enBrick]);
+
+  const handleSave = async (): Promise<boolean> => {
+    if (!draft) return false;
+    setSaveState('saving');
+    setPublishIssues([]);
+    try {
+      await patchBrick(brickId, draft);
+      await reloadCatalogs();
+      await reloadCatalogState();
+      setSaveState('saved');
+      return true;
+    } catch (err) {
+      setSaveState('error');
+      return false;
+    }
+  };
+
+  const handlePublish = async () => {
+    if (!draft || busy) return;
+    setBusy(true);
+    setPublishIssues([]);
+    try {
+      const saved = await handleSave();
+      if (!saved) return;
+      const result = await publishCatalog();
+      if (!result.ok) {
+        setPublishIssues(result.issues);
+        return;
+      }
+      await reloadCatalogState();
+      await reloadCatalogs();
+    } catch (err) {
+      setPublishIssues([{
+        code: 'publish_error',
+        message: err instanceof Error ? err.message : 'Publish failed'
+      }]);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (busy || deleting) return;
+    if (!window.confirm(`Delete brick “${brickId}”? Variants and dependencies that reference it must be removed first.`)) return;
+    setDeleting(true);
+    setPublishIssues([]);
+    try {
+      await deleteBrick(brickId);
+      invalidateLegoCatalogCache();
+      router.push('/admin/catalog/bricks');
+    } catch (err) {
+      setPublishIssues([{
+        code: 'delete_error',
+        message: err instanceof Error ? err.message : 'Delete failed',
+      }]);
+      setDeleting(false);
+    }
+  };
+
+  const markDirty = () => {
+    if (saveState !== 'dirty') setSaveState('dirty');
+  };
+
+  if (error) {
+    return <div className="warnbox" style={{ margin: 22 }}>{error}</div>;
+  }
+
+  if (!enCatalog || !frCatalog) {
+    return <div className="empty">Loading brick…</div>;
+  }
+
+  if (!enBrick || !draft) {
+    return (
+      <>
+        <div className="empty">Brick not found: {brickId}</div>
+        <div style={{ padding: '0 22px 24px' }}>
+          <Link href="/admin/catalog/bricks" className="btn sm">
+            <Icon name="back" size={13} />Back to briques
+          </Link>
+        </div>
+      </>
+    );
+  }
+
+  const toggleConcern = (tag: ConcernTag) => {
+    markDirty();
+    setDraft(d => {
+      if (!d) return d;
+      const has = d.concernTags.includes(tag);
+      return {
+        ...d,
+        concernTags: has
+          ? d.concernTags.filter(t => t !== tag)
+          : [...d.concernTags, tag]
+      };
+    });
+  };
+
+  const purpose = contentLocale === 'en' ? draft.purposeEn : draft.purposeFr;
+  const role = contentLocale === 'en' ? draft.roleEn : draft.roleFr;
+  const setPurpose = (v: string) => {
+    markDirty();
+    setDraft(d => d && ({
+      ...d,
+      ...(contentLocale === 'en' ? { purposeEn: v } : { purposeFr: v })
+    }));
+  };
+  const setRole = (v: string) => {
+    markDirty();
+    setDraft(d => d && ({
+      ...d,
+      ...(contentLocale === 'en' ? { roleEn: v } : { roleFr: v })
+    }));
+  };
+
+  return (
+    <div className="editor-body">
+      <div className="content-main">
+        <div className="cpanel">
+          <div className="cpanel-head">
+            <div>
+              <h2 className="mono" style={{ fontSize: 15 }}>{brickId}</h2>
+              <p className="hint">{enBrick.capabilityPhrase || 'Lego brick'}</p>
+            </div>
+            <div className="cpanel-actions">
+              <PublishBadge state={catalogState?.dirty ? 'modified' : 'published'} />
+              <SaveFlag state={saveState} />
+              <button
+                type="button"
+                className="btn primary"
+                disabled={saveState === 'saving' || busy || deleting}
+                onClick={() => void handleSave()}
+              >
+                Save draft
+              </button>
+              <button
+                type="button"
+                className="btn"
+                disabled={saveState === 'saving' || busy || deleting}
+                onClick={() => void handlePublish()}
+              >
+                Publish catalogue
+              </button>
+              <button
+                type="button"
+                className="btn"
+                disabled={saveState === 'saving' || busy || deleting}
+                onClick={() => void handleDelete()}
+              >
+                {deleting ? 'Deleting…' : 'Delete'}
+              </button>
+            </div>
+          </div>
+
+          <IssuesBox issues={publishIssues} />
+
+          <Group title="Metadata" data-admin-field="metadata">
+            <IconPicker
+              value={draft.icon}
+              onChange={icon => { markDirty(); setDraft(d => d && { ...d, icon }); }}
+            />
+            <div data-admin-field="layer">
+            <Choice
+              label="Layer"
+              value={draft.layer}
+              onChange={layer => { markDirty(); setDraft(d => d && { ...d, layer }); }}
+              options={layerOpts}
+            />
+            </div>
+            <div data-admin-field="defaultScope">
+            <Choice
+              label="Default scope"
+              value={draft.defaultScope}
+              onChange={defaultScope => { markDirty(); setDraft(d => d && { ...d, defaultScope }); }}
+              options={scopeOpts}
+            />
+            </div>
+            <div className="field" data-admin-field="concernTags">
+              <span>Concern tags</span>
+              <div className="chiprow">
+                {ALL_CONCERN_TAGS.map(tag => {
+                  const active = draft.concernTags.includes(tag);
+                  return (
+                    <button
+                      key={tag}
+                      type="button"
+                      className="tagchip"
+                      aria-pressed={active}
+                      style={active ? { borderColor: 'var(--brand)', color: 'var(--brand-ink)' } : undefined}
+                      onClick={() => toggleConcern(tag)}
+                    >
+                      {tag}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          </Group>
+
+          <Group title="Content">
+            <div className="segmented" role="group" aria-label="Content locale" style={{ marginBottom: 12 }}>
+              <button
+                type="button"
+                aria-pressed={contentLocale === 'en'}
+                onClick={() => setContentLocale('en')}
+              >
+                EN
+              </button>
+              <button
+                type="button"
+                aria-pressed={contentLocale === 'fr'}
+                onClick={() => setContentLocale('fr')}
+              >
+                FR
+              </button>
+            </div>
+            <div data-admin-field={contentLocale === 'en' ? 'purposeEn' : 'purposeFr'}>
+            <Area
+              label={`Purpose (${contentLocale})`}
+              value={purpose}
+              onChange={v => setPurpose(v)}
+              minHeight={72}
+              hint="One- or two-sentence catalog purpose for ADD and glossary."
+            />
+            </div>
+            <div data-admin-field={contentLocale === 'en' ? 'roleEn' : 'roleFr'}>
+            <Area
+              label={`Role (${contentLocale})`}
+              value={role}
+              onChange={v => setRole(v)}
+              minHeight={56}
+              hint="Legacy role prose — used when purpose is empty at placement."
+            />
+            </div>
+          </Group>
+
+          <div className="insp-sep" />
+
+          <div className={`elist${advancedOpen ? ' open' : ''}`}>
+            <div className="elist-head">
+              <button
+                type="button"
+                className="iconbtn twist"
+                aria-expanded={advancedOpen}
+                onClick={() => setAdvancedOpen(o => !o)}
+                title={advancedOpen ? 'Collapse' : 'Expand'}
+              >
+                <Icon name="chevron" size={14} />
+              </button>
+              <button type="button" className="elist-name" onClick={() => setAdvancedOpen(o => !o)}>
+                Advanced
+              </button>
+            </div>
+            {advancedOpen && (
+              <div className="elist-body">
+                <label className="field">
+                  <span>Brick JSON (read-only)</span>
+                  <textarea
+                    className="textarea"
+                    readOnly
+                    value={jsonPreview}
+                    style={{ minHeight: 220, fontFamily: 'var(--mono)', fontSize: 11 }}
+                  />
+                </label>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <aside className="inspector">
+        <div className="sub mono">{brickId}</div>
+        <h3>Preview</h3>
+        <BrickPreviewPane
+          brickId={brickId}
+          draft={draft}
+          capabilityPhrase={enBrick.capabilityPhrase}
+          lang={contentLocale}
+        />
+      </aside>
+    </div>
+  );
+}

--- a/src/components/admin/BrickPreviewPane.tsx
+++ b/src/components/admin/BrickPreviewPane.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Icon } from '@/components/Icon';
+
+type PreviewLocale = 'en' | 'fr';
+
+export type BrickPreviewDraft = {
+  icon: string;
+  layer: string;
+  defaultScope: string;
+  concernTags: string[];
+  purposeEn: string;
+  purposeFr: string;
+  roleEn: string;
+  roleFr: string;
+};
+
+/**
+ * Live inspector preview for a Lego brick — Atelier chrome (`.preview-shell` +
+ * `.previewframe`) with a real `.pcard` driven by current form state.
+ * No iframe route exists for bricks; this is the intentional M1 surface.
+ */
+export function BrickPreviewPane({
+  brickId,
+  draft,
+  capabilityPhrase,
+  lang: langProp,
+}: {
+  brickId: string;
+  draft: BrickPreviewDraft;
+  capabilityPhrase?: string;
+  lang?: PreviewLocale;
+}) {
+  const [previewLang, setPreviewLang] = useState<PreviewLocale>(langProp ?? 'en');
+
+  useEffect(() => {
+    if (langProp) setPreviewLang(langProp);
+  }, [langProp]);
+
+  const purpose =
+    previewLang === 'en'
+      ? draft.purposeEn || draft.roleEn
+      : draft.purposeFr || draft.roleFr;
+  const title = capabilityPhrase?.trim() || brickId;
+
+  return (
+    <div className="preview-shell preview-shell--compact">
+      <div className="preview-shell-head">
+        <div className="segmented" role="group" aria-label="Preview locale">
+          <button
+            type="button"
+            aria-pressed={previewLang === 'en'}
+            onClick={() => setPreviewLang('en')}
+          >
+            EN
+          </button>
+          <button
+            type="button"
+            aria-pressed={previewLang === 'fr'}
+            onClick={() => setPreviewLang('fr')}
+          >
+            FR
+          </button>
+        </div>
+      </div>
+
+      <div
+        className="previewframe"
+        style={{
+          minHeight: 240,
+          display: 'flex',
+          flexDirection: 'column',
+          padding: 16,
+          overflow: 'auto',
+        }}
+      >
+        <article
+          className="pcard"
+          style={{
+            width: '100%',
+            maxWidth: 280,
+            margin: '0 auto',
+            cursor: 'default',
+            position: 'relative',
+          }}
+          aria-label={`Brick preview: ${brickId}`}
+        >
+          <div className="accent" style={{ background: 'var(--brand)' }}>
+            <Icon
+              name={draft.icon || 'box'}
+              size={14}
+              style={{ stroke: 'var(--on-fill)' }}
+            />
+          </div>
+          <b>{title}</b>
+          {purpose ? (
+            <p>{purpose}</p>
+          ) : (
+            <p className="hint" style={{ margin: '5px 0 0' }}>
+              {previewLang === 'fr' ? 'Aucune purpose renseignée.' : 'No purpose set.'}
+            </p>
+          )}
+          <div className="foot">
+            <span className="mono">{brickId}</span>
+            <span className="count">
+              {draft.layer} · {draft.defaultScope}
+            </span>
+          </div>
+        </article>
+
+        {draft.concernTags.length > 0 && (
+          <div className="chiprow" style={{ marginTop: 14, justifyContent: 'center' }}>
+            {draft.concernTags.map(tag => (
+              <span key={tag} className="tagchip" role="status">
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/CatalogFormParts.tsx
+++ b/src/components/admin/CatalogFormParts.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { type ReactNode } from 'react';
+import { Group, Panel } from '@/components/editors/Fields';
+import { AdminEmpty } from '@/components/admin/AdminEmpty';
+import { CatalogSaveFlag, type CatalogSaveState } from '@/components/admin/CatalogList';
+import { PublishBadge, type PublishState } from '@/components/admin/PublishBadge';
+
+export const HOSTING_MODE_OPTIONS = [
+  { value: 'client', label: 'client' },
+  { value: 'baas', label: 'baas' },
+  { value: 'cloud', label: 'cloud' },
+  { value: 'selfhosted', label: 'selfhosted' },
+] as const;
+
+export const DEPENDENCY_STRENGTHS = [
+  { value: 'required', label: 'required' },
+  { value: 'recommended', label: 'recommended' },
+  { value: 'optional', label: 'optional' },
+];
+
+export const DEPENDENCY_KINDS = [
+  { value: 'sync', label: 'sync' },
+  { value: 'async', label: 'async' },
+  { value: 'batch', label: 'batch' },
+];
+
+/** Toggle chips for hosting modes — Atelier `.tagchip`, not segmented wrap. */
+export function ModeChips({
+  modes,
+  onToggle,
+}: {
+  modes: string[];
+  onToggle: (mode: string) => void;
+}) {
+  return (
+    <div className="field">
+      <span>Hosting modes</span>
+      <div className="chiprow">
+        {HOSTING_MODE_OPTIONS.map(mode => {
+          const active = modes.includes(mode.value);
+          return (
+            <button
+              key={mode.value}
+              type="button"
+              className="tagchip"
+              aria-pressed={active}
+              style={active ? { borderColor: 'var(--brand)', color: 'var(--brand-ink)' } : undefined}
+              onClick={() => onToggle(mode.value)}
+            >
+              {mode.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+/** Inspector chrome: id + Panel head + Groups + Save/Delete footer. */
+export function CatalogInspector({
+  entityId,
+  title,
+  subtitle,
+  publishState,
+  saveState,
+  onSave,
+  onDelete,
+  saveLabel = 'Save',
+  deleteLabel = 'Delete',
+  deleting,
+  deleteDisabledReason,
+  children,
+}: {
+  entityId: string;
+  title: string;
+  subtitle?: string;
+  publishState?: PublishState;
+  saveState: CatalogSaveState;
+  onSave: () => void;
+  onDelete?: () => void;
+  saveLabel?: string;
+  deleteLabel?: string;
+  deleting?: boolean;
+  deleteDisabledReason?: string | null;
+  children: ReactNode;
+}) {
+  return (
+    <Panel
+      title={title}
+      subtitle={subtitle}
+      actions={
+        <>
+          {publishState ? <PublishBadge state={publishState} /> : null}
+          <CatalogSaveFlag state={saveState} />
+        </>
+      }
+    >
+      <div className="mono sub" style={{ marginBottom: 10 }}>{entityId}</div>
+      {children}
+      <div className="insp-sep" />
+      <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap', marginTop: 4 }}>
+        <button
+          type="button"
+          className="btn primary"
+          disabled={saveState === 'saving' || deleting}
+          onClick={onSave}
+        >
+          {saveState === 'saving' ? 'Saving…' : saveLabel}
+        </button>
+        {onDelete && (
+          <button
+            type="button"
+            className="btn"
+            disabled={Boolean(deleteDisabledReason) || deleting || saveState === 'saving'}
+            title={deleteDisabledReason ?? undefined}
+            onClick={onDelete}
+          >
+            {deleting ? 'Deleting…' : deleteLabel}
+          </button>
+        )}
+        {deleteDisabledReason && (
+          <span className="hint" style={{ flex: '1 1 160px' }}>{deleteDisabledReason}</span>
+        )}
+        {onDelete && !deleteDisabledReason && (
+          <span className="hint" style={{ flex: '1 1 200px' }}>
+            Seeded ids reappear after catalog ensure.
+          </span>
+        )}
+      </div>
+    </Panel>
+  );
+}
+
+export function CatalogInspectorEmpty({ children }: { children?: ReactNode }) {
+  return <AdminEmpty>{children ?? 'Select an item to edit.'}</AdminEmpty>;
+}
+
+export function CatalogFormGroup({
+  title,
+  hint,
+  cols,
+  children,
+}: {
+  title?: string;
+  hint?: string;
+  cols?: number;
+  children: ReactNode;
+}) {
+  return (
+    <Group title={title} hint={hint} cols={cols}>
+      {children}
+    </Group>
+  );
+}

--- a/src/components/admin/CatalogList.tsx
+++ b/src/components/admin/CatalogList.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { type ReactNode } from 'react';
+import { Icon } from '@/components/Icon';
+import { AdminEmpty } from '@/components/admin/AdminEmpty';
+import { AdminPageHeader } from './AdminPageHeader';
+
+export type CatalogSaveState = 'idle' | 'dirty' | 'saving' | 'saved' | 'error';
+
+export function CatalogSplitShell({
+  countLabel,
+  query,
+  onQuery,
+  queryPlaceholder,
+  error,
+  issues,
+  list,
+  inspector,
+  actions,
+}: {
+  /** Body lede (counts / hint) — chrome title is layout topbar. */
+  countLabel: string;
+  query?: string;
+  onQuery?: (value: string) => void;
+  queryPlaceholder?: string;
+  error?: string | null;
+  issues?: string[];
+  list: ReactNode;
+  inspector: ReactNode;
+  actions?: ReactNode;
+}) {
+  return (
+    <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+      <AdminPageHeader
+        lede={countLabel}
+        search={onQuery ? {
+          value: query ?? '',
+          onChange: onQuery,
+          placeholder: queryPlaceholder,
+        } : undefined}
+        actions={actions}
+      />
+      {error && <div className="warnbox" style={{ margin: '12px 28px 0' }}>{error}</div>}
+      {issues && issues.length > 0 && (
+        <div className="warnbox" style={{ margin: '12px 28px 0' }}>{issues.join(' · ')}</div>
+      )}
+      <div className="editor-body">
+        <div className="content-main" style={{ padding: '8px 10px 24px' }}>
+          <div className="sect-label" style={{ margin: '4px 6px 8px' }}>
+            Catalogue
+            <span className="spacer" />
+          </div>
+          {list}
+        </div>
+        <aside className="inspector" style={{ overflow: 'auto' }}>
+          {inspector}
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+export function CatalogTreeRow({
+  active,
+  onClick,
+  icon,
+  label,
+  meta,
+}: {
+  active: boolean;
+  onClick: () => void;
+  icon?: string;
+  label: string;
+  meta?: string;
+}) {
+  return (
+    <button
+      type="button"
+      className={`tree-row${active ? ' active' : ''}`}
+      style={{ width: '100%', border: 'none', background: 'transparent', textAlign: 'left', cursor: 'pointer' }}
+      onClick={onClick}
+    >
+      {icon
+        ? <span className="ficon"><Icon name={icon} size={15} /></span>
+        : <span style={{ width: 14 }} />}
+      <span className="label mono" style={{ fontSize: 12 }}>{label}</span>
+      {meta ? <span className="count">{meta}</span> : null}
+    </button>
+  );
+}
+
+export function CatalogSaveFlag({ state }: { state: CatalogSaveState }) {
+  if (state === 'idle') return null;
+  const label = { saving: 'Saving…', saved: 'Saved', error: 'Not saved', dirty: 'Editing…' }[state];
+  return (
+    <span className={`saveflag${state === 'saving' || state === 'dirty' ? ' dirty' : ''}${state === 'error' ? ' error' : ''}`}>
+      <i />{label}
+    </span>
+  );
+}
+
+export function CatalogListEmpty({ query, noun }: { query?: string; noun: string }) {
+  if (query) return <AdminEmpty>No {noun} matches this search.</AdminEmpty>;
+  return <AdminEmpty>Loading {noun}…</AdminEmpty>;
+}

--- a/src/components/admin/FlowPatternEditor.tsx
+++ b/src/components/admin/FlowPatternEditor.tsx
@@ -1,0 +1,666 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Icon } from '@/components/Icon';
+import { Area, Group, IconPicker, Text } from '@/components/editors/Fields';
+import { CatalogSaveFlag, type CatalogSaveState } from '@/components/admin/CatalogList';
+import { PublishBadge } from '@/components/admin/PublishBadge';
+import {
+  deleteFlowPattern,
+  fetchFlowPattern,
+  fetchFlowPatternPreview,
+  fetchFlowPatternState,
+  fetchFlowPatterns,
+  publishFlowPatterns,
+  updateFlowPattern,
+  type FlowLibraryState,
+  type FlowPreviewStats,
+} from '@/lib/admin/flows';
+import { slugify } from '@/lib/defaults';
+import type { FlowHint, FlowTemplate, FlowTemplateStep } from '@/lib/flows/types';
+import type { L10n } from '@/lib/templates/types';
+
+type ContentLocale = 'en' | 'fr';
+type Mut<T> = (fn: (draft: T) => void) => void;
+
+function asPair(value: L10n | undefined): { en: string; fr: string } {
+  if (!value) return { en: '', fr: '' };
+  if (typeof value === 'string') return { en: value, fr: value };
+  return { en: value.en ?? '', fr: value.fr ?? '' };
+}
+
+function loc(value: L10n | undefined, lang: ContentLocale): string {
+  return asPair(value)[lang];
+}
+
+function setLoc(value: L10n | undefined, lang: ContentLocale, next: string): { en: string; fr: string } {
+  return { ...asPair(value), [lang]: next };
+}
+
+function csv(values?: string[]): string {
+  return (values ?? []).join(', ');
+}
+
+function parseCsv(raw: string): string[] {
+  return raw.split(',').map(part => part.trim()).filter(Boolean);
+}
+
+function hintSignalCount(hint?: FlowHint): number {
+  if (!hint) return 0;
+  return (['name', 'tech', 'layers', 'icons', 'avoid'] as const)
+    .reduce((n, key) => n + (hint[key]?.length ?? 0), 0);
+}
+
+function libraryPublishState(state: FlowLibraryState | null): 'draft' | 'modified' | 'published' {
+  if (!state) return 'published';
+  if (state.dirty) return 'modified';
+  if (state.publishedAt) return 'published';
+  return 'draft';
+}
+
+function localeFromField(field: string | null): ContentLocale | null {
+  if (!field) return null;
+  if (field.endsWith('.fr')) return 'fr';
+  if (field.endsWith('.en')) return 'en';
+  return null;
+}
+
+function blankStep(taken: string[]): FlowTemplateStep {
+  const key = slugify('New step', taken);
+  return {
+    key,
+    title: { en: 'New step', fr: 'Nouvelle étape' },
+    hint: { name: [key] },
+  };
+}
+
+function stepIndexForField(field: string | null, steps: FlowTemplateStep[]): number | null {
+  if (!field) return null;
+  if (field === 'steps') return 0;
+  const indexed = field.match(/^steps\.(\d+)\./);
+  if (indexed) return Number(indexed[1]);
+  const keyed = field.match(/^steps\.([^.]+)\./);
+  if (!keyed) return null;
+  const idx = steps.findIndex(step => step.key === keyed[1]);
+  return idx >= 0 ? idx : null;
+}
+
+function StepEditor({
+  step,
+  index,
+  locale,
+  open,
+  canRemove,
+  isFirst,
+  isLast,
+  onToggle,
+  onChange,
+  onMoveUp,
+  onMoveDown,
+  onRemove,
+}: {
+  step: FlowTemplateStep;
+  index: number;
+  locale: ContentLocale;
+  open: boolean;
+  canRemove: boolean;
+  isFirst: boolean;
+  isLast: boolean;
+  onToggle: () => void;
+  onChange: (next: FlowTemplateStep) => void;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+  onRemove: () => void;
+}) {
+  const hint: FlowHint = step.hint ?? {};
+  const setHint = (field: keyof FlowHint, raw: string) => {
+    onChange({ ...step, hint: { ...hint, [field]: parseCsv(raw) } });
+  };
+  const signals = hintSignalCount(hint);
+
+  return (
+    <div className={`elist${open ? ' open' : ''}`}>
+      <div className="elist-head">
+        <button
+          type="button"
+          className="iconbtn twist"
+          aria-expanded={open}
+          onClick={onToggle}
+          title={open ? 'Collapse' : 'Expand'}
+        >
+          <Icon name="chevron" size={14} />
+        </button>
+        <span className="mono" style={{ fontSize: 10, color: 'var(--ink-3)', width: 18, textAlign: 'right', flex: 'none' }}>
+          {index + 1}
+        </span>
+        <button type="button" className="elist-name" onClick={onToggle}>
+          {loc(step.title, locale) || step.key}
+          {step.key ? <em> · {step.key}</em> : null}
+        </button>
+        <span className="count" title="Hint signals">{signals}</span>
+        <button type="button" className="iconbtn" title="Move up" disabled={isFirst} onClick={onMoveUp}>
+          <Icon name="chevron" size={13} style={{ transform: 'rotate(-90deg)' }} />
+        </button>
+        <button type="button" className="iconbtn" title="Move down" disabled={isLast} onClick={onMoveDown}>
+          <Icon name="chevron" size={13} style={{ transform: 'rotate(90deg)' }} />
+        </button>
+        <button
+          type="button"
+          className="iconbtn danger"
+          title={canRemove ? 'Remove step' : 'A pattern needs at least two steps'}
+          disabled={!canRemove}
+          onClick={onRemove}
+        >
+          <Icon name="trash" size={14} />
+        </button>
+      </div>
+      {open && (
+        <div className="elist-body">
+          <div data-admin-field={`steps.${index}.key`}>
+            <label className="field">
+              <span>Key</span>
+              <input
+                className="input"
+                value={step.key}
+                readOnly
+                aria-readonly="true"
+                style={{ fontFamily: 'var(--mono)', fontSize: 12, color: 'var(--ink-3)' }}
+              />
+              <div className="hint">Set from the title when the step is added — then stable.</div>
+            </label>
+          </div>
+          <div data-admin-field={`steps.${step.key}.title`}>
+            <Text
+              label={`Title (${locale})`}
+              value={loc(step.title, locale)}
+              onChange={v => onChange({ ...step, title: setLoc(step.title, locale, v) })}
+            />
+          </div>
+          <Area
+            label={`Description (${locale})`}
+            value={loc(step.description, locale)}
+            onChange={v => onChange({ ...step, description: setLoc(step.description, locale, v) })}
+            minHeight={72}
+          />
+          <div data-admin-field={`steps.${step.key}.hint`}>
+            <Group title="Hints" hint="Comma-separated signals used at insert time.">
+              <div data-admin-field={`steps.${step.key}.hint.name`}>
+                <Area label="Name" value={csv(hint.name)} onChange={v => setHint('name', v)} />
+              </div>
+              <div data-admin-field={`steps.${step.key}.hint.tech`}>
+                <Area label="Tech" value={csv(hint.tech)} onChange={v => setHint('tech', v)} />
+              </div>
+              <div data-admin-field={`steps.${step.key}.hint.layers`}>
+                <Area label="Layers" value={csv(hint.layers)} onChange={v => setHint('layers', v)} />
+              </div>
+              <div data-admin-field={`steps.${step.key}.hint.icons`}>
+                <Area label="Icons" value={csv(hint.icons)} onChange={v => setHint('icons', v)} />
+              </div>
+              <div data-admin-field={`steps.${step.key}.hint.avoid`}>
+                <Area label="Avoid" value={csv(hint.avoid)} onChange={v => setHint('avoid', v)} />
+              </div>
+            </Group>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function BindingInspector({
+  patternId,
+  pattern,
+  locale,
+  preview,
+  onRefresh,
+}: {
+  patternId: string;
+  pattern: FlowTemplate;
+  locale: ContentLocale;
+  preview: FlowPreviewStats | null;
+  onRefresh: () => void;
+}) {
+  const mappable = preview?.mappableSteps ?? 0;
+  const matched = preview?.matchedOnDemo ?? 0;
+
+  return (
+    <aside className="inspector">
+      <div className="sub mono">{patternId}</div>
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginBottom: 4 }}>
+        <h3 style={{ margin: 0, flex: 1 }}>Binding preview</h3>
+        <button type="button" className="btn sm" onClick={onRefresh}>Refresh</button>
+      </div>
+      <p className="hint" style={{ marginTop: 0 }}>
+        Scored against the Acme demo at insert time.
+      </p>
+
+      {preview ? (
+        <>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr auto', gap: '8px 12px', fontSize: 13, marginTop: 12 }}>
+            <span className="hint">Steps</span>
+            <span className="count">{preview.stepCount}</span>
+            <span className="hint">Mappable</span>
+            <span className="count">{preview.mappableSteps}</span>
+            <span className="hint">Matched on demo</span>
+            <span className="count">{preview.matchedOnDemo}</span>
+          </div>
+          <p className="hint" style={{ marginTop: 12 }}>
+            {mappable === 0
+              ? 'No mappable steps — add at least one name or tech hint.'
+              : `${matched} of ${mappable} mappable steps found a component on the demo canvas.`}
+          </p>
+        </>
+      ) : (
+        <p className="hint">Preview unavailable.</p>
+      )}
+
+      <div className="insp-sep" />
+      <div className="sect-label" style={{ paddingTop: 0 }}>Steps</div>
+      <div className="flowmap" style={{ marginTop: 6 }}>
+        {pattern.steps.map((step, index) => (
+          <div key={`${step.key}-${index}`} className="flowmap-row" style={{ gridTemplateColumns: '20px minmax(0, 1fr)' }}>
+            <span className="n">{index + 1}</span>
+            <div className="what">
+              <b>{loc(step.title, locale) || step.key}</b>
+              <em className="mono">{step.key}</em>
+            </div>
+          </div>
+        ))}
+      </div>
+    </aside>
+  );
+}
+
+export default function FlowPatternEditor({ patternId }: { patternId: string }) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const focusField = searchParams.get('field');
+  const [pattern, setPattern] = useState<FlowTemplate | null>(null);
+  const [locked, setLocked] = useState(false);
+  const [contentLocale, setContentLocale] = useState<ContentLocale>('en');
+  const [libraryState, setLibraryState] = useState<FlowLibraryState | null>(null);
+  const [saveState, setSaveState] = useState<CatalogSaveState>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [publishIssues, setPublishIssues] = useState<string[]>([]);
+  const [busy, setBusy] = useState(false);
+  const [busyDelete, setBusyDelete] = useState(false);
+  const [preview, setPreview] = useState<FlowPreviewStats | null>(null);
+  const [openSteps, setOpenSteps] = useState<Set<number>>(() => new Set([0]));
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+
+  const dirtyRef = useRef(false);
+  const syncingRef = useRef(false);
+
+  const reloadState = useCallback(async () => {
+    try {
+      setLibraryState(await fetchFlowPatternState());
+    } catch {
+      /* state endpoint optional during rollout */
+    }
+  }, []);
+
+  const reloadPattern = useCallback(async () => {
+    const [detail, list] = await Promise.all([
+      fetchFlowPattern(patternId),
+      fetchFlowPatterns().catch(() => ({ patterns: [] as { id: string; locked: boolean }[] })),
+    ]);
+    syncingRef.current = true;
+    setPattern(structuredClone(detail));
+    setLocked(list.patterns.some(item => item.id === patternId && item.locked));
+    dirtyRef.current = false;
+    setSaveState('idle');
+    const focused = stepIndexForField(focusField, detail.steps);
+    setOpenSteps(new Set([focused ?? 0]));
+    setTimeout(() => { syncingRef.current = false; }, 0);
+  }, [patternId, focusField]);
+
+  useEffect(() => {
+    Promise.all([reloadPattern(), reloadState()])
+      .catch(err => setError(err instanceof Error ? err.message : 'Failed to load flow pattern'));
+  }, [reloadPattern, reloadState]);
+
+  const reloadPreview = useCallback(async () => {
+    try {
+      setPreview(await fetchFlowPatternPreview(patternId, contentLocale));
+    } catch {
+      setPreview(null);
+    }
+  }, [patternId, contentLocale]);
+
+  useEffect(() => {
+    void reloadPreview();
+  }, [reloadPreview]);
+
+  useEffect(() => {
+    if (saveState === 'saved') void reloadPreview();
+  }, [saveState, reloadPreview]);
+
+  useEffect(() => {
+    const lang = localeFromField(focusField);
+    if (lang) setContentLocale(lang);
+  }, [focusField]);
+
+  useEffect(() => {
+    if (!focusField || !pattern) return;
+    const t = window.setTimeout(() => {
+      const root = document.querySelector(`[data-admin-field="${focusField}"]`);
+      if (!(root instanceof HTMLElement)) return;
+      root.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      root.style.outline = '2px solid var(--brand)';
+      root.style.outlineOffset = '2px';
+      const input = root.querySelector('textarea, input:not([readonly]), select');
+      if (input instanceof HTMLElement) input.focus();
+    }, 120);
+    return () => window.clearTimeout(t);
+  }, [focusField, pattern, contentLocale, openSteps]);
+
+  const markDirty = useCallback(() => {
+    if (syncingRef.current) return;
+    dirtyRef.current = true;
+    if (saveState !== 'dirty' && saveState !== 'saving') setSaveState('dirty');
+  }, [saveState]);
+
+  const setDraft: Mut<FlowTemplate> = useCallback((fn) => {
+    setPattern(prev => {
+      if (!prev) return prev;
+      const next = structuredClone(prev);
+      fn(next);
+      return next;
+    });
+    markDirty();
+  }, [markDirty]);
+
+  useEffect(() => {
+    if (!pattern || !dirtyRef.current || syncingRef.current) return;
+    setSaveState('saving');
+    const t = setTimeout(async () => {
+      try {
+        await updateFlowPattern(patternId, pattern);
+        dirtyRef.current = false;
+        setSaveState('saved');
+        await reloadState();
+        setTimeout(() => setSaveState('idle'), 1200);
+      } catch (e) {
+        setSaveState('error');
+        setError((e as Error).message);
+      }
+    }, 700);
+    return () => clearTimeout(t);
+  }, [pattern, patternId, reloadState]);
+
+  const handlePublish = async () => {
+    if (busy) return;
+    setBusy(true);
+    setPublishIssues([]);
+    setError(null);
+    try {
+      if (dirtyRef.current && pattern) {
+        await updateFlowPattern(patternId, pattern);
+        dirtyRef.current = false;
+      }
+      const result = await publishFlowPatterns();
+      if (!result.ok) {
+        setPublishIssues((result.issues ?? []).map(i => i.message));
+        return;
+      }
+      await reloadState();
+      await reloadPreview();
+      setSaveState('saved');
+      setTimeout(() => setSaveState('idle'), 1200);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  async function onDelete() {
+    const restore = locked
+      ? ' Deleting a catalogue recipe restores the seed on the next load.'
+      : ' This cannot be undone.';
+    if (!window.confirm(`Delete pattern "${patternId}" from the flow library?${restore}`)) return;
+    setBusyDelete(true);
+    setError(null);
+    try {
+      await deleteFlowPattern(patternId);
+      router.push('/admin/flows');
+    } catch (e) {
+      setError((e as Error).message);
+      setBusyDelete(false);
+    }
+  }
+
+  function addStep() {
+    const nextIndex = pattern?.steps.length ?? 0;
+    setDraft(d => {
+      d.steps.push(blankStep(d.steps.map(s => s.key)));
+    });
+    setOpenSteps(new Set([nextIndex]));
+  }
+
+  function removeStep(index: number) {
+    if (!pattern || pattern.steps.length <= 2) return;
+    const target = pattern.steps[index];
+    if (!window.confirm(`Remove step "${target.key}"? A pattern needs at least two steps.`)) return;
+    setDraft(d => {
+      d.steps.splice(index, 1);
+    });
+    setOpenSteps(prev => {
+      const next = new Set<number>();
+      for (const i of prev) {
+        if (i === index) continue;
+        next.add(i > index ? i - 1 : i);
+      }
+      return next.size ? next : new Set([0]);
+    });
+  }
+
+  function moveStep(index: number, delta: number) {
+    const dest = index + delta;
+    setDraft(d => {
+      if (dest < 0 || dest >= d.steps.length) return;
+      const [step] = d.steps.splice(index, 1);
+      d.steps.splice(dest, 0, step);
+    });
+    setOpenSteps(prev => {
+      const next = new Set<number>();
+      for (const i of prev) {
+        if (i === index) next.add(dest);
+        else if (i === dest) next.add(index);
+        else next.add(i);
+      }
+      return next;
+    });
+  }
+
+  const jsonPreview = useMemo(() => {
+    if (!pattern) return '';
+    return JSON.stringify(pattern, null, 2);
+  }, [pattern]);
+
+  if (error && !pattern) {
+    return <div className="warnbox" style={{ margin: 22 }}>{error}</div>;
+  }
+
+  if (!pattern) {
+    return <div className="empty">Loading flow pattern…</div>;
+  }
+
+  const publishState = libraryPublishState(libraryState);
+
+  return (
+    <div className="editor-body">
+      <div className="content-main">
+        <div className="cpanel">
+          <div className="cpanel-head">
+            <div>
+              <h2 className="mono" style={{ fontSize: 15 }}>{patternId}</h2>
+              <p className="hint">
+                {pattern.steps.length} steps
+                {locked
+                  ? ' · catalogue recipe — delete restores seed on next load'
+                  : ' · custom pattern'}
+              </p>
+            </div>
+            <div className="cpanel-actions">
+              <PublishBadge state={publishState} />
+              <CatalogSaveFlag state={saveState} />
+              <Link href="/admin/flows" className="btn sm">
+                <Icon name="back" size={13} />Library
+              </Link>
+              <button
+                type="button"
+                className="btn primary sm"
+                disabled={busy || saveState === 'saving'}
+                onClick={() => void handlePublish()}
+              >
+                {busy ? 'Publishing…' : 'Publish library'}
+              </button>
+              <button
+                type="button"
+                className="btn sm"
+                disabled={busyDelete || saveState === 'saving'}
+                onClick={() => void onDelete()}
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+
+          {error && <div className="warnbox" style={{ marginBottom: 12 }}>{error}</div>}
+          {publishIssues.length > 0 && (
+            <div className="warnbox" style={{ marginBottom: 12 }}>
+              <ul style={{ margin: 0, paddingLeft: 18 }}>
+                {publishIssues.map((msg, i) => <li key={i}>{msg}</li>)}
+              </ul>
+            </div>
+          )}
+
+          <div className="segmented" role="group" aria-label="Content locale" style={{ marginBottom: 14 }}>
+            <button
+              type="button"
+              aria-pressed={contentLocale === 'en'}
+              onClick={() => setContentLocale('en')}
+            >
+              EN
+            </button>
+            <button
+              type="button"
+              aria-pressed={contentLocale === 'fr'}
+              onClick={() => setContentLocale('fr')}
+            >
+              FR
+            </button>
+          </div>
+
+          <Group title="Identity">
+            <div data-admin-field="icon">
+              <IconPicker value={pattern.icon} onChange={v => setDraft(d => { d.icon = v; })} />
+            </div>
+            <div data-admin-field={contentLocale === 'fr' ? 'name.fr' : 'name.en'}>
+              <Text
+                label={`Name (${contentLocale})`}
+                value={loc(pattern.name, contentLocale)}
+                onChange={v => setDraft(d => { d.name = setLoc(d.name, contentLocale, v); })}
+              />
+            </div>
+            <div data-admin-field={contentLocale === 'fr' ? 'tagline.fr' : 'tagline.en'}>
+              <Text
+                label={`Tagline (${contentLocale})`}
+                value={loc(pattern.tagline, contentLocale)}
+                onChange={v => setDraft(d => { d.tagline = setLoc(d.tagline, contentLocale, v); })}
+              />
+            </div>
+            <Text
+              label={`Sub (${contentLocale})`}
+              value={loc(pattern.sub, contentLocale)}
+              onChange={v => setDraft(d => { d.sub = setLoc(d.sub, contentLocale, v); })}
+            />
+            <Area
+              label={`Note (${contentLocale})`}
+              value={loc(pattern.note, contentLocale)}
+              onChange={v => setDraft(d => { d.note = setLoc(d.note, contentLocale, v); })}
+              minHeight={80}
+            />
+          </Group>
+
+          <div className="insp-sep" />
+
+          <div data-admin-field="steps">
+            <Group title="Steps" hint="Add, remove, or reorder steps. Keys are set from the title when a step is added. At least two steps required.">
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                {pattern.steps.map((step, index) => (
+                  <StepEditor
+                    key={step.key}
+                    step={step}
+                    index={index}
+                    locale={contentLocale}
+                    open={openSteps.has(index)}
+                    canRemove={pattern.steps.length > 2}
+                    isFirst={index === 0}
+                    isLast={index === pattern.steps.length - 1}
+                    onToggle={() => setOpenSteps(prev => {
+                      const next = new Set(prev);
+                      if (next.has(index)) next.delete(index);
+                      else next.add(index);
+                      return next;
+                    })}
+                    onChange={next => setDraft(d => { d.steps[index] = next; })}
+                    onMoveUp={() => moveStep(index, -1)}
+                    onMoveDown={() => moveStep(index, 1)}
+                    onRemove={() => removeStep(index)}
+                  />
+                ))}
+              </div>
+              <button type="button" className="btn sm" style={{ marginTop: 8 }} onClick={addStep}>
+                <Icon name="plus" size={13} />Add step
+              </button>
+            </Group>
+          </div>
+
+          <div className="insp-sep" />
+
+          <div className={`elist${advancedOpen ? ' open' : ''}`}>
+            <div className="elist-head">
+              <button
+                type="button"
+                className="iconbtn twist"
+                aria-expanded={advancedOpen}
+                onClick={() => setAdvancedOpen(o => !o)}
+                title={advancedOpen ? 'Collapse' : 'Expand'}
+              >
+                <Icon name="chevron" size={14} />
+              </button>
+              <button type="button" className="elist-name" onClick={() => setAdvancedOpen(o => !o)}>
+                Advanced
+              </button>
+            </div>
+            {advancedOpen && (
+              <div className="elist-body">
+                <label className="field">
+                  <span>Pattern JSON (read-only)</span>
+                  <textarea
+                    className="textarea"
+                    readOnly
+                    value={jsonPreview}
+                    style={{ minHeight: 220, fontFamily: 'var(--mono)', fontSize: 11 }}
+                  />
+                </label>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <BindingInspector
+        patternId={patternId}
+        pattern={pattern}
+        locale={contentLocale}
+        preview={preview}
+        onRefresh={() => { void reloadPreview(); }}
+      />
+    </div>
+  );
+}

--- a/src/components/admin/IssueList.tsx
+++ b/src/components/admin/IssueList.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import Link from 'next/link';
+import type { CatalogIssue } from '@/lib/lego/admin-catalog';
+import { issueEditHref } from '@/lib/admin/issue-routes';
+
+export function IssueList({
+  issues,
+  title,
+  clickable = true,
+}: {
+  issues: CatalogIssue[];
+  title?: string;
+  clickable?: boolean;
+}) {
+  if (issues.length === 0) return null;
+
+  return (
+    <div className="warnbox">
+      {title && <b>{title}</b>}
+      <ul style={{ margin: title ? '8px 0 0' : 0, paddingLeft: 18 }}>
+        {issues.map((issue, i) => {
+          const href = clickable ? issueEditHref(issue) : null;
+          // Always suffix index — same code+entityId can appear twice (e.g. en+fr placeholders).
+          const key = `${issue.code}-${issue.entityId ?? ''}-${issue.field ?? ''}-${i}`;
+          return (
+            <li key={key} style={{ marginBottom: 6 }}>
+              {href ? (
+                <Link href={href}>{issue.message}</Link>
+              ) : (
+                <span>{issue.message}</span>
+              )}
+              {issue.field && (
+                <span className="hint"> — field: {issue.field}</span>
+              )}
+              {issue.entityId && (
+                <span className="mono" style={{ fontSize: 11, display: 'block', marginTop: 2 }}>
+                  {issue.entityId}
+                </span>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/admin/NewCatalogDialogs.tsx
+++ b/src/components/admin/NewCatalogDialogs.tsx
@@ -1,0 +1,402 @@
+'use client';
+
+import { useState, type ReactNode } from 'react';
+import { Choice, IconPicker, Text } from '@/components/editors/Fields';
+import {
+  createBrick,
+  createDependency,
+  createIntent,
+  createScope,
+  createTechnology,
+  createVariant,
+} from '@/lib/admin/catalog-entities';
+import {
+  DEPENDENCY_KINDS,
+  DEPENDENCY_STRENGTHS,
+  HOSTING_MODE_OPTIONS,
+  ModeChips,
+} from '@/components/admin/CatalogFormParts';
+
+function CatalogCreateDialog({
+  title,
+  lede,
+  busy,
+  error,
+  onClose,
+  onSubmit,
+  submitLabel,
+  children,
+}: {
+  title: string;
+  lede: string;
+  busy: boolean;
+  error: string;
+  onClose: () => void;
+  onSubmit: () => void;
+  submitLabel: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="modal-scrim" onClick={onClose}>
+      <div className="modal" onClick={e => e.stopPropagation()}>
+        <h2>{title}</h2>
+        <p className="lede">{lede}</p>
+        {children}
+        {error && <div className="err">{error}</div>}
+        <div className="modal-actions">
+          <button type="button" className="btn ghost" onClick={onClose}>Cancel</button>
+          <button type="button" className="btn primary" disabled={busy} onClick={onSubmit}>
+            {busy ? 'Creating…' : submitLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function NewScopeDialog({ onClose, onCreated }: {
+  onClose: () => void;
+  onCreated: (id: string) => void;
+}) {
+  const [id, setId] = useState('');
+  const [labelEn, setLabelEn] = useState('');
+  const [labelFr, setLabelFr] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+
+  async function submit() {
+    if (!labelEn.trim() || !labelFr.trim()) {
+      setError('English and French labels are required.');
+      return;
+    }
+    setBusy(true);
+    setError('');
+    try {
+      const res = await createScope({
+        id: id.trim() || undefined,
+        labelEn: labelEn.trim(),
+        labelFr: labelFr.trim(),
+      });
+      onCreated(res.scopeId);
+    } catch (e) {
+      setError((e as Error).message);
+      setBusy(false);
+    }
+  }
+
+  return (
+    <CatalogCreateDialog
+      title="New scope"
+      lede="Adds a placement scope with bilingual labels. Id defaults from the English label."
+      busy={busy}
+      error={error}
+      onClose={onClose}
+      onSubmit={() => void submit()}
+      submitLabel="Create scope"
+    >
+      <Text label="Label (EN)" value={labelEn} onChange={setLabelEn} placeholder="Product" />
+      <Text label="Label (FR)" value={labelFr} onChange={setLabelFr} placeholder="Produit" />
+      <Text label="Scope id (optional)" value={id} onChange={setId} mono placeholder="product" hint="Lowercase, hyphens." />
+    </CatalogCreateDialog>
+  );
+}
+
+export function NewIntentDialog({ onClose, onCreated }: {
+  onClose: () => void;
+  onCreated: (id: string) => void;
+}) {
+  const [id, setId] = useState('');
+  const [label, setLabel] = useState('');
+  const [modes, setModes] = useState<string[]>(['cloud']);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+
+  async function submit() {
+    if (!label.trim()) { setError('Label is required.'); return; }
+    if (modes.length === 0) { setError('Pick at least one hosting mode.'); return; }
+    setBusy(true);
+    setError('');
+    try {
+      const res = await createIntent({
+        id: id.trim() || undefined,
+        label: label.trim(),
+        modes,
+      });
+      onCreated(res.intentId);
+    } catch (e) {
+      setError((e as Error).message);
+      setBusy(false);
+    }
+  }
+
+  return (
+    <CatalogCreateDialog
+      title="New intent"
+      lede="Placement intent with hosting modes. Shapes can be edited after create."
+      busy={busy}
+      error={error}
+      onClose={onClose}
+      onSubmit={() => void submit()}
+      submitLabel="Create intent"
+    >
+      <Text label="Label" value={label} onChange={setLabel} placeholder="Identity provider" />
+      <ModeChips
+        modes={modes}
+        onToggle={mode => setModes(list => list.includes(mode) ? list.filter(m => m !== mode) : [...list, mode])}
+      />
+      <Text label="Intent id (optional)" value={id} onChange={setId} mono placeholder="identity" hint="Lowercase, hyphens." />
+    </CatalogCreateDialog>
+  );
+}
+
+export function NewVariantDialog({
+  intents,
+  bricks,
+  onClose,
+  onCreated,
+}: {
+  intents: string[];
+  bricks: string[];
+  onClose: () => void;
+  onCreated: (id: string) => void;
+}) {
+  const [id, setId] = useState('');
+  const [label, setLabel] = useState('');
+  const [intent, setIntent] = useState(intents[0] ?? '');
+  const [mode, setMode] = useState('cloud');
+  const [mapsTo, setMapsTo] = useState(bricks[0] ?? '');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+
+  async function submit() {
+    if (!label.trim()) { setError('Label is required.'); return; }
+    if (!intent) { setError('Intent is required.'); return; }
+    if (!mapsTo) { setError('Maps-to brick is required.'); return; }
+    setBusy(true);
+    setError('');
+    try {
+      const res = await createVariant({
+        id: id.trim() || undefined,
+        label: label.trim(),
+        intent,
+        mode: mode as 'client' | 'baas' | 'cloud' | 'selfhosted',
+        maps_to: mapsTo,
+      });
+      onCreated(res.variantId);
+    } catch (e) {
+      setError((e as Error).message);
+      setBusy(false);
+    }
+  }
+
+  return (
+    <CatalogCreateDialog
+      title="New variant"
+      lede="Maps an intent + hosting mode to a concrete brick."
+      busy={busy}
+      error={error}
+      onClose={onClose}
+      onSubmit={() => void submit()}
+      submitLabel="Create variant"
+    >
+      <Text label="Label" value={label} onChange={setLabel} placeholder="Auth0 (cloud)" />
+      <Choice
+        label="Intent"
+        value={intent}
+        onChange={setIntent}
+        options={intents.map(i => ({ value: i, label: i }))}
+      />
+      <Choice
+        label="Mode"
+        value={mode}
+        onChange={setMode}
+        options={HOSTING_MODE_OPTIONS.map(m => ({ value: m.value, label: m.label }))}
+      />
+      <Choice
+        label="Maps to brick"
+        value={mapsTo}
+        onChange={setMapsTo}
+        options={bricks.map(b => ({ value: b, label: b }))}
+      />
+      <Text label="Variant id (optional)" value={id} onChange={setId} mono placeholder="identity-auth0" />
+    </CatalogCreateDialog>
+  );
+}
+
+export function NewDependencyDialog({
+  bricks,
+  onClose,
+  onCreated,
+}: {
+  bricks: string[];
+  onClose: () => void;
+  onCreated: (from: string, to: string) => void;
+}) {
+  const [from, setFrom] = useState(bricks[0] ?? '');
+  const [to, setTo] = useState(bricks[1] ?? bricks[0] ?? '');
+  const [strength, setStrength] = useState('recommended');
+  const [kind, setKind] = useState('sync');
+  const [protocolId, setProtocolId] = useState('http');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+
+  async function submit() {
+    if (!from || !to) { setError('From and to bricks are required.'); return; }
+    if (from === to) { setError('Endpoints must differ.'); return; }
+    setBusy(true);
+    setError('');
+    try {
+      const res = await createDependency({
+        from,
+        to,
+        strength: strength as 'required' | 'recommended' | 'optional',
+        kind: kind as 'sync' | 'async' | 'batch',
+        protocol_id: protocolId.trim() || 'http',
+      });
+      onCreated(res.from, res.to);
+    } catch (e) {
+      setError((e as Error).message);
+      setBusy(false);
+    }
+  }
+
+  return (
+    <CatalogCreateDialog
+      title="New dependency"
+      lede="Suggestion edge between two bricks. Why copy can be refined in the inspector."
+      busy={busy}
+      error={error}
+      onClose={onClose}
+      onSubmit={() => void submit()}
+      submitLabel="Create dependency"
+    >
+      <Choice label="From brick" value={from} onChange={setFrom} options={bricks.map(b => ({ value: b, label: b }))} />
+      <Choice label="To brick" value={to} onChange={setTo} options={bricks.map(b => ({ value: b, label: b }))} />
+      <Choice label="Strength" value={strength} onChange={setStrength} options={DEPENDENCY_STRENGTHS} />
+      <Choice label="Kind" value={kind} onChange={setKind} options={DEPENDENCY_KINDS} />
+      <Text label="Protocol id" value={protocolId} onChange={setProtocolId} mono placeholder="http" />
+    </CatalogCreateDialog>
+  );
+}
+
+export function NewTechnologyDialog({ onClose, onCreated }: {
+  onClose: () => void;
+  onCreated: (key: string) => void;
+}) {
+  const [key, setKey] = useState('');
+  const [en, setEn] = useState('');
+  const [fr, setFr] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+
+  async function submit() {
+    if (!en.trim() || !fr.trim()) {
+      setError('English and French descriptions are required.');
+      return;
+    }
+    setBusy(true);
+    setError('');
+    try {
+      const res = await createTechnology({
+        key: key.trim() || undefined,
+        en: en.trim(),
+        fr: fr.trim(),
+      });
+      onCreated(res.key);
+    } catch (e) {
+      setError((e as Error).message);
+      setBusy(false);
+    }
+  }
+
+  return (
+    <CatalogCreateDialog
+      title="New technology"
+      lede="Stack description key used by brick glossaries and ADD copy."
+      busy={busy}
+      error={error}
+      onClose={onClose}
+      onSubmit={() => void submit()}
+      submitLabel="Create technology"
+    >
+      <Text label="Key (optional)" value={key} onChange={setKey} mono placeholder="auth0" hint="Lowercase, hyphens. Defaults from EN copy." />
+      <label className="field">
+        <span>Description (EN)</span>
+        <textarea className="textarea" value={en} onChange={e => setEn(e.target.value)} style={{ minHeight: 72 }} />
+      </label>
+      <label className="field">
+        <span>Description (FR)</span>
+        <textarea className="textarea" value={fr} onChange={e => setFr(e.target.value)} style={{ minHeight: 72 }} />
+      </label>
+    </CatalogCreateDialog>
+  );
+}
+
+export function NewBrickDialog({
+  scopes,
+  layers,
+  onClose,
+  onCreated,
+}: {
+  scopes: { value: string; label: string }[];
+  layers: { value: string; label: string }[];
+  onClose: () => void;
+  onCreated: (id: string) => void;
+}) {
+  const [id, setId] = useState('');
+  const [icon, setIcon] = useState('box');
+  const [layer, setLayer] = useState(layers[0]?.value ?? 'services');
+  const [defaultScope, setDefaultScope] = useState(scopes[0]?.value ?? '');
+  const [roleEn, setRoleEn] = useState('');
+  const [roleFr, setRoleFr] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+
+  async function submit() {
+    if (!roleEn.trim() || !roleFr.trim()) {
+      setError('English and French roles are required.');
+      return;
+    }
+    if (!defaultScope) {
+      setError('Default scope is required.');
+      return;
+    }
+    setBusy(true);
+    setError('');
+    try {
+      const res = await createBrick({
+        id: id.trim() || undefined,
+        icon,
+        layer,
+        defaultScope,
+        roleEn: roleEn.trim(),
+        roleFr: roleFr.trim(),
+        purposeEn: roleEn.trim(),
+        purposeFr: roleFr.trim(),
+      });
+      onCreated(res.brickId);
+    } catch (e) {
+      setError((e as Error).message);
+      setBusy(false);
+    }
+  }
+
+  return (
+    <CatalogCreateDialog
+      title="New brick"
+      lede="Creates a Lego brick with EN/FR role. Refine purpose and tags on the fiche."
+      busy={busy}
+      error={error}
+      onClose={onClose}
+      onSubmit={() => void submit()}
+      submitLabel="Create brick"
+    >
+      <IconPicker value={icon} onChange={setIcon} />
+      <Text label="Role (EN)" value={roleEn} onChange={setRoleEn} placeholder="Provides identity for this architecture." />
+      <Text label="Role (FR)" value={roleFr} onChange={setRoleFr} placeholder="Fournit l’identité dans cette architecture." />
+      <Choice label="Layer" value={layer} onChange={setLayer} options={layers} />
+      <Choice label="Default scope" value={defaultScope} onChange={setDefaultScope} options={scopes} />
+      <Text label="Brick id (optional)" value={id} onChange={setId} mono placeholder="identity-custom" />
+    </CatalogCreateDialog>
+  );
+}

--- a/src/components/admin/NewCloudServiceDialog.tsx
+++ b/src/components/admin/NewCloudServiceDialog.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useState } from 'react';
+import { createCloudService } from '@/lib/admin/cloud';
+
+export function NewCloudServiceDialog({ onClose, onCreated }: {
+  onClose: () => void;
+  onCreated: (roleKey: string) => void;
+}) {
+  const [roleKey, setRoleKey] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+
+  async function submit() {
+    const key = roleKey.trim();
+    if (!key) { setError('Role key is required.'); return; }
+    setBusy(true);
+    setError('');
+    try {
+      const created = await createCloudService({
+        roleKey: key,
+        payload: {
+          aws: { name: key },
+          gcp: { name: key },
+          azure: { name: key },
+          selfhosted: { name: key },
+        },
+      });
+      onCreated(created.roleKey);
+    } catch (e) {
+      setError((e as Error).message);
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="modal-scrim" onClick={onClose}>
+      <div className="modal" onClick={e => e.stopPropagation()}>
+        <h2>New cloud service role</h2>
+        <p className="lede">Adds a correspondence row — one cell per hyperscaler plus self-hosted.</p>
+        <label className="field">
+          <span>Role key</span>
+          <input
+            className="input mono"
+            autoFocus
+            value={roleKey}
+            onChange={e => setRoleKey(e.target.value)}
+            onKeyDown={e => { if (e.key === 'Enter') void submit(); }}
+            placeholder="messageQueue"
+          />
+          <span className="hint">camelCase. Seeded keys reappear on next ensure if deleted.</span>
+        </label>
+        {error && <div className="err">{error}</div>}
+        <div className="modal-actions">
+          <button type="button" className="btn ghost" onClick={onClose}>Cancel</button>
+          <button type="button" className="btn primary" disabled={busy} onClick={() => void submit()}>
+            {busy ? 'Creating…' : 'Create role'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/NewFlowDialog.tsx
+++ b/src/components/admin/NewFlowDialog.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useState } from 'react';
+import { IconPicker } from '@/components/editors/Fields';
+import { createFlowPattern } from '@/lib/admin/flows';
+
+export function NewFlowDialog({ onClose, onCreated }: {
+  onClose: () => void;
+  onCreated: (id: string) => void;
+}) {
+  const [nameEn, setNameEn] = useState('');
+  const [nameFr, setNameFr] = useState('');
+  const [taglineEn, setTaglineEn] = useState('');
+  const [taglineFr, setTaglineFr] = useState('');
+  const [icon, setIcon] = useState('route');
+  const [id, setId] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+
+  async function submit() {
+    if (!nameEn.trim()) { setError('English name is required.'); return; }
+    setBusy(true);
+    setError('');
+    try {
+      const res = await createFlowPattern({
+        id: id.trim() || undefined,
+        icon: icon || 'route',
+        nameEn: nameEn.trim(),
+        nameFr: nameFr.trim() || undefined,
+        taglineEn: taglineEn.trim() || undefined,
+        taglineFr: taglineFr.trim() || undefined,
+      });
+      onCreated(res.id);
+    } catch (e) {
+      setError((e as Error).message);
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="modal-scrim" onClick={onClose}>
+      <div className="modal" onClick={e => e.stopPropagation()}>
+        <h2>New flow pattern</h2>
+        <p className="lede">Creates a custom recipe with a start and end step. Catalogue recipes stay locked and re-seed if deleted.</p>
+        <IconPicker value={icon} onChange={setIcon} />
+        <label className="field"><span>Name (EN)</span>
+          <input className="input" autoFocus value={nameEn} onChange={e => setNameEn(e.target.value)} placeholder="Incident response" />
+        </label>
+        <label className="field"><span>Name (FR, optional)</span>
+          <input className="input" value={nameFr} onChange={e => setNameFr(e.target.value)} placeholder="Réponse incident" />
+        </label>
+        <label className="field"><span>Tagline (EN, optional)</span>
+          <input className="input" value={taglineEn} onChange={e => setTaglineEn(e.target.value)} placeholder="Detect, contain, recover" />
+        </label>
+        <label className="field"><span>Tagline (FR, optional)</span>
+          <input className="input" value={taglineFr} onChange={e => setTaglineFr(e.target.value)} placeholder="Détecter, contenir, rétablir" />
+        </label>
+        <label className="field"><span>Pattern id (optional)</span>
+          <input className="input mono" value={id} onChange={e => setId(e.target.value)} placeholder="incident-response" />
+          <span className="hint">Lowercase, hyphens. Defaults from the English name.</span>
+        </label>
+        {error && <div className="err">{error}</div>}
+        <div className="modal-actions">
+          <button type="button" className="btn ghost" onClick={onClose}>Cancel</button>
+          <button type="button" className="btn primary" disabled={busy} onClick={submit}>
+            {busy ? 'Creating…' : 'Create pattern'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/NewSectionDialog.tsx
+++ b/src/components/admin/NewSectionDialog.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useState } from 'react';
+import { SECTION_TYPES } from '@/lib/defaults';
+import { createSection } from '@/lib/admin/sections';
+import type { SectionType } from '@/lib/types';
+
+export function NewSectionDialog({ onClose, onCreated }: {
+  onClose: () => void;
+  onCreated: (id: string) => void;
+}) {
+  const [type, setType] = useState<SectionType>('cards');
+  const [id, setId] = useState('');
+  const [titleEn, setTitleEn] = useState('');
+  const [titleFr, setTitleFr] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+
+  async function submit() {
+    if (!titleEn.trim()) { setError('English title is required.'); return; }
+    setBusy(true);
+    setError('');
+    try {
+      const res = await createSection({
+        id: id.trim() || undefined,
+        type,
+        titleEn: titleEn.trim(),
+        titleFr: titleFr.trim() || undefined,
+      });
+      onCreated(res.id);
+    } catch (e) {
+      setError((e as Error).message);
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="modal-scrim" onClick={onClose}>
+      <div className="modal" onClick={e => e.stopPropagation()}>
+        <h2>New ADD section</h2>
+        <p className="lede">Creates a reusable chapter for templates and the preset pack.</p>
+        <label className="field"><span>Type</span>
+          <select className="select" value={type} onChange={e => setType(e.target.value as SectionType)}>
+            {SECTION_TYPES.map(t => (
+              <option key={t.type} value={t.type}>{t.label}</option>
+            ))}
+          </select>
+        </label>
+        <label className="field"><span>Title (EN)</span>
+          <input className="input" autoFocus value={titleEn} onChange={e => setTitleEn(e.target.value)} placeholder="Operations runbook" />
+        </label>
+        <label className="field"><span>Title (FR, optional)</span>
+          <input className="input" value={titleFr} onChange={e => setTitleFr(e.target.value)} placeholder="Runbook opérations" />
+        </label>
+        <label className="field"><span>Section id (optional)</span>
+          <input className="input mono" value={id} onChange={e => setId(e.target.value)} placeholder="operations-runbook" />
+          <span className="hint">Lowercase, hyphens. Defaults from the English title.</span>
+        </label>
+        {error && <div className="err">{error}</div>}
+        <div className="modal-actions">
+          <button type="button" className="btn ghost" onClick={onClose}>Cancel</button>
+          <button type="button" className="btn primary" disabled={busy} onClick={submit}>
+            {busy ? 'Creating…' : 'Create section'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/NewTemplateDialog.tsx
+++ b/src/components/admin/NewTemplateDialog.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { useState } from 'react';
+import { createArchitectureTemplate } from '@/lib/admin/architecture';
+import { createTemplate } from '@/lib/admin/templates';
+
+type TemplateKind = 'project' | 'architecture';
+
+export function NewTemplateDialog({ onClose, onCreated }: {
+  onClose: () => void;
+  onCreated: (id: string) => void;
+}) {
+  const [kind, setKind] = useState<TemplateKind>('project');
+  const [id, setId] = useState('');
+  const [nameEn, setNameEn] = useState('');
+  const [nameFr, setNameFr] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+
+  async function submit() {
+    if (!nameEn.trim()) { setError('English name is required.'); return; }
+    setBusy(true); setError('');
+    try {
+      const body = {
+        id: id.trim() || nameEn.trim(),
+        nameEn: nameEn.trim(),
+        nameFr: nameFr.trim() || undefined,
+      };
+      const res = kind === 'architecture'
+        ? await createArchitectureTemplate(body)
+        : await createTemplate(body);
+      onCreated(res.id);
+    } catch (e) {
+      setError((e as Error).message);
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="modal-scrim" onClick={onClose}>
+      <div className="modal" onClick={e => e.stopPropagation()}>
+        <div className="modal-head">
+          <div>
+            <h2>Create template</h2>
+            <p className="lede">
+              {kind === 'project'
+                ? 'Editable project snapshot for the atelier.'
+                : 'Hyperscaler pattern — agnostic preview, per-cloud JSON under Advanced.'}
+            </p>
+          </div>
+          <div className="segmented" role="group" aria-label="Template kind">
+            <button type="button" aria-pressed={kind === 'project'} onClick={() => setKind('project')}>
+              Project
+            </button>
+            <button type="button" aria-pressed={kind === 'architecture'} onClick={() => setKind('architecture')}>
+              Architecture
+            </button>
+          </div>
+        </div>
+        <label className="field"><span>English name</span>
+          <input className="input" autoFocus value={nameEn} onChange={e => setNameEn(e.target.value)} placeholder="Payments platform" />
+        </label>
+        <label className="field"><span>French name (optional)</span>
+          <input className="input" value={nameFr} onChange={e => setNameFr(e.target.value)} placeholder="Plateforme paiements" />
+        </label>
+        <label className="field"><span>Template id (optional)</span>
+          <input className="input mono" value={id} onChange={e => setId(e.target.value)} placeholder="payments-v1" />
+          <span className="hint">Lowercase, hyphens. Defaults from the English name.</span>
+        </label>
+        {error && <div className="err">{error}</div>}
+        <div className="modal-actions">
+          <button type="button" className="btn ghost" onClick={onClose}>Cancel</button>
+          <button type="button" className="btn primary" disabled={busy} onClick={submit}>
+            {busy ? 'Creating…' : 'Create'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/ProjectTemplateEditor.tsx
+++ b/src/components/admin/ProjectTemplateEditor.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
+import { TemplateAddPanel } from '@/components/admin/TemplateAddPanel';
+import { TemplateDiagramPanel } from '@/components/admin/TemplateDiagramPanel';
+import { TemplateEditorShell, type TemplateEditorTab } from '@/components/admin/TemplateEditorShell';
+import { TemplateFlowsPanel } from '@/components/admin/TemplateFlowsPanel';
+import { TemplatePreviewPane } from '@/components/admin/TemplatePreviewPane';
+import { CatalogSaveFlag, type CatalogSaveState } from '@/components/admin/CatalogList';
+import { normalizeArchitecture } from '@/lib/defaults';
+import { updateTemplate } from '@/lib/admin/templates';
+import type { TemplateDetail } from '@/lib/admin/templates';
+import type { Architecture } from '@/lib/types';
+
+type Patch = (fn: (d: Architecture) => Architecture) => void;
+
+export function ProjectTemplateEditor({
+  tpl,
+  editable,
+  metadata,
+  header,
+  onSnapshotSaved,
+  onSnapshotError,
+}: {
+  tpl: TemplateDetail & { snapshot?: Architecture };
+  editable: boolean;
+  metadata: ReactNode;
+  header: {
+    title: string;
+    subtitle?: string;
+    badge?: ReactNode;
+    actions?: ReactNode;
+  };
+  onSnapshotSaved?: () => void;
+  onSnapshotError?: (message: string) => void;
+}) {
+  const [snapshot, setSnapshot] = useState<Architecture | null>(tpl.snapshot ?? null);
+  const [saveState, setSaveState] = useState<CatalogSaveState>('idle');
+  const dirtyRef = useRef(false);
+  const syncingRef = useRef(false);
+
+  useEffect(() => {
+    syncingRef.current = true;
+    setSnapshot(tpl.snapshot ?? null);
+    dirtyRef.current = false;
+    const t = setTimeout(() => { syncingRef.current = false; }, 0);
+    return () => clearTimeout(t);
+  }, [tpl.id]); // snapshot resync via `key` from parent after JSON import
+
+  const patch: Patch = useCallback((fn) => {
+    if (!editable) return;
+    setSnapshot(prev => {
+      if (!prev) return prev;
+      dirtyRef.current = true;
+      return normalizeArchitecture(fn(structuredClone(prev)));
+    });
+  }, [editable]);
+
+  useEffect(() => {
+    if (!editable || !snapshot || !dirtyRef.current || syncingRef.current) return;
+    setSaveState('saving');
+    const t = setTimeout(async () => {
+      try {
+        await updateTemplate(tpl.id, { snapshot });
+        dirtyRef.current = false;
+        setSaveState('saved');
+        onSnapshotSaved?.();
+        setTimeout(() => setSaveState('idle'), 1200);
+      } catch (e) {
+        setSaveState('error');
+        onSnapshotError?.((e as Error).message);
+      }
+    }, 700);
+    return () => clearTimeout(t);
+  }, [snapshot, editable, tpl.id, onSnapshotSaved, onSnapshotError]);
+
+  const readOnly = !editable;
+  const doc = snapshot;
+  const noopPatch: Patch = () => {};
+
+  const counts = doc
+    ? {
+        components: doc.components?.length ?? 0,
+        sections: doc.sections?.length ?? 0,
+        flows: doc.flows?.length ?? 0,
+      }
+    : { components: tpl.outline.componentCount, sections: tpl.outline.sectionIds.length, flows: tpl.outline.flowCount };
+
+  const readOnlyHint = (
+    <>
+      Architecture pattern — view only. Edit in <span className="mono">src/lib/templates/</span> or wait for M5.
+    </>
+  );
+
+  const panels: Partial<Record<TemplateEditorTab, ReactNode>> = doc
+    ? {
+        diagram: (
+          <TemplateDiagramPanel
+            doc={doc}
+            patch={readOnly ? noopPatch : patch}
+            readOnly={readOnly}
+            hint={readOnly ? readOnlyHint : undefined}
+          />
+        ),
+        flows: (
+          <TemplateFlowsPanel
+            doc={doc}
+            patch={readOnly ? noopPatch : patch}
+            readOnly={readOnly}
+            hint={readOnly ? readOnlyHint : undefined}
+          />
+        ),
+        add: (
+          <TemplateAddPanel
+            doc={doc}
+            patch={readOnly ? noopPatch : patch}
+            readOnly={readOnly}
+            hint={readOnly ? readOnlyHint : undefined}
+            onError={onSnapshotError}
+          />
+        ),
+        preview: (
+          <TemplatePreviewPane templateId={tpl.id} snapshot={doc} saveState={saveState} variant="full" />
+        ),
+      }
+    : {
+        diagram: <div className="empty">No snapshot loaded.</div>,
+        flows: <div className="empty">No snapshot loaded.</div>,
+        add: <div className="empty">No snapshot loaded.</div>,
+        preview: <div className="empty">No snapshot loaded.</div>,
+      };
+
+  const actions = (
+    <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+      {editable && <CatalogSaveFlag state={saveState} />}
+      {header.actions}
+    </div>
+  );
+
+  return (
+    <TemplateEditorShell
+      templateId={tpl.id}
+      title={header.title}
+      subtitle={header.subtitle}
+      badge={header.badge}
+      actions={actions}
+      counts={counts}
+      metadata={metadata}
+      panels={panels}
+      inspectorPreview={
+        doc ? (
+          <div className="inspector-preview">
+            <TemplatePreviewPane
+              templateId={tpl.id}
+              snapshot={doc}
+              saveState={saveState}
+              variant="compact"
+            />
+          </div>
+        ) : undefined
+      }
+    />
+  );
+}

--- a/src/components/admin/PublishBadge.tsx
+++ b/src/components/admin/PublishBadge.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+export type PublishState = 'draft' | 'modified' | 'published';
+
+const LABELS: Record<PublishState, string> = {
+  draft: 'Draft',
+  modified: 'Modified',
+  published: 'Published',
+};
+
+const ARIA: Record<PublishState, string> = {
+  draft: 'Publication state: Draft',
+  modified: 'Publication state: Modified',
+  published: 'Publication state: Published',
+};
+
+export function PublishBadge({ state }: { state: PublishState }) {
+  if (state === 'modified') {
+    return (
+      <span
+        className="btn sm"
+        role="status"
+        aria-label={ARIA.modified}
+        style={{ borderColor: 'var(--brand)', color: 'var(--brand-ink)' }}
+      >
+        {LABELS.modified}
+      </span>
+    );
+  }
+  if (state === 'published') {
+    return (
+      <span
+        className="btn sm"
+        role="status"
+        aria-label={ARIA.published}
+        style={{ borderColor: 'var(--ok)', color: 'var(--ok)' }}
+      >
+        {LABELS.published}
+      </span>
+    );
+  }
+  return (
+    <span className="btn sm" role="status" aria-label={ARIA.draft} style={{ color: 'var(--ink-2)' }}>
+      {LABELS.draft}
+    </span>
+  );
+}

--- a/src/components/admin/PublishWizard.tsx
+++ b/src/components/admin/PublishWizard.tsx
@@ -1,0 +1,333 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  fetchCatalogState,
+  publishCatalog,
+  type CatalogState,
+} from '@/lib/admin/catalog';
+import {
+  fetchProjectTemplateState,
+  publishProjectTemplates,
+  type ProjectTemplateState,
+} from '@/lib/admin/templates';
+import {
+  fetchArchitectureTemplateState,
+  publishArchitectureTemplates,
+  type ArchitectureLibraryState,
+} from '@/lib/admin/architecture';
+import {
+  fetchSectionState,
+  publishSections,
+  type SectionLibraryState,
+} from '@/lib/admin/sections';
+import {
+  fetchFlowPatternState,
+  publishFlowPatterns,
+  type FlowLibraryState,
+} from '@/lib/admin/flows';
+import {
+  fetchCloudServicesState,
+  publishCloudServices,
+  type CloudServiceAdminState,
+} from '@/lib/admin/cloud';
+import {
+  fetchSystemCopyState,
+  publishSystemCopy,
+  type SystemCopyAdminState,
+} from '@/lib/admin/copy';
+import type { CatalogIssue } from '@/lib/lego/admin-catalog';
+import {
+  domainsForScope,
+  filterIssuesByScope,
+  type PublishDomainSource,
+  type PublishScope,
+} from '@/lib/admin/publish';
+import { IssueList } from '@/components/admin/IssueList';
+import { PublishBadge } from '@/components/admin/PublishBadge';
+
+function publishBadgeState(dirty: boolean, publishedAt: string | null): 'draft' | 'modified' | 'published' {
+  if (dirty) return 'modified';
+  if (publishedAt) return 'published';
+  return 'draft';
+}
+
+const SCOPE_OPTIONS: { id: PublishScope; label: string; hint: string }[] = [
+  { id: 'all', label: 'All', hint: 'Every content domain, in order' },
+  { id: 'catalog', label: 'Catalogue', hint: 'Lego bricks, variants, dependencies' },
+  { id: 'templates', label: 'Project templates', hint: 'Project template snapshot' },
+  { id: 'architecture', label: 'Architecture', hint: 'Architecture templates library' },
+  { id: 'sections', label: 'ADD sections', hint: 'Document section presets' },
+  { id: 'flows', label: 'Flow patterns', hint: 'Journey pattern library' },
+  { id: 'cloud', label: 'Cloud services', hint: 'Provider service matrix' },
+  { id: 'system_copy', label: 'System copy', hint: 'Locale strings & layer labels' },
+];
+
+type DomainBundle = {
+  catalog: CatalogState;
+  templates: ProjectTemplateState;
+  architecture: ArchitectureLibraryState;
+  sections: SectionLibraryState;
+  flows: FlowLibraryState;
+  cloud: CloudServiceAdminState;
+  system_copy: SystemCopyAdminState;
+};
+
+type PublishFnResult =
+  | { ok: true; publishedAt: string }
+  | { ok: false; error?: string; issues: CatalogIssue[] };
+
+async function publishDomain(source: PublishDomainSource): Promise<PublishFnResult> {
+  switch (source) {
+    case 'catalog':
+      return publishCatalog();
+    case 'templates':
+      return publishProjectTemplates();
+    case 'architecture':
+      return publishArchitectureTemplates();
+    case 'sections':
+      return publishSections();
+    case 'flows':
+      return publishFlowPatterns();
+    case 'cloud':
+      return publishCloudServices();
+    case 'system_copy':
+      return publishSystemCopy();
+  }
+}
+
+function domainLabel(source: PublishDomainSource): string {
+  return SCOPE_OPTIONS.find(o => o.id === source)?.label ?? source;
+}
+
+function domainSummary(source: PublishDomainSource, bundle: DomainBundle): string {
+  switch (source) {
+    case 'catalog':
+      return `version ${bundle.catalog.version}${bundle.catalog.publishedAt ? ` · last ${bundle.catalog.publishedAt}` : ''}`;
+    case 'templates':
+      return `${bundle.templates.templateCount} templates${bundle.templates.publishedAt ? ` · last ${bundle.templates.publishedAt}` : ''}`;
+    case 'architecture':
+      return `${bundle.architecture.templateCount} templates${bundle.architecture.publishedAt ? ` · last ${bundle.architecture.publishedAt}` : ''}`;
+    case 'sections':
+      return `${bundle.sections.sectionCount} sections${bundle.sections.publishedAt ? ` · last ${bundle.sections.publishedAt}` : ''}`;
+    case 'flows':
+      return `${bundle.flows.patternCount} patterns${bundle.flows.publishedAt ? ` · last ${bundle.flows.publishedAt}` : ''}`;
+    case 'cloud':
+      return `${bundle.cloud.serviceCount} services${bundle.cloud.publishedAt ? ` · last ${bundle.cloud.publishedAt}` : ''}`;
+    case 'system_copy':
+      return `${bundle.system_copy.keyCount} keys${bundle.system_copy.publishedAt ? ` · last ${bundle.system_copy.publishedAt}` : ''}`;
+  }
+}
+
+function domainDirty(source: PublishDomainSource, bundle: DomainBundle): boolean {
+  return bundle[source].dirty;
+}
+
+function domainPublishedAt(source: PublishDomainSource, bundle: DomainBundle): string | null {
+  return bundle[source].publishedAt;
+}
+
+function domainIssues(source: PublishDomainSource, bundle: DomainBundle): CatalogIssue[] {
+  return bundle[source].issues ?? [];
+}
+
+export function PublishWizard() {
+  const [scope, setScope] = useState<PublishScope>('all');
+  const [bundle, setBundle] = useState<DomainBundle | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [publishError, setPublishError] = useState<string | null>(null);
+  const [publishIssues, setPublishIssues] = useState<CatalogIssue[]>([]);
+  const [publishedAt, setPublishedAt] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const [catalog, templates, architecture, sections, flows, cloud, system_copy] = await Promise.all([
+        fetchCatalogState({ validate: true }),
+        fetchProjectTemplateState({ validate: true }),
+        fetchArchitectureTemplateState({ validate: true }),
+        fetchSectionState({ validate: true }),
+        fetchFlowPatternState({ validate: true }),
+        fetchCloudServicesState({ validate: true }),
+        fetchSystemCopyState({ validate: true }),
+      ]);
+      setBundle({ catalog, templates, architecture, sections, flows, cloud, system_copy });
+      setLoadError(null);
+    } catch (err) {
+      setLoadError(err instanceof Error ? err.message : 'Failed to load publish state');
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const selectedDomains = useMemo(() => domainsForScope(scope), [scope]);
+
+  const validationIssues = useMemo(() => {
+    if (publishIssues.length > 0) return publishIssues;
+    if (!bundle) return [];
+    return selectedDomains.flatMap(source =>
+      filterIssuesByScope(domainIssues(source, bundle), scope, source),
+    );
+  }, [bundle, scope, selectedDomains, publishIssues]);
+
+  const blocked = validationIssues.length > 0;
+
+  const handlePublish = async () => {
+    setBusy(true);
+    setPublishError(null);
+    setPublishIssues([]);
+    setPublishedAt(null);
+    try {
+      let lastPublished: string | null = null;
+      for (const source of selectedDomains) {
+        const result = await publishDomain(source);
+        if (!result.ok) {
+          setPublishIssues(result.issues);
+          setPublishError(result.error || `${domainLabel(source)} publish blocked`);
+          return;
+        }
+        lastPublished = result.publishedAt;
+      }
+      setPublishedAt(lastPublished);
+      await load();
+    } catch (err) {
+      setPublishError(err instanceof Error ? err.message : 'Publish failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleCancel = () => {
+    setPublishError(null);
+    setPublishIssues([]);
+    setPublishedAt(null);
+    void load();
+  };
+
+  if (publishedAt) {
+    return (
+      <div className="empty" style={{ padding: '32px 0' }}>
+        Published successfully
+        <div className="mono hint" style={{ marginTop: 8, fontSize: 11 }}>
+          {publishedAt}
+        </div>
+        <button
+          type="button"
+          className="btn ghost sm"
+          style={{ marginTop: 16 }}
+          onClick={() => {
+            setPublishedAt(null);
+            void load();
+          }}
+        >
+          Publish again
+        </button>
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return <div className="warnbox">{loadError}</div>;
+  }
+
+  if (!bundle) {
+    return <div className="empty">Loading publish state…</div>;
+  }
+
+  return (
+    <div className="flowmap">
+      <div className="flowmap-row">
+        <i className="n">1</i>
+        <div className="what" style={{ gridColumn: '2 / -1' }}>
+          <b>Scope</b>
+          <em>Choose what to publish</em>
+          <div className="radio-row" style={{ marginTop: 10 }}>
+            {SCOPE_OPTIONS.map(option => (
+              <button
+                key={option.id}
+                type="button"
+                className={`radio${scope === option.id ? ' on' : ''}`}
+                aria-pressed={scope === option.id}
+                onClick={() => {
+                  setScope(option.id);
+                  setPublishIssues([]);
+                }}
+              >
+                <i /> {option.label}
+                <em>{option.hint}</em>
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="flowmap-row">
+        <i className="n">2</i>
+        <div className="what" style={{ gridColumn: '2 / -1' }}>
+          <b>Validation</b>
+          <em>{blocked ? 'Fix issues before publishing' : 'No blocking issues'}</em>
+          <div style={{ marginTop: 10 }}>
+            {blocked ? (
+              <IssueList issues={validationIssues} />
+            ) : (
+              <p className="hint" style={{ margin: 0 }}>Ready to publish.</p>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className="flowmap-row">
+        <i className="n">3</i>
+        <div className="what" style={{ gridColumn: '2 / -1' }}>
+          <b>Summary</b>
+          <em>What will be published</em>
+          <div className="hist" style={{ marginTop: 10, display: 'block', border: '1px solid var(--line)' }}>
+            <div className="hist-list" style={{ borderRight: 0 }}>
+              {selectedDomains.map(source => (
+                <div
+                  key={source}
+                  className="histrow on"
+                  style={{ cursor: 'default', borderLeft: '2px solid var(--brand)' }}
+                >
+                  <div>
+                    <span className="when">{domainLabel(source)}</span>
+                    <span className="at" style={{ display: 'block', marginTop: 4 }}>
+                      <span className="mono">{domainSummary(source, bundle)}</span>
+                    </span>
+                  </div>
+                  <PublishBadge state={publishBadgeState(domainDirty(source, bundle), domainPublishedAt(source, bundle))} />
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="flowmap-row">
+        <i className="n">4</i>
+        <div className="what" style={{ gridColumn: '2 / -1' }}>
+          <b>Confirm</b>
+          <em>{blocked ? 'Resolve validation issues first' : 'Publish when ready'}</em>
+          {publishError && (
+            <div className="warnbox" style={{ marginTop: 10 }}>{publishError}</div>
+          )}
+          <div style={{ display: 'flex', gap: 8, marginTop: 12 }}>
+            <button type="button" className="btn ghost" disabled={busy} onClick={handleCancel}>
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="btn primary"
+              disabled={busy || blocked}
+              onClick={() => void handlePublish()}
+            >
+              {busy ? 'Publishing…' : 'Publish'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/SectionEditor.tsx
+++ b/src/components/admin/SectionEditor.tsx
@@ -1,0 +1,293 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { Icon } from '@/components/Icon';
+import { SectionForm } from '@/components/editors/SectionsEditor';
+import { CatalogSaveFlag, type CatalogSaveState } from '@/components/admin/CatalogList';
+import { PublishBadge } from '@/components/admin/PublishBadge';
+import { SectionPreviewPane } from '@/components/admin/SectionPreviewPane';
+import { blankArchitecture, STARTER_GROUPS, STARTER_LAYERS } from '@/lib/defaults';
+import {
+  deleteSection,
+  fetchSection,
+  fetchSectionState,
+  publishSections,
+  updateSection,
+  type SectionLibraryState,
+} from '@/lib/admin/sections';
+import type { Architecture, Section } from '@/lib/types';
+
+type ContentLocale = 'en' | 'fr';
+type Mut<T> = (fn: (draft: T) => void) => void;
+
+function stubDoc(sec: Section, lang: ContentLocale): Architecture {
+  const doc = blankArchitecture('Section editor');
+  doc.meta.lang = lang;
+  doc.groups = STARTER_GROUPS();
+  doc.layers = STARTER_LAYERS.map(layer => ({ ...layer }));
+  doc.sections = [sec];
+  return doc;
+}
+
+function libraryPublishState(state: SectionLibraryState | null): 'draft' | 'modified' | 'published' {
+  if (!state) return 'published';
+  if (state.dirty) return 'modified';
+  if (state.publishedAt) return 'published';
+  return 'draft';
+}
+
+export default function SectionEditor({ sectionId }: { sectionId: string }) {
+  const router = useRouter();
+  const [enSection, setEnSection] = useState<Section | null>(null);
+  const [frSection, setFrSection] = useState<Section | null>(null);
+  const [contentLocale, setContentLocale] = useState<ContentLocale>('en');
+  const [libraryState, setLibraryState] = useState<SectionLibraryState | null>(null);
+  const [saveState, setSaveState] = useState<CatalogSaveState>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [publishIssues, setPublishIssues] = useState<string[]>([]);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [busyDelete, setBusyDelete] = useState(false);
+
+  const dirtyRef = useRef(false);
+  const syncingRef = useRef(false);
+
+  const reloadState = useCallback(async () => {
+    try {
+      setLibraryState(await fetchSectionState());
+    } catch {
+      /* state endpoint optional during rollout */
+    }
+  }, []);
+
+  const reloadSection = useCallback(async () => {
+    const detail = await fetchSection(sectionId);
+    syncingRef.current = true;
+    setEnSection(structuredClone(detail.en));
+    setFrSection(structuredClone(detail.fr));
+    dirtyRef.current = false;
+    setSaveState('idle');
+    setTimeout(() => { syncingRef.current = false; }, 0);
+  }, [sectionId]);
+
+  useEffect(() => {
+    Promise.all([reloadSection(), reloadState()])
+      .catch(err => setError(err instanceof Error ? err.message : 'Failed to load section'));
+  }, [reloadSection, reloadState]);
+
+  const activeSection = contentLocale === 'en' ? enSection : frSection;
+
+  const markDirty = useCallback(() => {
+    if (syncingRef.current) return;
+    dirtyRef.current = true;
+    if (saveState !== 'dirty' && saveState !== 'saving') setSaveState('dirty');
+  }, [saveState]);
+
+  const setActive: Mut<Section> = useCallback((fn) => {
+    if (contentLocale === 'en') {
+      setEnSection(prev => {
+        if (!prev) return prev;
+        const next = structuredClone(prev);
+        fn(next);
+        return next;
+      });
+    } else {
+      setFrSection(prev => {
+        if (!prev) return prev;
+        const next = structuredClone(prev);
+        fn(next);
+        return next;
+      });
+    }
+    markDirty();
+  }, [contentLocale, markDirty]);
+
+  useEffect(() => {
+    if (!enSection || !frSection || !dirtyRef.current || syncingRef.current) return;
+    setSaveState('saving');
+    const t = setTimeout(async () => {
+      try {
+        await updateSection(sectionId, { en: enSection, fr: frSection });
+        dirtyRef.current = false;
+        setSaveState('saved');
+        await reloadState();
+        setTimeout(() => setSaveState('idle'), 1200);
+      } catch (e) {
+        setSaveState('error');
+        setError((e as Error).message);
+      }
+    }, 700);
+    return () => clearTimeout(t);
+  }, [enSection, frSection, sectionId, reloadState]);
+
+  async function onDelete() {
+    if (!window.confirm(`Delete section "${sectionId}" from the ADD library? This cannot be undone.`)) return;
+    setBusyDelete(true);
+    setError(null);
+    try {
+      await deleteSection(sectionId);
+      router.push('/admin/sections');
+    } catch (e) {
+      setError((e as Error).message);
+      setBusyDelete(false);
+    }
+  }
+
+  const handlePublish = async () => {
+    if (busy) return;
+    setBusy(true);
+    setPublishIssues([]);
+    setError(null);
+    try {
+      if (dirtyRef.current && enSection && frSection) {
+        await updateSection(sectionId, { en: enSection, fr: frSection });
+        dirtyRef.current = false;
+      }
+      const result = await publishSections();
+      if (!result.ok) {
+        setPublishIssues((result.issues ?? []).map(i => i.message));
+        if (result.error) setError(result.error);
+        return;
+      }
+      await reloadState();
+      setSaveState('saved');
+      setTimeout(() => setSaveState('idle'), 1200);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const editorDoc = useMemo(
+    () => (activeSection ? stubDoc(activeSection, contentLocale) : null),
+    [activeSection, contentLocale],
+  );
+
+  const jsonPreview = useMemo(() => {
+    if (!activeSection) return '';
+    return JSON.stringify(activeSection, null, 2);
+  }, [activeSection]);
+
+  if (error && !enSection) {
+    return <div className="warnbox" style={{ margin: 22 }}>{error}</div>;
+  }
+
+  if (!enSection || !frSection || !editorDoc || !activeSection) {
+    return <div className="empty">Loading section…</div>;
+  }
+
+  const publishState = libraryPublishState(libraryState);
+
+  return (
+    <div className="editor-body">
+      <div className="content-main">
+        <div className="cpanel">
+          <div className="cpanel-head">
+            <div>
+              <h2 className="mono" style={{ fontSize: 15 }}>{sectionId}</h2>
+              <p className="hint">{activeSection.type} section · bilingual ADD block</p>
+            </div>
+            <div className="cpanel-actions">
+              <PublishBadge state={publishState} />
+              <CatalogSaveFlag state={saveState} />
+              <Link href="/admin/sections" className="btn sm">
+                <Icon name="back" size={13} />Library
+              </Link>
+              <button
+                type="button"
+                className="btn primary sm"
+                disabled={busy || saveState === 'saving'}
+                onClick={() => void handlePublish()}
+              >
+                {busy ? 'Publishing…' : 'Publish library'}
+              </button>
+              <button
+                type="button"
+                className="btn sm"
+                disabled={busyDelete || saveState === 'saving'}
+                onClick={() => void onDelete()}
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+
+          {error && <div className="warnbox" style={{ marginBottom: 12 }}>{error}</div>}
+          {publishIssues.length > 0 && (
+            <div className="warnbox" style={{ marginBottom: 12 }}>
+              <ul style={{ margin: 0, paddingLeft: 18 }}>
+                {publishIssues.map((msg, i) => <li key={i}>{msg}</li>)}
+              </ul>
+            </div>
+          )}
+
+          <div className="segmented" role="group" aria-label="Content locale" style={{ marginBottom: 14 }}>
+            <button
+              type="button"
+              aria-pressed={contentLocale === 'en'}
+              onClick={() => setContentLocale('en')}
+            >
+              EN
+            </button>
+            <button
+              type="button"
+              aria-pressed={contentLocale === 'fr'}
+              onClick={() => setContentLocale('fr')}
+            >
+              FR
+            </button>
+          </div>
+
+          <SectionForm doc={editorDoc} sec={activeSection} set={setActive} />
+
+          <div className="insp-sep" />
+
+          <div className={`elist${advancedOpen ? ' open' : ''}`}>
+            <div className="elist-head">
+              <button
+                type="button"
+                className="iconbtn twist"
+                aria-expanded={advancedOpen}
+                onClick={() => setAdvancedOpen(o => !o)}
+                title={advancedOpen ? 'Collapse' : 'Expand'}
+              >
+                <Icon name="chevron" size={14} />
+              </button>
+              <button type="button" className="elist-name" onClick={() => setAdvancedOpen(o => !o)}>
+                Advanced
+              </button>
+            </div>
+            {advancedOpen && (
+              <div className="elist-body">
+                <label className="field">
+                  <span>Section JSON ({contentLocale}, read-only)</span>
+                  <textarea
+                    className="textarea"
+                    readOnly
+                    value={jsonPreview}
+                    style={{ minHeight: 220, fontFamily: 'var(--mono)', fontSize: 11 }}
+                  />
+                </label>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <aside className="inspector">
+        <div className="sub mono">{sectionId}</div>
+        <h3>Paper preview</h3>
+        <SectionPreviewPane
+          sectionId={sectionId}
+          section={activeSection}
+          saveState={saveState}
+          variant="compact"
+          lang={contentLocale}
+        />
+      </aside>
+    </div>
+  );
+}

--- a/src/components/admin/SectionPreviewPane.tsx
+++ b/src/components/admin/SectionPreviewPane.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { Section } from '@/lib/types';
+import type { CatalogSaveState } from '@/components/admin/CatalogList';
+
+const DOC_WIDTH_FALLBACK = 1440;
+
+type PreviewVariant = 'compact' | 'full';
+
+export function SectionPreviewPane({
+  sectionId,
+  section,
+  saveState,
+  variant = 'full',
+  lang: langProp,
+}: {
+  sectionId: string;
+  section: Section;
+  saveState?: CatalogSaveState;
+  variant?: PreviewVariant;
+  lang?: 'en' | 'fr';
+}) {
+  const [previewLang, setPreviewLang] = useState<'en' | 'fr'>(langProp ?? 'en');
+  const [src, setSrc] = useState('');
+  const [err, setErr] = useState<string | null>(null);
+  const [scale, setScale] = useState(1);
+  const [docSize, setDocSize] = useState({ w: DOC_WIDTH_FALLBACK, h: 900 });
+
+  const shellRef = useRef<HTMLDivElement>(null);
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  useEffect(() => {
+    if (langProp) setPreviewLang(langProp);
+  }, [langProp]);
+
+  const key = useMemo(() => JSON.stringify(section).length, [section]);
+
+  useEffect(() => {
+    let alive = true;
+    const delay = saveState === 'saving' ? 850 : 350;
+    const t = setTimeout(async () => {
+      setErr(null);
+      try {
+        const res = await fetch(`/api/admin/sections/${sectionId}/preview`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ section, lang: previewLang }),
+        });
+        if (!res.ok) throw new Error(await res.text());
+        const html = await res.text();
+        if (alive) setSrc(html);
+      } catch (e) {
+        if (alive) setErr((e as Error).message);
+      }
+    }, delay);
+    return () => {
+      alive = false;
+      clearTimeout(t);
+    };
+  }, [sectionId, section, key, saveState, previewLang]);
+
+  const measureDoc = useCallback(() => {
+    const iframe = iframeRef.current;
+    const doc = iframe?.contentDocument;
+    if (!doc?.body) return null;
+
+    const w = Math.max(
+      doc.documentElement.scrollWidth,
+      doc.body.scrollWidth,
+      DOC_WIDTH_FALLBACK,
+    );
+    const h = Math.max(
+      doc.documentElement.scrollHeight,
+      doc.body.scrollHeight,
+      600,
+    );
+    return { w, h };
+  }, []);
+
+  const updateScale = useCallback(() => {
+    const shell = shellRef.current;
+    if (!shell) return;
+
+    const measured = measureDoc();
+    const w = measured?.w ?? docSize.w;
+    const h = measured?.h ?? docSize.h;
+    if (measured) setDocSize(measured);
+
+    const cw = shell.clientWidth;
+    if (cw <= 0 || w <= 0) return;
+
+    if (variant === 'compact') {
+      const ch = shell.clientHeight;
+      const sw = cw / w;
+      const sh = ch > 0 ? ch / h : sw;
+      setScale(Math.min(sw, sh, 1));
+    } else {
+      setScale(Math.min(cw / w, 1));
+    }
+  }, [variant, measureDoc, docSize.w, docSize.h]);
+
+  useEffect(() => {
+    const shell = shellRef.current;
+    if (!shell) return;
+    const ro = new ResizeObserver(() => updateScale());
+    ro.observe(shell);
+    return () => ro.disconnect();
+  }, [updateScale, src]);
+
+  const onIframeLoad = () => {
+    requestAnimationFrame(() => updateScale());
+  };
+
+  const scaledW = docSize.w * scale;
+  const scaledH = docSize.h * scale;
+
+  if (err) return <div className="warnbox">{err}</div>;
+
+  return (
+    <div className={`preview-shell preview-shell--${variant}`}>
+      <div className="preview-shell-head">
+        <div className="segmented" role="group" aria-label="Preview locale">
+          <button
+            type="button"
+            aria-pressed={previewLang === 'en'}
+            onClick={() => setPreviewLang('en')}
+          >
+            EN
+          </button>
+          <button
+            type="button"
+            aria-pressed={previewLang === 'fr'}
+            onClick={() => setPreviewLang('fr')}
+          >
+            FR
+          </button>
+        </div>
+      </div>
+
+      {!src ? (
+        <div className="empty">Rendering preview…</div>
+      ) : (
+        <div ref={shellRef} className="preview-stage">
+          <div
+            className="preview-scale"
+            style={{ width: scaledW, height: scaledH }}
+          >
+            <iframe
+              ref={iframeRef}
+              className="previewframe"
+              srcDoc={src}
+              title="Section preview"
+              sandbox="allow-scripts allow-popups"
+              onLoad={onIframeLoad}
+              style={{
+                width: docSize.w,
+                height: docSize.h,
+                transform: `scale(${scale})`,
+                transformOrigin: 'top left',
+              }}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/admin/TemplateAddPanel.tsx
+++ b/src/components/admin/TemplateAddPanel.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { useState, type ReactNode } from 'react';
+import SectionsEditor from '@/components/editors/SectionsEditor';
+import { BlocksDrawer } from '@/components/admin/BlocksDrawer';
+import { fetchSection } from '@/lib/admin/sections';
+import { slugify } from '@/lib/defaults';
+import { registerSectionTab } from '@/lib/tabs';
+import type { Architecture } from '@/lib/types';
+
+type Patch = (fn: (d: Architecture) => Architecture) => void;
+
+const noopPatch: Patch = () => {};
+
+export function TemplateAddPanel({
+  doc,
+  patch,
+  readOnly = false,
+  hint,
+  onError,
+}: {
+  doc: Architecture;
+  patch: Patch;
+  readOnly?: boolean;
+  hint?: ReactNode;
+  onError?: (message: string) => void;
+}) {
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const effective = readOnly ? noopPatch : patch;
+
+  return (
+    <div className="cpanel-body">
+      {(readOnly || hint) && (
+        <div className="hint" style={{ marginBottom: 14 }}>
+          {hint ?? (
+            <>
+              Read-only agnostic snapshot. Full per-cloud edits stay under{' '}
+              <span className="mono">Advanced</span> JSON.
+            </>
+          )}
+        </div>
+      )}
+      {!readOnly && (
+        <div style={{ marginBottom: 12 }}>
+          <button type="button" className="btn sm" onClick={() => setDrawerOpen(true)}>
+            From library
+          </button>
+        </div>
+      )}
+      <SectionsEditor doc={doc} patch={effective} />
+      {!readOnly && (
+        <BlocksDrawer
+          open={drawerOpen}
+          onClose={() => setDrawerOpen(false)}
+          locale={doc.meta?.lang === 'fr' ? 'fr' : 'en'}
+          onPick={async (id) => {
+            try {
+              const detail = await fetchSection(id);
+              const lang = doc.meta?.lang === 'fr' ? 'fr' : 'en';
+              const source = lang === 'fr' ? detail.fr : detail.en;
+              patch(d => {
+                const taken = d.sections.map(s => s.id);
+                let newId = source.id;
+                if (taken.includes(newId)) {
+                  newId = slugify(`${source.id}-copy`, taken);
+                }
+                const copy = structuredClone({ ...source, id: newId });
+                d.sections.push(copy);
+                registerSectionTab(d, newId);
+                return d;
+              });
+            } catch (e) {
+              onError?.((e as Error).message);
+            } finally {
+              setDrawerOpen(false);
+            }
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/admin/TemplateCanvasEditor.tsx
+++ b/src/components/admin/TemplateCanvasEditor.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { CardList, Group, IconPicker, Panel, Text } from '@/components/editors/Fields';
+import { PALETTE, PALETTE_DARK, slugify } from '@/lib/defaults';
+import { displayLayerLabel } from '@/lib/layers';
+import type { Architecture, Component, Group as Scope, Layer } from '@/lib/types';
+
+type Patch = (fn: (d: Architecture) => Architecture) => void;
+
+export function TemplateCanvasEditor({ doc, patch, readOnly }: { doc: Architecture; patch: Patch; readOnly?: boolean }) {
+  const noop = () => {};
+  const p = readOnly ? ((_fn: (d: Architecture) => Architecture) => noop()) as Patch : patch;
+
+  return (
+    <Panel title="Canvas"
+      subtitle="Scopes, layers and components — the architecture diagram skeleton.">
+
+      <Group title={`Scopes (${doc.groups.length})`}>
+        <CardList<Scope>
+          items={doc.groups}
+          onChange={next => p(d => { d.groups = next; return d; })}
+          addLabel="Add scope"
+          empty="No scope yet."
+          blank={() => {
+            const i = doc.groups.length;
+            const name = `Scope ${i + 1}`;
+            return {
+              id: slugify(name, doc.groups.map(g => g.id)),
+              name,
+              short: name,
+              color: PALETTE[i % PALETTE.length],
+              colorDark: PALETTE_DARK[i % PALETTE_DARK.length],
+            };
+          }}
+          summary={g => g.name}
+          render={(g, set) => (
+            <>
+              <div className="frow">
+                <Text label="Name" value={g.name}
+                  onChange={v => set(x => { x.name = v; x.short = v; })} />
+                <label className="field"><span>Colour</span>
+                  <input type="color" className="swatch" value={g.color || PALETTE[0]}
+                    disabled={readOnly}
+                    onChange={e => set(x => { x.color = e.target.value; })} />
+                </label>
+              </div>
+            </>
+          )}
+        />
+      </Group>
+
+      <Group title={`Layers (${doc.layers.length})`}>
+        <CardList<Layer>
+          items={doc.layers}
+          onChange={next => p(d => { d.layers = next; return d; })}
+          addLabel="Add layer"
+          empty="No layer yet."
+          blank={() => {
+            const name = `Layer ${doc.layers.length + 1}`;
+            return { id: slugify(name, doc.layers.map(l => l.id)), name };
+          }}
+          summary={l => displayLayerLabel(l.name === l.id ? l.id : l.name)}
+          render={(l, set) => (
+            <Text label="Name" value={l.name}
+              onChange={v => set(x => { x.name = v; })} />
+          )}
+        />
+      </Group>
+
+      <Group title={`Components (${doc.components.length})`}>
+        <CardList<Component>
+          items={doc.components}
+          onChange={next => p(d => { d.components = next; return d; })}
+          addLabel="Add component"
+          empty="No component yet."
+          blank={() => {
+            const name = `Component ${doc.components.length + 1}`;
+            const group = doc.groups[0]?.id ?? 'core';
+            const layer = doc.layers[0]?.id ?? 'services';
+            return {
+              id: slugify(name, doc.components.map(c => c.id)),
+              name,
+              group,
+              layer,
+              icon: 'box',
+            };
+          }}
+          summary={c => c.name}
+          badge={c => <span className="count mono">{c.id}</span>}
+          render={(c, set) => (
+            <>
+              <Text label="Name" value={c.name} onChange={v => set(x => { x.name = v; })} />
+              <div className="frow">
+                <label className="field"><span>Scope</span>
+                  <select className="select" value={c.group} disabled={readOnly}
+                    onChange={e => set(x => { x.group = e.target.value; })}>
+                    {doc.groups.map(g => <option key={g.id} value={g.id}>{g.name}</option>)}
+                  </select>
+                </label>
+                <label className="field"><span>Layer</span>
+                  <select className="select" value={c.layer} disabled={readOnly}
+                    onChange={e => set(x => { x.layer = e.target.value; })}>
+                    {doc.layers.map(l => (
+                      <option key={l.id} value={l.id}>{displayLayerLabel(l.name === l.id ? l.id : l.name)}</option>
+                    ))}
+                  </select>
+                </label>
+              </div>
+              <IconPicker label="Icon" value={c.icon || 'box'}
+                onChange={v => set(x => { x.icon = v; })} />
+              <Text label="Role" value={c.role || ''}
+                onChange={v => set(x => { x.role = v || undefined; })} />
+            </>
+          )}
+        />
+      </Group>
+    </Panel>
+  );
+}

--- a/src/components/admin/TemplateDiagramPanel.tsx
+++ b/src/components/admin/TemplateDiagramPanel.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import ArchitectureDiagramSurface from '@/components/ArchitectureDiagramSurface';
+import type { Architecture } from '@/lib/types';
+
+type Patch = (fn: (d: Architecture) => Architecture) => void;
+
+export function TemplateDiagramPanel({
+  doc,
+  patch,
+  readOnly = false,
+  hint,
+}: {
+  doc: Architecture;
+  patch: Patch;
+  readOnly?: boolean;
+  hint?: ReactNode;
+}) {
+  return (
+    <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
+      {(readOnly || hint) && (
+        <div className="hint" style={{ margin: '10px 14px 0', flexShrink: 0 }}>
+          {hint ?? (
+            <>
+              Read-only agnostic snapshot. Full per-cloud edits stay under{' '}
+              <span className="mono">Advanced</span> JSON.
+            </>
+          )}
+        </div>
+      )}
+      <ArchitectureDiagramSurface doc={doc} patch={patch} readOnly={readOnly} />
+    </div>
+  );
+}

--- a/src/components/admin/TemplateEditorShell.tsx
+++ b/src/components/admin/TemplateEditorShell.tsx
@@ -1,0 +1,197 @@
+'use client';
+
+import { useState, type ReactNode } from 'react';
+import { Icon } from '@/components/Icon';
+
+export type TemplateEditorTab =
+  | 'metadata'
+  | 'diagram'
+  | 'flows'
+  | 'add'
+  | 'preview'
+  | 'advanced';
+
+export type TemplateEditorTabSpec = { id: TemplateEditorTab; label: string; icon: string };
+
+export const PROJECT_TABS: TemplateEditorTabSpec[] = [
+  { id: 'metadata', label: 'Metadata', icon: 'file' },
+  { id: 'diagram', label: 'Diagram', icon: 'grid' },
+  { id: 'flows', label: 'Flows', icon: 'route' },
+  { id: 'add', label: 'ADD', icon: 'folder' },
+  { id: 'preview', label: 'Preview', icon: 'eye' },
+];
+
+export const ARCHITECTURE_EDITOR_TABS: TemplateEditorTabSpec[] = [
+  { id: 'metadata', label: 'Metadata', icon: 'file' },
+  { id: 'diagram', label: 'Diagram', icon: 'grid' },
+  { id: 'flows', label: 'Flows', icon: 'route' },
+  { id: 'add', label: 'ADD', icon: 'folder' },
+  { id: 'preview', label: 'Preview', icon: 'eye' },
+  { id: 'advanced', label: 'Advanced', icon: 'terminal' },
+];
+
+export function TemplateEditorShell({
+  templateId,
+  title,
+  subtitle,
+  badge,
+  actions,
+  counts,
+  tab: controlledTab,
+  onTabChange,
+  metadata,
+  panels,
+  inspectorPreview,
+  placeholder = 'Panel not available.',
+  tabs = PROJECT_TABS,
+  railHint = 'Edit the project snapshot by tab.',
+}: {
+  templateId: string;
+  title: string;
+  subtitle?: string;
+  badge?: ReactNode;
+  actions?: ReactNode;
+  counts?: { components: number; sections: number; flows: number };
+  tab?: TemplateEditorTab;
+  onTabChange?: (tab: TemplateEditorTab) => void;
+  metadata: ReactNode;
+  panels?: Partial<Record<TemplateEditorTab, ReactNode>>;
+  inspectorPreview?: ReactNode;
+  placeholder?: string;
+  tabs?: TemplateEditorTabSpec[];
+  railHint?: string;
+}) {
+  const [internalTab, setInternalTab] = useState<TemplateEditorTab>('metadata');
+  const tab = controlledTab ?? internalTab;
+  const setTab = onTabChange ?? setInternalTab;
+
+  const tabCounts: Partial<Record<TemplateEditorTab, number>> = counts
+    ? { diagram: counts.components, flows: counts.flows, add: counts.sections }
+    : {};
+
+  const mainContent = tab === 'metadata'
+    ? metadata
+    : (panels?.[tab] ?? <div className="empty">{placeholder}</div>);
+
+  const fullBleed = tab === 'preview' || tab === 'diagram';
+  const bleedTitle = tab === 'diagram' ? 'Diagram' : 'Preview';
+  const bleedSubtitle = tab === 'diagram'
+    ? `${title} — architecture canvas`
+    : `${title} — rendered ADD export`;
+
+  return (
+    <div style={{ flex: 1, minHeight: 0, display: 'flex', overflow: 'hidden' }}>
+      <nav className="content-rail" aria-label="Template editor">
+        <div className="sect-label">Template</div>
+        {tabs.map(item => {
+          const n = tabCounts[item.id];
+          return (
+            <button
+              key={item.id}
+              type="button"
+              className={`railitem${tab === item.id ? ' on' : ''}`}
+              aria-current={tab === item.id}
+              onClick={() => setTab(item.id)}
+            >
+              <Icon name={item.icon} size={15} />
+              <span>{item.label}</span>
+              {n !== undefined && <em>{n}</em>}
+            </button>
+          );
+        })}
+        <div className="hint" style={{ marginTop: 14 }}>
+          {railHint}
+        </div>
+      </nav>
+
+      <div className="editor-body" style={{ flex: 1 }}>
+        <div
+          className="content-main"
+          style={fullBleed ? {
+            display: 'flex',
+            flexDirection: 'column',
+            minHeight: 0,
+            padding: 0,
+            overflow: 'hidden',
+          } : undefined}
+        >
+          <div
+            className="cpanel"
+            style={fullBleed ? {
+              flex: 1,
+              minHeight: 0,
+              display: 'flex',
+              flexDirection: 'column',
+              maxWidth: 'none',
+              margin: 0,
+              width: '100%',
+            } : undefined}
+          >
+            {!fullBleed && (
+              <div className="cpanel-head">
+                <div>
+                  <h2>{title}</h2>
+                  {subtitle && <p>{subtitle}</p>}
+                </div>
+                <div className="cpanel-actions">
+                  {badge}
+                  {actions}
+                </div>
+              </div>
+            )}
+            <div style={fullBleed ? { flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' } : undefined}>
+              {fullBleed ? (
+                <>
+                  <div className="cpanel-head" style={{ flexShrink: 0, padding: '16px 20px 0' }}>
+                    <div>
+                      <h2>{bleedTitle}</h2>
+                      <p>{bleedSubtitle}</p>
+                    </div>
+                    <div className="cpanel-actions">
+                      {badge}
+                      {actions}
+                    </div>
+                  </div>
+                  <div className={tab === 'diagram' ? 'diagram-tab-body' : 'preview-tab-body'}>
+                    {mainContent}
+                  </div>
+                </>
+              ) : mainContent}
+            </div>
+          </div>
+        </div>
+
+        {!fullBleed && (
+          <aside className="inspector">
+            <div className="sub mono">{templateId}</div>
+            <h3>Preview</h3>
+            {inspectorPreview ?? (
+              <p className="hint" style={{ marginBottom: 16 }}>
+                Open the Preview tab for the full paper render.
+              </p>
+            )}
+            {counts ? (
+              <div className="cgroup">
+                <div className="sect-label">Outline</div>
+                <div className="field">
+                  <span>Components</span>
+                  <div className="mono">{counts.components}</div>
+                </div>
+                <div className="field">
+                  <span>Flows</span>
+                  <div className="mono">{counts.flows}</div>
+                </div>
+                <div className="field">
+                  <span>Sections</span>
+                  <div className="mono">{counts.sections}</div>
+                </div>
+              </div>
+            ) : (
+              <div className="empty">No outline loaded.</div>
+            )}
+          </aside>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/TemplateFlowsPanel.tsx
+++ b/src/components/admin/TemplateFlowsPanel.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import FlowsEditor from '@/components/editors/FlowsEditor';
+import type { Architecture } from '@/lib/types';
+
+type Patch = (fn: (d: Architecture) => Architecture) => void;
+
+const noopPatch: Patch = () => {};
+
+export function TemplateFlowsPanel({
+  doc,
+  patch,
+  readOnly = false,
+  hint,
+}: {
+  doc: Architecture;
+  patch: Patch;
+  readOnly?: boolean;
+  hint?: ReactNode;
+}) {
+  return (
+    <div className="cpanel-body">
+      {(readOnly || hint) && (
+        <div className="hint" style={{ marginBottom: 14 }}>
+          {hint ?? (
+            <>
+              Read-only agnostic snapshot. Full per-cloud edits stay under{' '}
+              <span className="mono">Advanced</span> JSON.
+            </>
+          )}
+        </div>
+      )}
+      <FlowsEditor doc={doc} patch={readOnly ? noopPatch : patch} catalog={null} />
+    </div>
+  );
+}

--- a/src/components/admin/TemplatePreviewPane.tsx
+++ b/src/components/admin/TemplatePreviewPane.tsx
@@ -1,0 +1,176 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { Architecture } from '@/lib/types';
+import type { CatalogSaveState } from '@/components/admin/CatalogList';
+
+const DOC_WIDTH_FALLBACK = 1440;
+
+type PreviewVariant = 'compact' | 'full';
+
+export function TemplatePreviewPane({
+  templateId,
+  snapshot,
+  saveState,
+  variant = 'full',
+}: {
+  templateId: string;
+  snapshot: Architecture;
+  saveState?: CatalogSaveState;
+  variant?: PreviewVariant;
+}) {
+  const [previewLang, setPreviewLang] = useState<'en' | 'fr'>(
+    snapshot.meta?.lang === 'fr' ? 'fr' : 'en',
+  );
+  const [src, setSrc] = useState('');
+  const [err, setErr] = useState<string | null>(null);
+  const [scale, setScale] = useState(1);
+  const [docSize, setDocSize] = useState({ w: DOC_WIDTH_FALLBACK, h: 900 });
+
+  const shellRef = useRef<HTMLDivElement>(null);
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  useEffect(() => {
+    setPreviewLang(snapshot.meta?.lang === 'fr' ? 'fr' : 'en');
+  }, [snapshot.meta?.lang]);
+
+  const previewSnapshot = useMemo(
+    () => ({
+      ...snapshot,
+      meta: { ...snapshot.meta, lang: previewLang },
+    }),
+    [snapshot, previewLang],
+  );
+
+  const key = useMemo(() => JSON.stringify(previewSnapshot).length, [previewSnapshot]);
+
+  useEffect(() => {
+    let alive = true;
+    const delay = saveState === 'saving' ? 850 : 350;
+    const t = setTimeout(async () => {
+      setErr(null);
+      try {
+        const res = await fetch(`/api/admin/templates/${templateId}/preview`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ snapshot: previewSnapshot }),
+        });
+        if (!res.ok) throw new Error(await res.text());
+        const html = await res.text();
+        if (alive) setSrc(html);
+      } catch (e) {
+        if (alive) setErr((e as Error).message);
+      }
+    }, delay);
+    return () => {
+      alive = false;
+      clearTimeout(t);
+    };
+  }, [templateId, key, saveState, previewSnapshot]);
+
+  const measureDoc = useCallback(() => {
+    const iframe = iframeRef.current;
+    const doc = iframe?.contentDocument;
+    if (!doc?.body) return null;
+
+    const w = Math.max(
+      doc.documentElement.scrollWidth,
+      doc.body.scrollWidth,
+      DOC_WIDTH_FALLBACK,
+    );
+    const h = Math.max(
+      doc.documentElement.scrollHeight,
+      doc.body.scrollHeight,
+      600,
+    );
+    return { w, h };
+  }, []);
+
+  const updateScale = useCallback(() => {
+    const shell = shellRef.current;
+    if (!shell) return;
+
+    const measured = measureDoc();
+    const w = measured?.w ?? docSize.w;
+    const h = measured?.h ?? docSize.h;
+    if (measured) setDocSize(measured);
+
+    const cw = shell.clientWidth;
+    if (cw <= 0 || w <= 0) return;
+
+    if (variant === 'compact') {
+      const ch = shell.clientHeight;
+      const sw = cw / w;
+      const sh = ch > 0 ? ch / h : sw;
+      setScale(Math.min(sw, sh, 1));
+    } else {
+      setScale(Math.min(cw / w, 1));
+    }
+  }, [variant, measureDoc, docSize.w, docSize.h]);
+
+  useEffect(() => {
+    const shell = shellRef.current;
+    if (!shell) return;
+    const ro = new ResizeObserver(() => updateScale());
+    ro.observe(shell);
+    return () => ro.disconnect();
+  }, [updateScale, src]);
+
+  const onIframeLoad = () => {
+    requestAnimationFrame(() => updateScale());
+  };
+
+  const scaledW = docSize.w * scale;
+  const scaledH = docSize.h * scale;
+
+  if (err) return <div className="warnbox">{err}</div>;
+
+  return (
+    <div className={`preview-shell preview-shell--${variant}`}>
+      <div className="preview-shell-head">
+        <div className="segmented" role="group" aria-label="Preview locale">
+          <button
+            type="button"
+            aria-pressed={previewLang === 'en'}
+            onClick={() => setPreviewLang('en')}
+          >
+            EN
+          </button>
+          <button
+            type="button"
+            aria-pressed={previewLang === 'fr'}
+            onClick={() => setPreviewLang('fr')}
+          >
+            FR
+          </button>
+        </div>
+      </div>
+
+      {!src ? (
+        <div className="empty">Rendering preview…</div>
+      ) : (
+        <div ref={shellRef} className="preview-stage">
+          <div
+            className="preview-scale"
+            style={{ width: scaledW, height: scaledH }}
+          >
+            <iframe
+              ref={iframeRef}
+              className="previewframe"
+              srcDoc={src}
+              title="Template preview"
+              sandbox="allow-scripts allow-popups"
+              onLoad={onIframeLoad}
+              style={{
+                width: docSize.w,
+                height: docSize.h,
+                transform: `scale(${scale})`,
+                transformOrigin: 'top left',
+              }}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/editors/Fields.tsx
+++ b/src/components/editors/Fields.tsx
@@ -12,8 +12,9 @@ export const RICH_HINT = 'Inline <b>, <i>, <code> and <span class="mono"> render
 
 /* ------------------------------------------------------------------ inputs */
 
-export function Text({ label, value, onChange, placeholder, hint, mono }: {
+export function Text({ label, value, onChange, onBlur, placeholder, hint, mono }: {
   label?: string; value: string; onChange: (v: string) => void;
+  onBlur?: () => void;
   placeholder?: string; hint?: string; mono?: boolean;
 }) {
   return (
@@ -21,14 +22,15 @@ export function Text({ label, value, onChange, placeholder, hint, mono }: {
       {label && <span>{label}</span>}
       <input className="input" value={value} placeholder={placeholder}
         style={mono ? { fontFamily: 'ui-monospace, monospace', fontSize: 12 } : undefined}
-        onChange={e => onChange(e.target.value)} />
+        onChange={e => onChange(e.target.value)} onBlur={onBlur} />
       {hint && <div className="hint">{hint}</div>}
     </label>
   );
 }
 
-export function Area({ label, value, onChange, placeholder, hint, minHeight }: {
+export function Area({ label, value, onChange, onBlur, placeholder, hint, minHeight }: {
   label?: string; value: string; onChange: (v: string) => void;
+  onBlur?: () => void;
   placeholder?: string; hint?: string; minHeight?: number;
 }) {
   return (
@@ -36,7 +38,7 @@ export function Area({ label, value, onChange, placeholder, hint, minHeight }: {
       {label && <span>{label}</span>}
       <textarea className="textarea" value={value} placeholder={placeholder}
         style={minHeight ? { minHeight } : undefined}
-        onChange={e => onChange(e.target.value)} />
+        onChange={e => onChange(e.target.value)} onBlur={onBlur} />
       {hint && <div className="hint">{hint}</div>}
     </label>
   );

--- a/src/components/editors/SectionsEditor.tsx
+++ b/src/components/editors/SectionsEditor.tsx
@@ -11,8 +11,8 @@ import {
   Area, CardList, CellGrid, Group, IconPicker, Panel, RICH_HINT, ScopePicker, StringList, Text
 } from './Fields';
 import { SECTION_TYPES, blankSection } from '@/lib/defaults';
-import { applyDesignDocumentPreset, missingPresetSections } from '@/lib/document/preset';
-import { registerSectionTab, resyncSectionOrder, unregisterTab } from '@/lib/tabs';
+import { missingGatedPresetSections, syncGatedPresetSections } from '@/lib/document/preset';
+import { naturalTabs, registerSectionTab, resyncSectionOrder, unregisterTab } from '@/lib/tabs';
 import type {
   Architecture, CardItem, CardsSection, CompareCard, ComparePole, CompareSection,
   Section, SectionType, TableColumn, TableSection, TextBlock, TextSection,
@@ -32,17 +32,20 @@ function fitRows(rows: string[][], n: number): string[][] {
 export default function SectionsEditor({ doc, patch }: { doc: Architecture; patch: Patch }) {
   const [newType, setNewType] = useState<SectionType>('cards');
   const chosen = SECTION_TYPES.find(t => t.type === newType)!;
-  const missing = missingPresetSections(doc);
+  const missing = missingGatedPresetSections(doc);
 
-  /* The preset appends chapters without registering them as tabs, so the
-   * viewer is left alone — hence no `setSections` here, which would. */
+  /* Gated chapters stay off the tab bar — pin current tabs first, then sync. */
   const addPreset = () => {
     if (!confirm(
-      `Add the ${missing} missing design-document chapters (data, scaling, tenancy, recovery, `
-      + 'observability, IAM, networking, cost, delivery…)?\n\n'
-      + 'They are added empty, for the printable document only — the viewer keeps its current tabs.'
+      `Add ${missing} design-document chapter(s) opened by the bricks on the canvas `
+      + '(IAM, data, networking…)?\n\n'
+      + 'They fill from catalog metadata. The viewer keeps its current tabs.'
     )) return;
-    patch(d => { applyDesignDocumentPreset(d); return d; });
+    patch(d => {
+      if (!d.ui.tabs?.length) d.ui.tabs = naturalTabs(d).map(t => t.id);
+      syncGatedPresetSections(d);
+      return d;
+    });
   };
 
   const setSections = (next: Section[]) => patch(d => {
@@ -72,8 +75,8 @@ export default function SectionsEditor({ doc, patch }: { doc: Architecture; patc
         <div>
           <b>Architecture Design Document</b>
           <div className="hint">
-            The written chapters an ADD carries around the diagram — scaling, tenancy, recovery,
-            IAM, networking, delivery, cost. Empty and vendor-neutral, printed by the Document view.
+            The written chapters an ADD carries around the diagram — opened by placed bricks,
+            filled from catalog metadata, printed by the Document view.
           </div>
         </div>
         <button className="btn sm" onClick={addPreset} disabled={!missing}>
@@ -97,7 +100,7 @@ export default function SectionsEditor({ doc, patch }: { doc: Architecture; patc
 
 /* ------------------------------------------------------------------- shell */
 
-function SectionForm({ doc, sec, set }: { doc: Architecture; sec: Section; set: Mut<Section> }) {
+export function SectionForm({ doc, sec, set }: { doc: Architecture; sec: Section; set: Mut<Section> }) {
   const changeType = (type: SectionType) => {
     if (type === sec.type) return;
     if (!confirm(`Switch "${sec.tab || sec.title}" to a ${type} section? Its current content is dropped.`)) return;

--- a/src/lib/admin/add-sections.test.ts
+++ b/src/lib/admin/add-sections.test.ts
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import * as AS from './add-sections';
+import { PRESET_SECTION_IDS } from '../document/preset';
+
+describe('add-sections admin', () => {
+  test('seeds preset library on ensure', () => {
+    AS.ensureAddSectionsDomain();
+    const list = AS.listAddSectionsAdmin();
+    assert.ok(list.length >= PRESET_SECTION_IDS.length);
+    assert.ok(list.some(s => s.id === 'add-data'));
+  });
+
+  test('get and update bilingual section', () => {
+    const detail = AS.getAddSectionAdmin('add-data');
+    assert.ok(detail);
+    const next = structuredClone(detail);
+    next.en.title = 'Data architecture (admin test)';
+    AS.updateAddSection('add-data', { en: next.en, fr: next.fr });
+    const saved = AS.getAddSectionAdmin('add-data');
+    assert.equal(saved?.en.title, 'Data architecture (admin test)');
+  });
+
+  test('publish blocked when placeholders remain', () => {
+    const result = AS.publishAddSections();
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.ok(result.issues.length > 0);
+      assert.ok(result.issues.some(i => i.code === 'placeholder_section'));
+    }
+  });
+
+  // F-REG R4 — named regression (duplicate assert so removal of the gate fails loudly)
+  test('F-REG R4: publishAddSections rejects with placeholder_section', () => {
+    const result = AS.publishAddSections();
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.ok(
+        result.issues.some(i => i.code === 'placeholder_section'),
+        'placeholder_section gate must remain on ADD/sections publish',
+      );
+    }
+  });
+
+  test('preview html includes section title', () => {
+    const detail = AS.getAddSectionAdmin('add-scope');
+    assert.ok(detail);
+    const html = AS.buildSectionPreviewHtml(detail.en, 'en');
+    assert.ok(html.includes(detail.en.title));
+  });
+
+  test('create and delete custom section', () => {
+    const id = AS.createAddSection({
+      type: 'text',
+      titleEn: 'Ops runbook (test)',
+      titleFr: 'Runbook ops (test)',
+    });
+    assert.match(id, /^ops-runbook-test$/);
+    const detail = AS.getAddSectionAdmin(id);
+    assert.ok(detail);
+    assert.equal(detail.en.title, 'Ops runbook (test)');
+    assert.equal(detail.fr.title, 'Runbook ops (test)');
+    AS.deleteAddSection(id);
+    assert.equal(AS.getAddSectionAdmin(id), null);
+  });
+
+  test('create rejects duplicate id', () => {
+    const id = AS.createAddSection({ type: 'cards', titleEn: 'Duplicate probe' });
+    assert.throws(
+      () => AS.createAddSection({ id, type: 'cards', titleEn: 'Another' }),
+      /already exists/,
+    );
+    AS.deleteAddSection(id);
+  });
+});

--- a/src/lib/admin/add-sections.ts
+++ b/src/lib/admin/add-sections.ts
@@ -1,0 +1,284 @@
+import { allPresetSectionSpecs, type PresetSection } from '../document/preset';
+import { blankSection, normalizeArchitecture, slugify, STARTER_GROUPS, STARTER_LAYERS, blankArchitecture } from '../defaults';
+import { db, now, plain, plainAll } from '../db';
+import { buildStandaloneHtml } from '../exportHtml';
+import type { CatalogIssue } from '../lego/admin-catalog';
+import { resolveDeep, type Lang } from '../templates/types';
+import type { Architecture, Section, SectionType } from '../types';
+
+export const ADD_SECTIONS_DOMAIN = 'add-sections';
+
+const PLACEHOLDER_MARKERS = ['[…]', 'À estimer', 'To be estimated'];
+
+export type AddSectionPayload = {
+  en: Section;
+  fr: Section;
+};
+
+export type AddSectionCreate = {
+  id?: string;
+  type: SectionType;
+  titleEn: string;
+  titleFr?: string;
+};
+
+export type AddSectionAdminState = {
+  dirty: boolean;
+  publishedAt: string | null;
+  sectionCount: number;
+  issueCount?: number;
+  issues?: CatalogIssue[];
+};
+
+export type PublishAddSectionsResult =
+  | { ok: true; publishedAt: string }
+  | { ok: false; issues: CatalogIssue[] };
+
+function getRow<T>(sql: string, ...params: (string | number | null)[]): T | null {
+  const raw = db.prepare(sql).get(...params);
+  if (!raw) return null;
+  return plain<T>(raw);
+}
+
+function rows<T>(sql: string, ...values: (string | number | null)[]): T[] {
+  return plainAll<T>(db.prepare(sql).all(...values));
+}
+
+function parsePayload(raw: string | null): AddSectionPayload {
+  if (!raw) throw new Error('add section payload_json is missing');
+  const parsed = JSON.parse(raw) as AddSectionPayload;
+  return {
+    en: normalizeArchitecture({ sections: [parsed.en] }).sections[0] as Section,
+    fr: normalizeArchitecture({ sections: [parsed.fr] }).sections[0] as Section,
+  };
+}
+
+function specToPayload(spec: PresetSection): AddSectionPayload {
+  return {
+    en: resolveDeep<Section>(spec, 'en'),
+    fr: resolveDeep<Section>(spec, 'fr'),
+  };
+}
+
+function markDirty(): void {
+  db.prepare('UPDATE content_domains SET status=?, published_at=published_at WHERE id=?')
+    .run('draft', ADD_SECTIONS_DOMAIN);
+}
+
+function sectionItemCount(sec: Section): number {
+  switch (sec.type) {
+    case 'cards': return (sec as { items?: unknown[] }).items?.length ?? 0;
+    case 'text': return (sec as { blocks?: unknown[] }).blocks?.length ?? 0;
+    case 'timeline': return (sec as { items?: unknown[] }).items?.length ?? 0;
+    case 'table': return (sec as { rows?: unknown[] }).rows?.length ?? 0;
+    case 'compare': return (sec as { columns?: unknown[] }).columns?.length ?? 0;
+    default: return 0;
+  }
+}
+
+function hasPlaceholder(section: Section): boolean {
+  const blob = JSON.stringify(section);
+  return PLACEHOLDER_MARKERS.some(m => blob.includes(m));
+}
+
+/** Ensures domain + seeds preset library on first run. */
+export function ensureAddSectionsDomain(): void {
+  const existing = getRow<{ id: string }>('SELECT id FROM content_domains WHERE id=?', ADD_SECTIONS_DOMAIN);
+  if (!existing) {
+    db.prepare('INSERT INTO content_domains (id, status, published_at) VALUES (?, ?, NULL)')
+      .run(ADD_SECTIONS_DOMAIN, 'draft');
+  }
+
+  for (const spec of allPresetSectionSpecs()) {
+    const row = getRow<{ id: string }>(
+      'SELECT id FROM add_sections WHERE domain_id=? AND id=?',
+      ADD_SECTIONS_DOMAIN,
+      spec.id,
+    );
+    if (row) continue;
+    const payload = specToPayload(spec);
+    db.prepare(
+      'INSERT INTO add_sections (domain_id, id, type, payload_json) VALUES (?, ?, ?, ?)'
+    ).run(ADD_SECTIONS_DOMAIN, spec.id, spec.type, JSON.stringify(payload));
+    markDirty();
+  }
+}
+
+export function listAddSectionsAdmin() {
+  ensureAddSectionsDomain();
+  const domain = getRow<{ published_at: string | null }>(
+    'SELECT published_at FROM content_domains WHERE id=?',
+    ADD_SECTIONS_DOMAIN,
+  );
+  return rows<{ id: string; type: string; payload_json: string }>(
+    'SELECT id, type, payload_json FROM add_sections WHERE domain_id=? ORDER BY id',
+    ADD_SECTIONS_DOMAIN,
+  ).map(row => {
+    const { en, fr } = parsePayload(row.payload_json);
+    return {
+      id: row.id,
+      type: row.type as SectionType,
+      titleEn: en.title,
+      titleFr: fr.title,
+      tabEn: en.tab,
+      tabFr: fr.tab,
+      subtitleEn: en.subtitle,
+      subtitleFr: fr.subtitle,
+      itemCount: Math.max(sectionItemCount(en), sectionItemCount(fr)),
+      publishedAt: domain?.published_at ?? null,
+    };
+  });
+}
+
+export function getAddSectionAdmin(id: string): AddSectionPayload & { id: string; type: SectionType } | null {
+  ensureAddSectionsDomain();
+  const row = getRow<{ id: string; type: string; payload_json: string }>(
+    'SELECT id, type, payload_json FROM add_sections WHERE domain_id=? AND id=?',
+    ADD_SECTIONS_DOMAIN,
+    id,
+  );
+  if (!row) return null;
+  const payload = parsePayload(row.payload_json);
+  return { id: row.id, type: row.type as SectionType, ...payload };
+}
+
+
+function existingSectionIds(): Set<string> {
+  return new Set(rows<{ id: string }>(
+    'SELECT id FROM add_sections WHERE domain_id=?',
+    ADD_SECTIONS_DOMAIN,
+  ).map(r => r.id));
+}
+
+function slugSectionId(raw: string, taken: Set<string>): string {
+  const id = slugify(raw.trim() || 'section', taken);
+  if (!/^[a-z0-9][a-z0-9-]*$/.test(id)) throw new Error('Section id must be lowercase letters, digits and hyphens');
+  return id;
+}
+
+/** Create a custom ADD section in the library. */
+export function createAddSection(input: AddSectionCreate): string {
+  ensureAddSectionsDomain();
+  const taken = existingSectionIds();
+  const titleEn = input.titleEn.trim();
+  if (!titleEn) throw new Error('English title is required');
+  const id = input.id?.trim()
+    ? slugSectionId(input.id.trim(), new Set())
+    : slugSectionId(titleEn, taken);
+  if (taken.has(id)) throw new Error(`Section "${id}" already exists`);
+  const titleFr = (input.titleFr?.trim() || titleEn).trim();
+
+  const en = blankSection(input.type, taken);
+  en.id = id;
+  en.title = titleEn;
+  en.tab = titleEn;
+
+  const fr = structuredClone(en);
+  fr.title = titleFr;
+  fr.tab = titleFr;
+
+  db.prepare(
+    'INSERT INTO add_sections (domain_id, id, type, payload_json) VALUES (?, ?, ?, ?)'
+  ).run(ADD_SECTIONS_DOMAIN, id, input.type, JSON.stringify({ en, fr }));
+  markDirty();
+  return id;
+}
+
+/** Remove a section from the library. Preset rows can be re-seeded on next ensure. */
+export function deleteAddSection(id: string): void {
+  ensureAddSectionsDomain();
+  const result = db.prepare(
+    'DELETE FROM add_sections WHERE domain_id=? AND id=?'
+  ).run(ADD_SECTIONS_DOMAIN, id);
+  if (!result.changes) throw new Error(`section not found: ${id}`);
+  markDirty();
+}
+
+export function updateAddSection(id: string, body: AddSectionPayload): void {
+  ensureAddSectionsDomain();
+  if (!getAddSectionAdmin(id)) throw new Error(`section not found: ${id}`);
+  if (body.en.id !== id || body.fr.id !== id) throw new Error('section id mismatch');
+  db.prepare(
+    'UPDATE add_sections SET type=?, payload_json=? WHERE domain_id=? AND id=?'
+  ).run(body.en.type, JSON.stringify({
+    en: body.en,
+    fr: body.fr,
+  }), ADD_SECTIONS_DOMAIN, id);
+  markDirty();
+}
+
+export function validateAddSectionsPublish(): CatalogIssue[] {
+  ensureAddSectionsDomain();
+  const issues: CatalogIssue[] = [];
+  for (const row of rows<{ id: string; payload_json: string }>(
+    'SELECT id, payload_json FROM add_sections WHERE domain_id=?',
+    ADD_SECTIONS_DOMAIN,
+  )) {
+    const { en, fr } = parsePayload(row.payload_json);
+    for (const [lang, sec] of [['EN', en], ['FR', fr]] as const) {
+      if (hasPlaceholder(sec)) {
+        issues.push({
+          code: 'placeholder_section',
+          message: `Section "${row.id}" contains placeholder content (${lang})`,
+          entityId: row.id,
+          field: lang === 'EN' ? 'en' : 'fr',
+        });
+      }
+    }
+  }
+  return issues;
+}
+
+export function publishAddSections(): PublishAddSectionsResult {
+  const issues = validateAddSectionsPublish();
+  if (issues.length > 0) return { ok: false, issues };
+  const publishedAt = now();
+  db.prepare('UPDATE content_domains SET status=?, published_at=? WHERE id=?')
+    .run('published', publishedAt, ADD_SECTIONS_DOMAIN);
+  return { ok: true, publishedAt };
+}
+
+export function getAddSectionsAdminState(options?: { validate?: boolean }): AddSectionAdminState {
+  ensureAddSectionsDomain();
+  const domain = getRow<{ status: string; published_at: string | null }>(
+    'SELECT status, published_at FROM content_domains WHERE id=?',
+    ADD_SECTIONS_DOMAIN,
+  );
+  const sectionCount = getRow<{ n: number }>(
+    'SELECT COUNT(*) AS n FROM add_sections WHERE domain_id=?',
+    ADD_SECTIONS_DOMAIN,
+  )?.n ?? 0;
+  const state: AddSectionAdminState = {
+    dirty: domain?.status !== 'published',
+    publishedAt: domain?.published_at ?? null,
+    sectionCount,
+  };
+  if (!options?.validate) return state;
+  const issues = validateAddSectionsPublish();
+  return { ...state, issueCount: issues.length, issues };
+}
+
+/** Runtime read when domain is published (ISC-M3). */
+export function getPublishedAddSection(id: string, lang?: Lang): Section | null {
+  ensureAddSectionsDomain();
+  const domain = getRow<{ status: string }>(
+    'SELECT status FROM content_domains WHERE id=?',
+    ADD_SECTIONS_DOMAIN,
+  );
+  if (domain?.status !== 'published') return null;
+  const detail = getAddSectionAdmin(id);
+  if (!detail) return null;
+  const l: Lang = lang ?? 'en';
+  return l === 'fr' ? detail.fr : detail.en;
+}
+
+export function buildSectionPreviewHtml(section: Section, lang: 'en' | 'fr'): string {
+  const doc = blankArchitecture('Section preview');
+  doc.meta.lang = lang;
+  doc.meta.title = section.title;
+  doc.groups = STARTER_GROUPS();
+  doc.layers = STARTER_LAYERS.map(layer => ({ ...layer }));
+  doc.sections = [section];
+  doc.ui.tabs = [section.id];
+  return buildStandaloneHtml(normalizeArchitecture(doc));
+}

--- a/src/lib/admin/architecture-templates.test.ts
+++ b/src/lib/admin/architecture-templates.test.ts
@@ -1,0 +1,250 @@
+import { strict as assert } from 'node:assert';
+import { after, before, describe, test } from 'node:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const dbFile = path.join(os.tmpdir(), `archstudio-architecture-templates-${process.pid}.db`);
+process.env.DATABASE_PATH = dbFile;
+
+let AT: typeof import('./architecture-templates');
+let Tpl: typeof import('../templates');
+
+before(async () => {
+  AT = await import('./architecture-templates');
+  Tpl = await import('../templates');
+});
+
+after(() => {
+  for (const f of [dbFile, `${dbFile}-wal`, `${dbFile}-shm`]) fs.rmSync(f, { force: true });
+});
+
+describe('architecture templates admin', { concurrency: 1 }, () => {
+  test('seeds 6 locked hyperscaler templates', () => {
+    AT.ensureArchitectureTemplatesDomain();
+    const list = AT.listArchitectureTemplatesAdmin();
+    assert.equal(list.filter(t => t.locked).length, 6);
+    for (const id of AT.LOCKED_ARCHITECTURE_TEMPLATE_IDS) {
+      assert.ok(list.some(t => t.id === id && t.locked));
+    }
+  });
+
+  test('instantiate(admin serverless-mvp, agnostic, en) matches code component count', () => {
+    const spec = AT.getArchitectureTemplateSpec('serverless-mvp');
+    const code = Tpl.getTemplate('serverless-mvp');
+    assert.ok(spec);
+    assert.ok(code);
+    const opts = { target: 'agnostic' as const, lang: 'en' as const, projectName: 'Count' };
+    assert.equal(
+      Tpl.instantiate(spec!, opts).components.length,
+      Tpl.instantiate(code!, opts).components.length,
+    );
+  });
+
+  test('update name persists', () => {
+    AT.updateArchitectureTemplate('serverless-mvp', { nameEn: 'Serverless MVP (admin)' });
+    const saved = AT.getArchitectureTemplateSpec('serverless-mvp');
+    assert.equal(Tpl.t(saved!.name, 'en'), 'Serverless MVP (admin)');
+    AT.updateArchitectureTemplate('serverless-mvp', {
+      spec: Tpl.getTemplate('serverless-mvp')!,
+    });
+  });
+
+  test('create and delete custom; locked re-seeds', () => {
+    const id = AT.createArchitectureTemplate({ nameEn: 'Custom hyperscaler probe' });
+    assert.ok(id);
+    assert.ok(AT.getArchitectureTemplateSpec(id));
+    AT.deleteArchitectureTemplate(id);
+    assert.equal(AT.getArchitectureTemplateSpec(id), null);
+
+    AT.deleteArchitectureTemplate('rag');
+    AT.ensureArchitectureTemplatesDomain();
+    assert.ok(AT.getArchitectureTemplateSpec('rag'));
+  });
+
+  test('publish ok when locked six are present', () => {
+    AT.ensureArchitectureTemplatesDomain();
+    const result = AT.publishArchitectureTemplates();
+    assert.equal(result.ok, true);
+    const published = AT.getPublishedArchitectureTemplates();
+    assert.ok(published.length >= 6);
+    assert.ok(AT.getPublishedArchitectureTemplate('monolith'));
+  });
+
+  test('snapshot: rename keeps fr when en unchanged for id', () => {
+    const current = baseTemplate();
+    const snap = snapFrom(current);
+    snap.components = snap.components.map(c =>
+      c.id === 'api' ? { ...c, name: 'API Gateway' } : c,
+    );
+    const next = AT.applyArchitectureSnapshotToSpec(current, snap);
+    const api = next.components.find(c => c.id === 'api')!;
+    assert.deepEqual(api.name, { en: 'API Gateway', fr: 'API Gateway' });
+
+    const snapSameEn = snapFrom(current);
+    // en equals previous en → fr preserved
+    const nextKeep = AT.applyArchitectureSnapshotToSpec(current, snapSameEn);
+    const apiKeep = nextKeep.components.find(c => c.id === 'api')!;
+    assert.deepEqual(apiKeep.name, { en: 'API', fr: 'Passerelle API' });
+  });
+
+  test('snapshot: cloud.aws override survives apply', () => {
+    const current = baseTemplate();
+    const snap = snapFrom(current);
+    snap.components = snap.components.map(c =>
+      c.id === 'api' ? { ...c, name: 'API (edited)' } : c,
+    );
+    const next = AT.applyArchitectureSnapshotToSpec(current, snap);
+    const api = next.components.find(c => c.id === 'api')!;
+    assert.ok(api.cloud?.aws);
+    assert.equal(api.cloud!.aws!.name, 'Amazon API Gateway');
+    assert.deepEqual(api.cloud!.aws!.tech, ['API Gateway']);
+  });
+
+  test('snapshot: deleted component drops from spec and loses cloud', () => {
+    const current = baseTemplate();
+    const snap = snapFrom(current);
+    snap.components = snap.components.filter(c => c.id !== 'db');
+    const next = AT.applyArchitectureSnapshotToSpec(current, snap);
+    assert.equal(next.components.some(c => c.id === 'db'), false);
+    assert.ok(!next.components.some(c => c.cloud?.aws && c.id === 'db'));
+  });
+
+  test('snapshot: added component appears in spec', () => {
+    const current = baseTemplate();
+    const snap = snapFrom(current);
+    snap.components.push({
+      id: 'queue',
+      name: 'Queue',
+      group: 'app',
+      layer: 'data',
+      icon: 'queue',
+      tech: ['SQS'],
+      deps: [],
+    });
+    const next = AT.applyArchitectureSnapshotToSpec(current, snap);
+    const queue = next.components.find(c => c.id === 'queue');
+    assert.ok(queue);
+    assert.deepEqual(queue!.name, { en: 'Queue', fr: 'Queue' });
+    assert.equal(queue!.cloud, undefined);
+  });
+
+  test('snapshot: flow add/remove round-trips', () => {
+    const current = baseTemplate();
+    const snap = snapFrom(current);
+    snap.flows = [
+      {
+        id: 'new-flow',
+        name: 'Checkout',
+        steps: [
+          { component: 'api', title: 'Receive' },
+          { component: 'db', title: 'Persist' },
+        ],
+      },
+    ];
+    const next = AT.applyArchitectureSnapshotToSpec(current, snap);
+    assert.equal(next.flows?.length, 1);
+    assert.equal(next.flows![0]!.id, 'new-flow');
+    assert.deepEqual(next.flows![0]!.name, { en: 'Checkout', fr: 'Checkout' });
+    assert.equal(next.flows!.some(f => f.id === 'happy'), false);
+
+    snap.flows = [];
+    const cleared = AT.applyArchitectureSnapshotToSpec(current, snap);
+    assert.deepEqual(cleared.flows, []);
+  });
+
+  test('updateArchitectureTemplate accepts snapshot and preserves cloud', () => {
+    AT.ensureArchitectureTemplatesDomain();
+    const id = AT.createArchitectureTemplate({
+      nameEn: 'Snapshot probe',
+      spec: baseTemplate(),
+    });
+    const current = AT.getArchitectureTemplateSpec(id)!;
+    const snap = snapFrom(current);
+    snap.components = snap.components.map(c =>
+      c.id === 'api' ? { ...c, name: 'API renamed' } : c,
+    );
+    AT.updateArchitectureTemplate(id, { snapshot: snap });
+    const saved = AT.getArchitectureTemplateSpec(id)!;
+    const api = saved.components.find(c => c.id === 'api')!;
+    assert.deepEqual(api.name, { en: 'API renamed', fr: 'API renamed' });
+    assert.equal(api.cloud?.aws?.name, 'Amazon API Gateway');
+    AT.deleteArchitectureTemplate(id);
+  });
+});
+
+function baseTemplate(): import('../templates/types').Template {
+  return {
+    id: 'probe',
+    name: { en: 'Probe', fr: 'Sonde' },
+    tagline: { en: 'Tag', fr: 'Tag FR' },
+    icon: 'cube',
+    accent: '#111111',
+    accentDark: '#222222',
+    whenToUse: [{ en: 'Use', fr: 'Utiliser' }],
+    whenNotToUse: [{ en: 'Skip', fr: 'Passer' }],
+    supportedTargets: ['agnostic', 'aws'],
+    groups: [{ id: 'app', name: { en: 'App', fr: 'App FR' } }],
+    layers: [
+      { id: 'compute', name: { en: 'Compute', fr: 'Calcul' } },
+      { id: 'data', name: { en: 'Data', fr: 'Données' } },
+    ],
+    components: [
+      {
+        id: 'api',
+        name: { en: 'API', fr: 'Passerelle API' },
+        group: 'app',
+        layer: 'compute',
+        icon: 'api',
+        tech: ['HTTP'],
+        role: { en: 'Entry', fr: 'Entrée' },
+        features: [{ en: 'REST', fr: 'REST FR' }],
+        notes: [{ en: 'Note', fr: 'Note FR' }],
+        deps: ['db'],
+        cloud: {
+          aws: { name: 'Amazon API Gateway', tech: ['API Gateway'] },
+        },
+      },
+      {
+        id: 'db',
+        name: { en: 'Database', fr: 'Base de données' },
+        group: 'app',
+        layer: 'data',
+        icon: 'db',
+        tech: ['SQL'],
+        deps: [],
+        cloud: {
+          aws: { name: 'Amazon RDS', tech: ['RDS'] },
+        },
+      },
+    ],
+    flows: [
+      {
+        id: 'happy',
+        name: { en: 'Happy path', fr: 'Chemin heureux' },
+        steps: [
+          { component: 'api', title: { en: 'Call', fr: 'Appel' } },
+          { component: 'db', title: { en: 'Store', fr: 'Stocker' } },
+        ],
+      },
+    ],
+    sections: [
+      {
+        id: 'overview',
+        type: 'text',
+        title: { en: 'Overview', fr: 'Aperçu' },
+        blocks: [{ title: { en: 'Intro', fr: 'Intro FR' }, body: { en: 'Body', fr: 'Corps' } }],
+      },
+    ],
+    technologies: [{ name: 'HTTP', category: { en: 'Protocol', fr: 'Protocole' } }],
+  };
+}
+
+function snapFrom(tpl: import('../templates/types').Template): import('../types').Architecture {
+  return Tpl.instantiate(tpl, {
+    target: 'agnostic',
+    lang: 'en',
+    projectName: 'Probe',
+    today: '2026-01-01',
+  });
+}

--- a/src/lib/admin/architecture-templates.ts
+++ b/src/lib/admin/architecture-templates.ts
@@ -1,0 +1,750 @@
+import { slugify } from '../defaults';
+import { db, now, plain, plainAll } from '../db';
+import type { CatalogIssue } from '../lego/admin-catalog';
+import { instantiate, TEMPLATES, t, tList } from '../templates';
+import type {
+  CloudTarget,
+  L10n,
+  Template,
+  TemplateComponent,
+  TemplateFlow,
+  TemplateGroup,
+  TemplateLayer,
+  TemplateSection,
+  TemplateTechnology,
+} from '../templates/types';
+import type {
+  Architecture,
+  CardsSection,
+  CompareSection,
+  Component,
+  Flow,
+  Group,
+  Layer,
+  Section,
+  TableSection,
+  Technology,
+  TextSection,
+  TimelineSection,
+} from '../types';
+
+export const ARCHITECTURE_TEMPLATES_DOMAIN = 'architecture-templates';
+
+export const LOCKED_ARCHITECTURE_TEMPLATE_IDS = [
+  'serverless-mvp',
+  'saas-multitenant',
+  'rag',
+  'event-driven',
+  'monolith',
+  'multi-service',
+] as const;
+
+export type LockedArchitectureTemplateId = (typeof LOCKED_ARCHITECTURE_TEMPLATE_IDS)[number];
+
+export type ArchitectureTemplateAdminState = {
+  dirty: boolean;
+  publishedAt: string | null;
+  templateCount: number;
+  issueCount?: number;
+  issues?: CatalogIssue[];
+};
+
+export type PublishArchitectureTemplatesResult =
+  | { ok: true; publishedAt: string }
+  | { ok: false; issues: CatalogIssue[] };
+
+export type ArchitectureTemplateCreate = {
+  id?: string;
+  nameEn: string;
+  nameFr?: string;
+  spec?: Template;
+};
+
+export type ArchitectureTemplatePatch = {
+  nameEn?: string;
+  nameFr?: string;
+  meta?: {
+    icon?: string;
+    accent?: string;
+    accentDark?: string;
+    taglineEn?: string;
+    taglineFr?: string;
+    whenToUseEn?: string[];
+    whenToUseFr?: string[];
+    whenNotToUseEn?: string[];
+    whenNotToUseFr?: string[];
+  };
+  spec?: Template;
+  /** Agnostic Architecture edit snapshot — merged into `spec` without wiping `cloud`. */
+  snapshot?: Architecture;
+};
+
+export type AdminArchitectureListItem = {
+  id: string;
+  kind: 'architecture';
+  editable: true;
+  locked: boolean;
+  nameEn: string;
+  nameFr: string;
+  sortOrder: number;
+  featured: false;
+  componentCount: number;
+  sectionCount: number;
+  flowCount: number;
+  accent: string;
+  icon: string;
+  taglineEn: string;
+  taglineFr: string;
+};
+
+function getRow<T>(sql: string, ...params: (string | number | null)[]): T | null {
+  const raw = db.prepare(sql).get(...params);
+  if (!raw) return null;
+  return plain<T>(raw);
+}
+
+function rows<T>(sql: string, ...values: (string | number | null)[]): T[] {
+  return plainAll<T>(db.prepare(sql).all(...values));
+}
+
+function pair(v: L10n | undefined): { en: string; fr: string } {
+  if (!v) return { en: '', fr: '' };
+  if (typeof v === 'string') return { en: v, fr: v };
+  return { en: v.en ?? '', fr: v.fr ?? '' };
+}
+
+function markDirty(): void {
+  db.prepare('UPDATE content_domains SET status=?, published_at=published_at WHERE id=?')
+    .run('draft', ARCHITECTURE_TEMPLATES_DOMAIN);
+}
+
+function parseTemplate(raw: string | null): Template {
+  if (!raw) throw new Error('architecture template payload_json is missing');
+  return JSON.parse(raw) as Template;
+}
+
+
+function sortArchitectureRows<T extends { id: string }>(items: T[]): T[] {
+  const lockedOrder = new Map<string, number>(LOCKED_ARCHITECTURE_TEMPLATE_IDS.map((id, i) => [id, i]));
+  return [...items].sort((a, b) => {
+    const ai = lockedOrder.has(a.id) ? lockedOrder.get(a.id)! : 1000;
+    const bi = lockedOrder.has(b.id) ? lockedOrder.get(b.id)! : 1000;
+    if (ai !== bi) return ai - bi;
+    return a.id.localeCompare(b.id);
+  });
+}
+
+export function isLockedArchitectureTemplate(id: string): boolean {
+  return (LOCKED_ARCHITECTURE_TEMPLATE_IDS as readonly string[]).includes(id);
+}
+
+function existingIds(): Set<string> {
+  return new Set(rows<{ id: string }>(
+    'SELECT id FROM architecture_templates WHERE domain_id=?',
+    ARCHITECTURE_TEMPLATES_DOMAIN,
+  ).map(r => r.id));
+}
+
+function blankTemplate(id: string, nameEn: string, nameFr: string): Template {
+  return {
+    id,
+    name: { en: nameEn, fr: nameFr },
+    tagline: { en: nameEn, fr: nameFr },
+    icon: 'cube',
+    accent: '#4F8AC6',
+    accentDark: '#00E5FF',
+    whenToUse: [{ en: 'A custom starting point.', fr: 'Un point de départ personnalisé.' }],
+    whenNotToUse: [{ en: 'Not a recommendation.', fr: 'Pas une recommandation.' }],
+    supportedTargets: ['agnostic', 'aws', 'gcp', 'azure', 'selfhosted'],
+    groups: [{ id: 'app', name: { en: 'Application', fr: 'Application' } }],
+    layers: [{ id: 'compute', name: { en: 'Compute', fr: 'Calcul' } }],
+    components: [{
+      id: 'app',
+      name: { en: 'Application', fr: 'Application' },
+      group: 'app',
+      layer: 'compute',
+    }],
+  };
+}
+
+function validatePayload(tpl: Template, expectedId?: string): CatalogIssue[] {
+  const issues: CatalogIssue[] = [];
+  const id = tpl.id?.trim() ?? '';
+  if (!id) {
+    issues.push({ code: 'invalid_architecture_template', message: 'Template is missing id', field: 'id' });
+  } else if (expectedId && id !== expectedId) {
+    issues.push({
+      code: 'invalid_architecture_template',
+      message: `Template id "${id}" does not match row "${expectedId}"`,
+      entityId: expectedId,
+      field: 'id',
+    });
+  }
+  const name = pair(tpl.name);
+  if (!name.en.trim() && !name.fr.trim()) {
+    issues.push({
+      code: 'invalid_architecture_template',
+      message: `Template "${id || expectedId || '?'}" is missing name`,
+      entityId: id || expectedId,
+      field: 'name',
+    });
+  }
+  if (!Array.isArray(tpl.components) || tpl.components.length < 1) {
+    issues.push({
+      code: 'invalid_architecture_template',
+      message: `Template "${id || expectedId || '?'}" needs at least one component`,
+      entityId: id || expectedId,
+      field: 'components',
+    });
+  }
+  return issues;
+}
+
+/** Ensures domain + seeds the six locked hyperscaler templates from the code registry. */
+export function ensureArchitectureTemplatesDomain(): void {
+  const existing = getRow<{ id: string }>('SELECT id FROM content_domains WHERE id=?', ARCHITECTURE_TEMPLATES_DOMAIN);
+  if (!existing) {
+    db.prepare('INSERT INTO content_domains (id, status, published_at) VALUES (?, ?, NULL)')
+      .run(ARCHITECTURE_TEMPLATES_DOMAIN, 'draft');
+  }
+  for (const tpl of TEMPLATES) {
+    const row = getRow<{ id: string }>(
+      'SELECT id FROM architecture_templates WHERE domain_id=? AND id=?',
+      ARCHITECTURE_TEMPLATES_DOMAIN,
+      tpl.id,
+    );
+    if (row) continue;
+    db.prepare(
+      'INSERT INTO architecture_templates (domain_id, id, payload_json) VALUES (?, ?, ?)'
+    ).run(ARCHITECTURE_TEMPLATES_DOMAIN, tpl.id, JSON.stringify(tpl));
+    markDirty();
+  }
+}
+
+export function listArchitectureTemplatesAdmin(): AdminArchitectureListItem[] {
+  ensureArchitectureTemplatesDomain();
+  return sortArchitectureRows(rows<{ id: string; payload_json: string }>(
+    'SELECT id, payload_json FROM architecture_templates WHERE domain_id=?',
+    ARCHITECTURE_TEMPLATES_DOMAIN,
+  )).map((row, index) => {
+    const tpl = parseTemplate(row.payload_json);
+    return {
+      id: tpl.id,
+      kind: 'architecture' as const,
+      editable: true as const,
+      locked: isLockedArchitectureTemplate(tpl.id),
+      nameEn: t(tpl.name, 'en'),
+      nameFr: t(tpl.name, 'fr'),
+      sortOrder: 100 + index,
+      featured: false as const,
+      componentCount: tpl.components.length,
+      sectionCount: tpl.sections?.length ?? 0,
+      flowCount: tpl.flows?.length ?? 0,
+      accent: tpl.accent,
+      icon: tpl.icon,
+      taglineEn: t(tpl.tagline, 'en'),
+      taglineFr: t(tpl.tagline, 'fr'),
+    };
+  });
+}
+
+export function getArchitectureTemplateSpec(id: string): Template | null {
+  ensureArchitectureTemplatesDomain();
+  const row = getRow<{ payload_json: string }>(
+    'SELECT payload_json FROM architecture_templates WHERE domain_id=? AND id=?',
+    ARCHITECTURE_TEMPLATES_DOMAIN,
+    id,
+  );
+  if (!row) return null;
+  return parseTemplate(row.payload_json);
+}
+
+/** Admin detail: SQLite spec plus an agnostic instantiate snapshot for preview. */
+export function getArchitectureTemplateAdmin(id: string) {
+  const tpl = getArchitectureTemplateSpec(id);
+  if (!tpl) return null;
+  return {
+    id: tpl.id,
+    kind: 'architecture' as const,
+    editable: true as const,
+    locked: isLockedArchitectureTemplate(tpl.id),
+    nameEn: t(tpl.name, 'en'),
+    nameFr: t(tpl.name, 'fr'),
+    meta: {
+      icon: tpl.icon,
+      accent: tpl.accent,
+      accentDark: tpl.accentDark,
+      taglineEn: t(tpl.tagline, 'en'),
+      taglineFr: t(tpl.tagline, 'fr'),
+      whenToUseEn: tList(tpl.whenToUse, 'en'),
+      whenToUseFr: tList(tpl.whenToUse, 'fr'),
+      whenNotToUseEn: tList(tpl.whenNotToUse, 'en'),
+      whenNotToUseFr: tList(tpl.whenNotToUse, 'fr'),
+    },
+    supportedTargets: tpl.supportedTargets as CloudTarget[],
+    spec: tpl,
+    outline: {
+      componentCount: tpl.components.length,
+      sectionIds: (tpl.sections ?? []).map(s => s.id),
+      flowCount: tpl.flows?.length ?? 0,
+    },
+    snapshot: instantiate(tpl, {
+      target: 'agnostic',
+      lang: 'en',
+      projectName: t(tpl.name, 'en'),
+    }),
+  };
+}
+
+export function createArchitectureTemplate(input: ArchitectureTemplateCreate): string {
+  ensureArchitectureTemplatesDomain();
+  const taken = existingIds();
+  const nameEn = input.nameEn.trim();
+  if (!nameEn) throw new Error('English name is required');
+  const id = input.id?.trim()
+    ? slugify(input.id.trim(), new Set())
+    : slugify(nameEn, taken);
+  if (!/^[a-z0-9][a-z0-9-]*$/.test(id)) {
+    throw new Error('Template id must be lowercase letters, digits and hyphens');
+  }
+  if (taken.has(id)) throw new Error(`Architecture template "${id}" already exists`);
+  const nameFr = (input.nameFr?.trim() || nameEn).trim();
+  const tpl = input.spec
+    ? { ...input.spec, id }
+    : blankTemplate(id, nameEn, nameFr);
+  const issues = validatePayload(tpl, id);
+  if (issues.length > 0) throw new Error(issues[0]!.message);
+  db.prepare(
+    'INSERT INTO architecture_templates (domain_id, id, payload_json) VALUES (?, ?, ?)'
+  ).run(ARCHITECTURE_TEMPLATES_DOMAIN, id, JSON.stringify(tpl));
+  markDirty();
+  return id;
+}
+
+export function deleteArchitectureTemplate(id: string): void {
+  ensureArchitectureTemplatesDomain();
+  const result = db.prepare(
+    'DELETE FROM architecture_templates WHERE domain_id=? AND id=?'
+  ).run(ARCHITECTURE_TEMPLATES_DOMAIN, id);
+  if (!result.changes) throw new Error(`architecture template not found: ${id}`);
+  markDirty();
+}
+
+/**
+ * Merge an edited Architecture snapshot back into a Template spec.
+ * Picker meta (id/name/tagline/icon/accents/when*) stays on `current`.
+ * Component `cloud` overrides are copied by id when the component still exists.
+ *
+ * Section conversion is best-effort: Architecture sections are lang-resolved
+ * strings while TemplateSection uses L10n. We sync cards/text/timeline/table/
+ * compare fields that exist on both shapes and preserve `fr` when the previous
+ * section's `en` still matches. Gaps: `doc` slots, index-signature extras, and
+ * any viewer-only keys not on TemplateSection are dropped.
+ */
+export function applyArchitectureSnapshotToSpec(current: Template, snap: Architecture): Template {
+  const prevById = new Map(current.components.map(c => [c.id, c]));
+  const prevGroups = new Map(current.groups.map(g => [g.id, g]));
+  const prevLayers = new Map(current.layers.map(l => [l.id, l]));
+  const prevFlows = new Map((current.flows ?? []).map(f => [f.id, f]));
+  const prevSections = new Map((current.sections ?? []).map(s => [s.id, s]));
+
+  const groups: TemplateGroup[] = (snap.groups ?? []).map(g => mapGroup(g, prevGroups.get(g.id)));
+  const layers: TemplateLayer[] = (snap.layers ?? []).map(l => mapLayer(l, prevLayers.get(l.id)));
+  const components: TemplateComponent[] = (snap.components ?? []).map(c =>
+    mapComponent(c, prevById.get(c.id)),
+  );
+  const flows: TemplateFlow[] = (snap.flows ?? []).map(f => mapFlow(f, prevFlows.get(f.id)));
+  const sections: TemplateSection[] = (snap.sections ?? [])
+    .map(s => mapSection(s, prevSections.get(s.id)))
+    .filter((s): s is TemplateSection => s !== null);
+
+  const technologies: TemplateTechnology[] | undefined = snap.technologies?.length
+    ? snap.technologies.map(tech => mapTechnology(tech, current.technologies))
+    : current.technologies;
+
+  return {
+    ...current,
+    groups,
+    layers,
+    components,
+    flows,
+    sections,
+    ...(technologies ? { technologies } : {}),
+  };
+}
+
+/** Preserve `fr` when previous was `{en,fr}` and `en` still equals the snapshot string. */
+function mergeL10n(prev: L10n | undefined, next: string | undefined): L10n {
+  const snap = next ?? '';
+  if (prev && typeof prev === 'object' && !Array.isArray(prev) && prev.en === snap) {
+    return { en: snap, fr: prev.fr };
+  }
+  return { en: snap, fr: snap };
+}
+
+function mergeL10nList(prev: L10n[] | undefined, next: string[] | undefined): L10n[] | undefined {
+  if (!next) return undefined;
+  return next.map((item, i) => mergeL10n(prev?.[i], item));
+}
+
+function mapGroup(g: Group, prev: TemplateGroup | undefined): TemplateGroup {
+  return {
+    id: g.id,
+    name: mergeL10n(prev?.name, g.name),
+    ...(g.short !== undefined ? { short: mergeL10n(prev?.short, g.short) } : {}),
+    ...(g.description !== undefined ? { description: mergeL10n(prev?.description, g.description) } : {}),
+    ...(g.color !== undefined ? { color: g.color } : {}),
+    ...(g.colorDark !== undefined ? { colorDark: g.colorDark } : {}),
+  };
+}
+
+function mapLayer(l: Layer, prev: TemplateLayer | undefined): TemplateLayer {
+  return {
+    id: l.id,
+    name: mergeL10n(prev?.name, l.name),
+    ...(l.desc !== undefined ? { desc: mergeL10n(prev?.desc, l.desc) } : {}),
+  };
+}
+
+function mapComponent(c: Component, prev: TemplateComponent | undefined): TemplateComponent {
+  const out: TemplateComponent = {
+    id: c.id,
+    name: mergeL10n(prev?.name, c.name),
+    group: c.group,
+    layer: c.layer,
+  };
+  if (c.icon !== undefined) out.icon = c.icon;
+  if (c.badge !== undefined) out.badge = mergeL10n(prev?.badge, c.badge);
+  if (c.tech !== undefined) out.tech = c.tech;
+  if (c.role !== undefined) out.role = mergeL10n(prev?.role, c.role);
+  const features = mergeL10nList(prev?.features, c.features);
+  if (features) out.features = features;
+  const notes = mergeL10nList(prev?.notes, c.notes);
+  if (notes) out.notes = notes;
+  if (c.deps !== undefined) out.deps = c.deps;
+  if (prev?.cloud) out.cloud = structuredClone(prev.cloud);
+  return out;
+}
+
+function mapFlow(f: Flow, prev: TemplateFlow | undefined): TemplateFlow {
+  const prevSteps = prev?.steps ?? [];
+  return {
+    id: f.id,
+    name: mergeL10n(prev?.name, f.name),
+    ...(f.group !== undefined ? { group: f.group } : {}),
+    ...(f.sub !== undefined ? { sub: mergeL10n(prev?.sub, f.sub) } : {}),
+    ...(f.note !== undefined ? { note: mergeL10n(prev?.note, f.note) } : {}),
+    steps: (f.steps ?? []).map((step, i) => ({
+      component: step.component,
+      title: mergeL10n(prevSteps[i]?.title, step.title),
+      ...(step.description !== undefined
+        ? { description: mergeL10n(prevSteps[i]?.description, step.description) }
+        : {}),
+    })),
+  };
+}
+
+function mapTechnology(tech: Technology, prevList: TemplateTechnology[] | undefined): TemplateTechnology {
+  const prev = prevList?.find(p => p.name === tech.name);
+  return {
+    name: tech.name,
+    ...(tech.category !== undefined ? { category: mergeL10n(prev?.category, tech.category) } : {}),
+    ...(tech.description !== undefined ? { description: mergeL10n(prev?.description, tech.description) } : {}),
+    ...(tech.groups !== undefined ? { groups: tech.groups } : {}),
+  };
+}
+
+function mapSection(s: Section, prev: TemplateSection | undefined): TemplateSection | null {
+  const base = {
+    id: s.id,
+    type: s.type,
+    title: mergeL10n(prev?.title, s.title),
+    ...(s.tab !== undefined ? { tab: mergeL10n(prev?.tab, s.tab) } : {}),
+    ...(s.subtitle !== undefined ? { subtitle: mergeL10n(prev?.subtitle, s.subtitle) } : {}),
+    ...(s.note !== undefined ? { note: mergeL10n(prev?.note, s.note) } : {}),
+  };
+
+  switch (s.type) {
+    case 'text': {
+      const text = s as TextSection;
+      const prevText = prev?.type === 'text' ? prev : undefined;
+      return {
+        ...base,
+        type: 'text',
+        blocks: (text.blocks ?? []).map((block, i) => {
+          const pb = prevText?.blocks?.[i];
+          return {
+            ...(block.group !== undefined ? { group: block.group } : {}),
+            ...(block.title !== undefined ? { title: mergeL10n(pb?.title, block.title) } : {}),
+            ...(block.body !== undefined
+              ? {
+                  body: Array.isArray(block.body)
+                    ? block.body.map((line, j) => {
+                        const prevBody = pb?.body;
+                        const prevLine = Array.isArray(prevBody) ? prevBody[j] : undefined;
+                        return mergeL10n(prevLine, line);
+                      })
+                    : mergeL10n(typeof pb?.body === 'string' || (pb?.body && !Array.isArray(pb.body)) ? pb.body as L10n : undefined, block.body),
+                }
+              : {}),
+          };
+        }),
+      };
+    }
+    case 'cards': {
+      const cards = s as CardsSection;
+      const prevCards = prev?.type === 'cards' ? prev : undefined;
+      return {
+        ...base,
+        type: 'cards',
+        items: (cards.items ?? []).map((item, i) => {
+          const pi = prevCards?.items?.[i];
+          return {
+            ...(item.group !== undefined ? { group: item.group } : {}),
+            ...(item.icon !== undefined ? { icon: item.icon } : {}),
+            title: mergeL10n(pi?.title, item.title),
+            ...(item.body !== undefined ? { body: mergeL10n(pi?.body, item.body) } : {}),
+            ...(item.bullets !== undefined ? { bullets: mergeL10nList(pi?.bullets, item.bullets) } : {}),
+          };
+        }),
+      };
+    }
+    case 'timeline': {
+      const tl = s as TimelineSection;
+      const prevTl = prev?.type === 'timeline' ? prev : undefined;
+      return {
+        ...base,
+        type: 'timeline',
+        ...(tl.lineTitle !== undefined ? { lineTitle: mergeL10n(prevTl?.lineTitle, tl.lineTitle) } : {}),
+        items: (tl.items ?? []).map((item, i) => {
+          const pi = prevTl?.items?.[i];
+          return {
+            ...(item.group !== undefined ? { group: item.group } : {}),
+            ...(item.period !== undefined ? { period: mergeL10n(pi?.period, item.period) } : {}),
+            title: mergeL10n(pi?.title, item.title),
+            ...(item.bullets !== undefined ? { bullets: mergeL10nList(pi?.bullets, item.bullets) } : {}),
+          };
+        }),
+        ...(tl.aside
+          ? {
+              aside: tl.aside.map((item, i) => {
+                const pi = prevTl?.aside?.[i];
+                return {
+                  ...(item.group !== undefined ? { group: item.group } : {}),
+                  ...(item.icon !== undefined ? { icon: item.icon } : {}),
+                  title: mergeL10n(pi?.title, item.title),
+                  ...(item.body !== undefined ? { body: mergeL10n(pi?.body, item.body) } : {}),
+                  ...(item.bullets !== undefined ? { bullets: mergeL10nList(pi?.bullets, item.bullets) } : {}),
+                };
+              }),
+            }
+          : {}),
+      };
+    }
+    case 'table': {
+      const table = s as TableSection;
+      const prevTable = prev?.type === 'table' ? prev : undefined;
+      return {
+        ...base,
+        type: 'table',
+        columns: (table.columns ?? []).map((col, i) => ({
+          label: mergeL10n(prevTable?.columns?.[i]?.label, col.label),
+          ...(col.width !== undefined ? { width: col.width } : {}),
+          ...(col.group !== undefined ? { group: col.group } : {}),
+        })),
+        rows: (table.rows ?? []).map((row, ri) =>
+          row.map((cell, ci) => mergeL10n(prevTable?.rows?.[ri]?.[ci], cell)),
+        ),
+      };
+    }
+    case 'compare': {
+      const cmp = s as CompareSection;
+      const prevCmp = prev?.type === 'compare' ? prev : undefined;
+      return {
+        ...base,
+        type: 'compare',
+        columns: (cmp.columns ?? []).map((col, i) => {
+          const pc = prevCmp?.columns?.[i];
+          return {
+            ...(col.group !== undefined ? { group: col.group } : {}),
+            ...(col.kicker !== undefined ? { kicker: mergeL10n(pc?.kicker, col.kicker) } : {}),
+            title: mergeL10n(pc?.title, col.title),
+            ...(col.short !== undefined ? { short: mergeL10n(pc?.short, col.short) } : {}),
+            ...(col.pitch !== undefined ? { pitch: mergeL10n(pc?.pitch, col.pitch) } : {}),
+            ...(col.rows !== undefined
+              ? {
+                  rows: col.rows.map((row, ri) =>
+                    row.map((cell, ci) => mergeL10n(pc?.rows?.[ri]?.[ci], cell)),
+                  ),
+                }
+              : {}),
+            ...(col.bullets !== undefined ? { bullets: mergeL10nList(pc?.bullets, col.bullets) } : {}),
+          };
+        }),
+        ...(cmp.table
+          ? {
+              table: {
+                ...(cmp.table.title !== undefined
+                  ? { title: mergeL10n(prevCmp?.table?.title, cmp.table.title) }
+                  : {}),
+                ...(cmp.table.subtitle !== undefined
+                  ? { subtitle: mergeL10n(prevCmp?.table?.subtitle, cmp.table.subtitle) }
+                  : {}),
+                ...(cmp.table.firstColumn !== undefined
+                  ? { firstColumn: mergeL10n(prevCmp?.table?.firstColumn, cmp.table.firstColumn) }
+                  : {}),
+                rows: (cmp.table.rows ?? []).map((row, ri) =>
+                  row.map((cell, ci) => mergeL10n(prevCmp?.table?.rows?.[ri]?.[ci], cell)),
+                ),
+              },
+            }
+          : {}),
+        ...(cmp.cards
+          ? {
+              cards: cmp.cards.map((card, i) => {
+                const pc = prevCmp?.cards?.[i];
+                return {
+                  ...(card.group !== undefined ? { group: card.group } : {}),
+                  title: mergeL10n(pc?.title, card.title),
+                  ...(card.subtitle !== undefined ? { subtitle: mergeL10n(pc?.subtitle, card.subtitle) } : {}),
+                  ...(card.bullets !== undefined ? { bullets: mergeL10nList(pc?.bullets, card.bullets) } : {}),
+                  ...(card.note !== undefined ? { note: mergeL10n(pc?.note, card.note) } : {}),
+                };
+              }),
+            }
+          : {}),
+      };
+    }
+    default:
+      return null;
+  }
+}
+
+export function updateArchitectureTemplate(id: string, patch: ArchitectureTemplatePatch): void {
+  ensureArchitectureTemplatesDomain();
+  const current = getArchitectureTemplateSpec(id);
+  if (!current) throw new Error(`architecture template not found: ${id}`);
+  let next: Template;
+  if (patch.snapshot) {
+    next = applyArchitectureSnapshotToSpec(current, patch.snapshot);
+  } else if (patch.spec) {
+    next = { ...patch.spec, id };
+  } else {
+    next = structuredClone(current);
+  }
+  if (patch.nameEn !== undefined || patch.nameFr !== undefined) {
+    const names = pair(next.name);
+    next.name = {
+      en: patch.nameEn ?? names.en,
+      fr: patch.nameFr ?? names.fr,
+    };
+  }
+  if (patch.meta) {
+    if (patch.meta.icon !== undefined) next.icon = patch.meta.icon;
+    if (patch.meta.accent !== undefined) next.accent = patch.meta.accent;
+    if (patch.meta.accentDark !== undefined) next.accentDark = patch.meta.accentDark;
+    if (patch.meta.taglineEn !== undefined || patch.meta.taglineFr !== undefined) {
+      const tag = pair(next.tagline);
+      next.tagline = {
+        en: patch.meta.taglineEn ?? tag.en,
+        fr: patch.meta.taglineFr ?? tag.fr,
+      };
+    }
+    if (patch.meta.whenToUseEn || patch.meta.whenToUseFr) {
+      const en = patch.meta.whenToUseEn ?? tList(next.whenToUse, 'en');
+      const fr = patch.meta.whenToUseFr ?? tList(next.whenToUse, 'fr');
+      next.whenToUse = en.map((item, i) => ({ en: item, fr: fr[i] ?? item }));
+    }
+    if (patch.meta.whenNotToUseEn || patch.meta.whenNotToUseFr) {
+      const en = patch.meta.whenNotToUseEn ?? tList(next.whenNotToUse, 'en');
+      const fr = patch.meta.whenNotToUseFr ?? tList(next.whenNotToUse, 'fr');
+      next.whenNotToUse = en.map((item, i) => ({ en: item, fr: fr[i] ?? item }));
+    }
+  }
+  const issues = validatePayload(next, id);
+  if (issues.length > 0) throw new Error(issues[0]!.message);
+  db.prepare(
+    'UPDATE architecture_templates SET payload_json=? WHERE domain_id=? AND id=?'
+  ).run(JSON.stringify(next), ARCHITECTURE_TEMPLATES_DOMAIN, id);
+  markDirty();
+}
+
+export function validateArchitectureTemplatesPublish(): CatalogIssue[] {
+  ensureArchitectureTemplatesDomain();
+  const issues: CatalogIssue[] = [];
+  const rowsData = rows<{ id: string; payload_json: string }>(
+    'SELECT id, payload_json FROM architecture_templates WHERE domain_id=?',
+    ARCHITECTURE_TEMPLATES_DOMAIN,
+  );
+  for (const expectedId of LOCKED_ARCHITECTURE_TEMPLATE_IDS) {
+    if (!rowsData.some(r => r.id === expectedId)) {
+      issues.push({
+        code: 'missing_architecture_template',
+        message: `Missing locked architecture template "${expectedId}"`,
+        entityId: expectedId,
+      });
+    }
+  }
+  for (const row of rowsData) {
+    issues.push(...validatePayload(parseTemplate(row.payload_json), row.id));
+  }
+  return issues;
+}
+
+export function publishArchitectureTemplates(): PublishArchitectureTemplatesResult {
+  const issues = validateArchitectureTemplatesPublish();
+  if (issues.length > 0) return { ok: false, issues };
+  const publishedAt = now();
+  db.prepare('UPDATE content_domains SET status=?, published_at=? WHERE id=?')
+    .run('published', publishedAt, ARCHITECTURE_TEMPLATES_DOMAIN);
+  return { ok: true, publishedAt };
+}
+
+export function getArchitectureTemplatesAdminState(options?: { validate?: boolean }): ArchitectureTemplateAdminState {
+  ensureArchitectureTemplatesDomain();
+  const domain = getRow<{ status: string; published_at: string | null }>(
+    'SELECT status, published_at FROM content_domains WHERE id=?',
+    ARCHITECTURE_TEMPLATES_DOMAIN,
+  );
+  const templateCount = getRow<{ n: number }>(
+    'SELECT COUNT(*) AS n FROM architecture_templates WHERE domain_id=?',
+    ARCHITECTURE_TEMPLATES_DOMAIN,
+  )?.n ?? 0;
+  const state: ArchitectureTemplateAdminState = {
+    dirty: domain?.status !== 'published',
+    publishedAt: domain?.published_at ?? null,
+    templateCount,
+  };
+  if (!options?.validate) return state;
+  const issues = validateArchitectureTemplatesPublish();
+  return { ...state, issueCount: issues.length, issues };
+}
+
+function domainPublished(): boolean {
+  ensureArchitectureTemplatesDomain();
+  const domain = getRow<{ status: string }>(
+    'SELECT status FROM content_domains WHERE id=?',
+    ARCHITECTURE_TEMPLATES_DOMAIN,
+  );
+  return domain?.status === 'published';
+}
+
+/** Runtime read when the domain is published (ISC-M5). Empty if draft. */
+export function getPublishedArchitectureTemplates(): Template[] {
+  if (!domainPublished()) return [];
+  return sortArchitectureRows(rows<{ id: string; payload_json: string }>(
+    'SELECT id, payload_json FROM architecture_templates WHERE domain_id=?',
+    ARCHITECTURE_TEMPLATES_DOMAIN,
+  )).map(row => parseTemplate(row.payload_json));
+}
+
+export function getPublishedArchitectureTemplate(id: string): Template | undefined {
+  if (!domainPublished()) return undefined;
+  const row = getRow<{ payload_json: string }>(
+    'SELECT payload_json FROM architecture_templates WHERE domain_id=? AND id=?',
+    ARCHITECTURE_TEMPLATES_DOMAIN,
+    id,
+  );
+  if (!row) return undefined;
+  return parseTemplate(row.payload_json);
+}

--- a/src/lib/admin/architecture.ts
+++ b/src/lib/admin/architecture.ts
@@ -1,0 +1,69 @@
+import { api } from '@/lib/api';
+import type { CatalogIssue } from '@/lib/lego/admin-catalog';
+import type { Architecture } from '@/lib/types';
+import type { Template } from '@/lib/templates/types';
+
+export type ArchitectureTemplatePatch = {
+  nameEn?: string;
+  nameFr?: string;
+  meta?: {
+    icon?: string;
+    accent?: string;
+    accentDark?: string;
+    taglineEn?: string;
+    taglineFr?: string;
+    whenToUseEn?: string[];
+    whenToUseFr?: string[];
+    whenNotToUseEn?: string[];
+    whenNotToUseFr?: string[];
+  };
+  spec?: Template;
+  /** Agnostic Architecture edit — merged into Template spec; preserves `cloud` by id. */
+  snapshot?: Architecture;
+};
+
+export type ArchitectureTemplateCreate = {
+  id?: string;
+  nameEn: string;
+  nameFr?: string;
+  spec?: Template;
+};
+
+export type ArchitectureLibraryState = {
+  dirty: boolean;
+  publishedAt: string | null;
+  templateCount: number;
+  issueCount?: number;
+  issues?: CatalogIssue[];
+};
+
+export function fetchArchitectureTemplateState(options?: { validate?: boolean }): Promise<ArchitectureLibraryState> {
+  const qs = options?.validate ? '?validate=1' : '';
+  return api.json(`/api/admin/architecture-templates/state${qs}`);
+}
+
+export function createArchitectureTemplate(body: ArchitectureTemplateCreate): Promise<{ ok: boolean; id: string }> {
+  return api.json('/api/admin/architecture-templates', { method: 'POST', body: JSON.stringify(body) });
+}
+
+export function updateArchitectureTemplate(id: string, body: ArchitectureTemplatePatch): Promise<{ ok: boolean; id: string }> {
+  return api.json(`/api/admin/architecture-templates/${id}`, { method: 'PATCH', body: JSON.stringify(body) });
+}
+
+export function deleteArchitectureTemplate(id: string): Promise<{ ok: boolean; id: string }> {
+  return api.json(`/api/admin/architecture-templates/${id}`, { method: 'DELETE' });
+}
+
+export async function publishArchitectureTemplates(): Promise<
+  | { ok: true; publishedAt: string }
+  | { ok: false; error: string; issues: CatalogIssue[] }
+> {
+  const res = await fetch('/api/admin/architecture-templates/publish', { method: 'POST' });
+  const body = await res.json().catch(() => ({}));
+  if (res.ok) return { ok: true, publishedAt: body.publishedAt as string };
+  return {
+    ok: false,
+    error: (body.error as string) || res.statusText,
+    issues: (body.issues as CatalogIssue[]) ?? [],
+  };
+}

--- a/src/lib/admin/bundle.client.ts
+++ b/src/lib/admin/bundle.client.ts
@@ -1,0 +1,85 @@
+import { api } from '@/lib/api';
+import type { CatalogIssue } from '@/lib/lego/admin-catalog';
+
+export type BundleImportMode = 'merge' | 'replace';
+
+export type ContentBundle = {
+  version: 1;
+  exportedAt: string;
+  domains: Record<string, unknown>;
+};
+
+export type BundleSummary = {
+  domains?: ContentBundle['domains'];
+  counts?: Record<string, number>;
+  exportedAt?: string;
+  mode?: BundleImportMode;
+};
+
+function countDomain(value: unknown): number {
+  if (value == null) return 0;
+  if (Array.isArray(value)) return value.length;
+  if (typeof value === 'object') return Object.keys(value as object).length;
+  return 0;
+}
+
+export function summarizeBundle(bundle: ContentBundle): BundleSummary {
+  const counts: Record<string, number> = {};
+  for (const [domain, payload] of Object.entries(bundle.domains ?? {})) {
+    counts[domain] = countDomain(payload);
+  }
+  return {
+    domains: bundle.domains,
+    counts,
+    exportedAt: bundle.exportedAt,
+  };
+}
+
+export function domainEntries(summary: BundleSummary | null | undefined): [string, number][] {
+  if (!summary) return [];
+  if (summary.counts && Object.keys(summary.counts).length > 0) {
+    return Object.entries(summary.counts).sort(([a], [b]) => a.localeCompare(b));
+  }
+  if (!summary.domains) return [];
+  return Object.entries(summary.domains)
+    .map(([domain, payload]) => [domain, countDomain(payload)] as [string, number])
+    .sort(([a], [b]) => a.localeCompare(b));
+}
+
+/** Client export — downloads via blob; summary for Import page. */
+export async function exportContentBundle(): Promise<{ blob: Blob; summary: BundleSummary }> {
+  const bundle = await api.json<ContentBundle>('/api/admin/bundle');
+  const summary = summarizeBundle(bundle);
+  const blob = new Blob([JSON.stringify(bundle, null, 2)], { type: 'application/json' });
+  return { blob, summary };
+}
+
+export async function importContentBundle(
+  bundle: unknown,
+  mode: BundleImportMode = 'merge',
+): Promise<
+  | { ok: true; issues: CatalogIssue[]; summary: BundleSummary }
+  | { ok: false; error: string; issues: CatalogIssue[] }
+> {
+  const res = await fetch('/api/admin/bundle', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ mode, bundle }),
+  });
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    return {
+      ok: false,
+      error: (body.error as string) || res.statusText || 'Import failed',
+      issues: (body.issues as CatalogIssue[]) ?? [],
+    };
+  }
+  const summary: BundleSummary = {
+    ...(typeof bundle === 'object' && bundle && 'domains' in bundle
+      ? summarizeBundle(bundle as ContentBundle)
+      : { counts: {} }),
+    mode,
+    exportedAt: new Date().toISOString(),
+  };
+  return { ok: true, issues: (body.issues as CatalogIssue[]) ?? [], summary };
+}

--- a/src/lib/admin/bundle.test.ts
+++ b/src/lib/admin/bundle.test.ts
@@ -1,0 +1,47 @@
+import { strict as assert } from 'node:assert';
+import { after, before, describe, test } from 'node:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const dbFile = path.join(os.tmpdir(), `archstudio-bundle-${process.pid}.db`);
+process.env.DATABASE_PATH = dbFile;
+
+let Bundle: typeof import('./bundle');
+let SC: typeof import('./system-copy');
+
+before(async () => {
+  SC = await import('./system-copy');
+  Bundle = await import('./bundle');
+});
+
+after(() => {
+  for (const f of [dbFile, `${dbFile}-wal`, `${dbFile}-shm`]) fs.rmSync(f, { force: true });
+});
+
+describe('content bundle', { concurrency: 1 }, () => {
+  test('export bundle includes system-copy keys', () => {
+    SC.ensureSystemCopyDomain();
+    const bundle = Bundle.exportContentBundle();
+    assert.equal(bundle.version, 1);
+    assert.ok(bundle.exportedAt);
+    assert.ok(bundle.domains['system-copy']);
+    assert.ok(bundle.domains['system-copy']!['flow.default.name']);
+    assert.ok(bundle.domains['system-copy']!['layer.clients']);
+  });
+
+  test('import merge restores a key', () => {
+    SC.ensureSystemCopyDomain();
+    SC.upsertSystemCopy('flow.default.sub', { en: 'Consumer · under an hour', fr: 'Sous-titre exporté' });
+    const exported = Bundle.exportContentBundle();
+
+    SC.upsertSystemCopy('flow.default.sub', { en: 'Consumer · under an hour', fr: 'Écrasé localement' });
+    assert.equal(SC.getSystemCopy('flow.default.sub')?.fr, 'Écrasé localement');
+
+    const result = Bundle.importContentBundle(exported, { mode: 'merge' });
+    assert.equal(result.ok, true);
+    assert.equal(SC.getSystemCopy('flow.default.sub')?.fr, 'Sous-titre exporté');
+    const state = SC.getSystemCopyState();
+    assert.equal(state.dirty, true);
+  });
+});

--- a/src/lib/admin/bundle.ts
+++ b/src/lib/admin/bundle.ts
@@ -1,0 +1,377 @@
+import { blankArchitecture } from '../defaults';
+import { db, plainAll } from '../db';
+import type { CatalogIssue } from '../lego/admin-catalog';
+import type { ServiceRow } from '../templates/services';
+import type { Template } from '../templates/types';
+import type { FlowTemplate } from '../flows/types';
+import type { Architecture, SectionType } from '../types';
+import {
+  ADD_SECTIONS_DOMAIN,
+  ensureAddSectionsDomain,
+  type AddSectionPayload,
+} from './add-sections';
+import {
+  ARCHITECTURE_TEMPLATES_DOMAIN,
+  ensureArchitectureTemplatesDomain,
+} from './architecture-templates';
+import {
+  CLOUD_SERVICES_DOMAIN,
+  ensureCloudServicesDomain,
+} from './cloud-services';
+import {
+  FLOW_PATTERNS_DOMAIN,
+  ensureFlowPatternsDomain,
+} from './flow-patterns';
+import {
+  PROJECT_TEMPLATES_DOMAIN,
+  ensureProjectTemplatesDomain,
+  type ProjectTemplateMeta,
+  type ProjectTemplateRow,
+} from './project-templates';
+import {
+  getDraftSystemCopyMap,
+  ensureSystemCopyDomain,
+  replaceSystemCopyMap,
+  upsertSystemCopy,
+  type SystemCopyPair,
+} from './system-copy';
+
+export type ContentBundle = {
+  version: 1;
+  exportedAt: string;
+  domains: {
+    /** Skipped in v1 — lego catalog has its own versioning (see note in export). */
+    catalog?: unknown;
+    'project-templates'?: ProjectTemplateRow[];
+    'add-sections'?: Array<{ id: string; type: SectionType; payload: AddSectionPayload }>;
+    'flow-patterns'?: FlowTemplate[];
+    'architecture-templates'?: Template[];
+    'cloud-services'?: Array<{ roleKey: string; payload: ServiceRow }>;
+    'system-copy'?: Record<string, SystemCopyPair>;
+  };
+};
+
+export type ImportContentBundleResult =
+  | { ok: true; issues: CatalogIssue[] }
+  | { ok: false; issues: CatalogIssue[] };
+
+function rows<T>(sql: string, ...values: (string | number | null)[]): T[] {
+  return plainAll<T>(db.prepare(sql).all(...values));
+}
+
+function markDomainDirty(domainId: string): void {
+  db.prepare('UPDATE content_domains SET status=?, published_at=published_at WHERE id=?')
+    .run('draft', domainId);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function dumpProjectTemplates(): ProjectTemplateRow[] {
+  ensureProjectTemplatesDomain();
+  return rows<{
+    id: string;
+    name_en: string | null;
+    name_fr: string | null;
+    meta_json: string | null;
+    snapshot_json: string | null;
+    sort_order: number | null;
+    featured: number | null;
+  }>(
+    'SELECT id, name_en, name_fr, meta_json, snapshot_json, sort_order, featured FROM project_templates WHERE domain_id=? ORDER BY sort_order, id',
+    PROJECT_TEMPLATES_DOMAIN,
+  ).map(row => ({
+    id: row.id,
+    nameEn: row.name_en ?? '',
+    nameFr: row.name_fr ?? '',
+    meta: row.meta_json ? (JSON.parse(row.meta_json) as ProjectTemplateMeta) : {
+      icon: 'cube',
+      accent: '#0E7C8A',
+      taglineEn: '',
+      taglineFr: '',
+      whenToUseEn: [],
+      whenToUseFr: [],
+      whenNotToUseEn: [],
+      whenNotToUseFr: [],
+    },
+    snapshot: row.snapshot_json
+      ? (JSON.parse(row.snapshot_json) as Architecture)
+      : blankArchitecture(row.id),
+    sortOrder: row.sort_order ?? 0,
+    featured: !!row.featured,
+  }));
+}
+
+function dumpAddSections(): Array<{ id: string; type: SectionType; payload: AddSectionPayload }> {
+  ensureAddSectionsDomain();
+  return rows<{ id: string; type: string; payload_json: string }>(
+    'SELECT id, type, payload_json FROM add_sections WHERE domain_id=? ORDER BY id',
+    ADD_SECTIONS_DOMAIN,
+  ).map(row => ({
+    id: row.id,
+    type: row.type as SectionType,
+    payload: JSON.parse(row.payload_json) as AddSectionPayload,
+  }));
+}
+
+function dumpFlowPatterns(): FlowTemplate[] {
+  ensureFlowPatternsDomain();
+  return rows<{ payload_json: string }>(
+    'SELECT payload_json FROM flow_patterns WHERE domain_id=? ORDER BY id',
+    FLOW_PATTERNS_DOMAIN,
+  ).map(row => JSON.parse(row.payload_json) as FlowTemplate);
+}
+
+function dumpArchitectureTemplates(): Template[] {
+  ensureArchitectureTemplatesDomain();
+  return rows<{ payload_json: string }>(
+    'SELECT payload_json FROM architecture_templates WHERE domain_id=? ORDER BY id',
+    ARCHITECTURE_TEMPLATES_DOMAIN,
+  ).map(row => JSON.parse(row.payload_json) as Template);
+}
+
+function dumpCloudServices(): Array<{ roleKey: string; payload: ServiceRow }> {
+  ensureCloudServicesDomain();
+  return rows<{ role_key: string; payload_json: string }>(
+    'SELECT role_key, payload_json FROM cloud_services WHERE domain_id=? ORDER BY role_key',
+    CLOUD_SERVICES_DOMAIN,
+  ).map(row => ({
+    roleKey: row.role_key,
+    payload: JSON.parse(row.payload_json) as ServiceRow,
+  }));
+}
+
+/** Dump draft rows for each admin content domain. Catalog skipped (own versioning). */
+export function exportContentBundle(): ContentBundle {
+  ensureSystemCopyDomain();
+  return {
+    version: 1,
+    exportedAt: new Date().toISOString(),
+    domains: {
+      // catalog: intentionally omitted — lego catalog uses catalog_version + publish flow
+      'project-templates': dumpProjectTemplates(),
+      'add-sections': dumpAddSections(),
+      'flow-patterns': dumpFlowPatterns(),
+      'architecture-templates': dumpArchitectureTemplates(),
+      'cloud-services': dumpCloudServices(),
+      'system-copy': getDraftSystemCopyMap(),
+    },
+  };
+}
+
+function importSystemCopy(
+  map: Record<string, SystemCopyPair>,
+  mode: 'merge' | 'replace',
+  issues: CatalogIssue[],
+): void {
+  if (mode === 'replace') {
+    replaceSystemCopyMap(map);
+    return;
+  }
+  for (const [key, pair] of Object.entries(map)) {
+    if (!pair || typeof pair.en !== 'string' || typeof pair.fr !== 'string') {
+      issues.push({
+        code: 'invalid_bundle_system_copy',
+        message: `system-copy "${key}" needs en and fr strings`,
+        entityId: key,
+      });
+      continue;
+    }
+    upsertSystemCopy(key, { en: pair.en, fr: pair.fr });
+  }
+}
+
+function importProjectTemplates(items: unknown, mode: 'merge' | 'replace', issues: CatalogIssue[]): void {
+  if (!Array.isArray(items)) {
+    issues.push({ code: 'invalid_bundle_domain', message: 'project-templates must be an array' });
+    return;
+  }
+  ensureProjectTemplatesDomain();
+  if (mode === 'replace') {
+    db.prepare('DELETE FROM project_templates WHERE domain_id=?').run(PROJECT_TEMPLATES_DOMAIN);
+  }
+  for (const raw of items) {
+    if (!isRecord(raw) || typeof raw.id !== 'string') {
+      issues.push({ code: 'invalid_bundle_row', message: 'project-templates row missing id' });
+      continue;
+    }
+    const id = raw.id;
+    const nameEn = typeof raw.nameEn === 'string' ? raw.nameEn : '';
+    const nameFr = typeof raw.nameFr === 'string' ? raw.nameFr : '';
+    const meta = raw.meta ?? {};
+    const snapshot = raw.snapshot ?? {};
+    const sortOrder = typeof raw.sortOrder === 'number' ? raw.sortOrder : 0;
+    const featured = raw.featured ? 1 : 0;
+    db.prepare(
+      `INSERT INTO project_templates (domain_id, id, name_en, name_fr, meta_json, snapshot_json, sort_order, featured)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(domain_id, id) DO UPDATE SET
+         name_en=excluded.name_en,
+         name_fr=excluded.name_fr,
+         meta_json=excluded.meta_json,
+         snapshot_json=excluded.snapshot_json,
+         sort_order=excluded.sort_order,
+         featured=excluded.featured`
+    ).run(
+      PROJECT_TEMPLATES_DOMAIN,
+      id,
+      nameEn,
+      nameFr,
+      JSON.stringify(meta),
+      JSON.stringify(snapshot),
+      sortOrder,
+      featured,
+    );
+  }
+  markDomainDirty(PROJECT_TEMPLATES_DOMAIN);
+  ensureProjectTemplatesDomain();
+}
+
+function importAddSections(items: unknown, mode: 'merge' | 'replace', issues: CatalogIssue[]): void {
+  if (!Array.isArray(items)) {
+    issues.push({ code: 'invalid_bundle_domain', message: 'add-sections must be an array' });
+    return;
+  }
+  ensureAddSectionsDomain();
+  if (mode === 'replace') {
+    db.prepare('DELETE FROM add_sections WHERE domain_id=?').run(ADD_SECTIONS_DOMAIN);
+  }
+  for (const raw of items) {
+    if (!isRecord(raw) || typeof raw.id !== 'string' || typeof raw.type !== 'string' || !raw.payload) {
+      issues.push({ code: 'invalid_bundle_row', message: 'add-sections row needs id, type, payload' });
+      continue;
+    }
+    db.prepare(
+      `INSERT INTO add_sections (domain_id, id, type, payload_json) VALUES (?, ?, ?, ?)
+       ON CONFLICT(domain_id, id) DO UPDATE SET type=excluded.type, payload_json=excluded.payload_json`
+    ).run(ADD_SECTIONS_DOMAIN, raw.id, raw.type, JSON.stringify(raw.payload));
+  }
+  markDomainDirty(ADD_SECTIONS_DOMAIN);
+  ensureAddSectionsDomain();
+}
+
+function importFlowPatterns(items: unknown, mode: 'merge' | 'replace', issues: CatalogIssue[]): void {
+  if (!Array.isArray(items)) {
+    issues.push({ code: 'invalid_bundle_domain', message: 'flow-patterns must be an array' });
+    return;
+  }
+  ensureFlowPatternsDomain();
+  if (mode === 'replace') {
+    db.prepare('DELETE FROM flow_patterns WHERE domain_id=?').run(FLOW_PATTERNS_DOMAIN);
+  }
+  for (const raw of items) {
+    if (!isRecord(raw) || typeof raw.id !== 'string') {
+      issues.push({ code: 'invalid_bundle_row', message: 'flow-patterns row missing id' });
+      continue;
+    }
+    db.prepare(
+      `INSERT INTO flow_patterns (domain_id, id, payload_json) VALUES (?, ?, ?)
+       ON CONFLICT(domain_id, id) DO UPDATE SET payload_json=excluded.payload_json`
+    ).run(FLOW_PATTERNS_DOMAIN, raw.id, JSON.stringify(raw));
+  }
+  markDomainDirty(FLOW_PATTERNS_DOMAIN);
+  ensureFlowPatternsDomain();
+}
+
+function importArchitectureTemplates(items: unknown, mode: 'merge' | 'replace', issues: CatalogIssue[]): void {
+  if (!Array.isArray(items)) {
+    issues.push({ code: 'invalid_bundle_domain', message: 'architecture-templates must be an array' });
+    return;
+  }
+  ensureArchitectureTemplatesDomain();
+  if (mode === 'replace') {
+    db.prepare('DELETE FROM architecture_templates WHERE domain_id=?').run(ARCHITECTURE_TEMPLATES_DOMAIN);
+  }
+  for (const raw of items) {
+    if (!isRecord(raw) || typeof raw.id !== 'string') {
+      issues.push({ code: 'invalid_bundle_row', message: 'architecture-templates row missing id' });
+      continue;
+    }
+    db.prepare(
+      `INSERT INTO architecture_templates (domain_id, id, payload_json) VALUES (?, ?, ?)
+       ON CONFLICT(domain_id, id) DO UPDATE SET payload_json=excluded.payload_json`
+    ).run(ARCHITECTURE_TEMPLATES_DOMAIN, raw.id, JSON.stringify(raw));
+  }
+  markDomainDirty(ARCHITECTURE_TEMPLATES_DOMAIN);
+  ensureArchitectureTemplatesDomain();
+}
+
+function importCloudServices(items: unknown, mode: 'merge' | 'replace', issues: CatalogIssue[]): void {
+  if (!Array.isArray(items)) {
+    issues.push({ code: 'invalid_bundle_domain', message: 'cloud-services must be an array' });
+    return;
+  }
+  ensureCloudServicesDomain();
+  if (mode === 'replace') {
+    db.prepare('DELETE FROM cloud_services WHERE domain_id=?').run(CLOUD_SERVICES_DOMAIN);
+  }
+  for (const raw of items) {
+    if (!isRecord(raw) || typeof raw.roleKey !== 'string' || !raw.payload) {
+      issues.push({ code: 'invalid_bundle_row', message: 'cloud-services row needs roleKey and payload' });
+      continue;
+    }
+    db.prepare(
+      `INSERT INTO cloud_services (domain_id, role_key, payload_json) VALUES (?, ?, ?)
+       ON CONFLICT(domain_id, role_key) DO UPDATE SET payload_json=excluded.payload_json`
+    ).run(CLOUD_SERVICES_DOMAIN, raw.roleKey, JSON.stringify(raw.payload));
+  }
+  markDomainDirty(CLOUD_SERVICES_DOMAIN);
+  ensureCloudServicesDomain();
+}
+
+/**
+ * Import a v1 content bundle into draft domains. Never auto-publishes.
+ * merge = upsert provided rows; replace = wipe domain then load bundle (seeds reappear via ensure).
+ */
+export function importContentBundle(
+  bundle: unknown,
+  options: { mode: 'merge' | 'replace' },
+): ImportContentBundleResult {
+  const issues: CatalogIssue[] = [];
+  if (!isRecord(bundle)) {
+    return { ok: false, issues: [{ code: 'invalid_bundle', message: 'bundle must be an object' }] };
+  }
+  if (bundle.version !== 1) {
+    return { ok: false, issues: [{ code: 'invalid_bundle_version', message: 'bundle.version must be 1' }] };
+  }
+  if (!isRecord(bundle.domains)) {
+    return { ok: false, issues: [{ code: 'invalid_bundle', message: 'bundle.domains must be an object' }] };
+  }
+
+  const domains = bundle.domains;
+  const mode = options.mode;
+
+  if (domains['system-copy'] !== undefined) {
+    if (!isRecord(domains['system-copy'])) {
+      issues.push({ code: 'invalid_bundle_domain', message: 'system-copy must be a key→{en,fr} map' });
+    } else {
+      importSystemCopy(domains['system-copy'] as Record<string, SystemCopyPair>, mode, issues);
+    }
+  }
+  if (domains['project-templates'] !== undefined) {
+    importProjectTemplates(domains['project-templates'], mode, issues);
+  }
+  if (domains['add-sections'] !== undefined) {
+    importAddSections(domains['add-sections'], mode, issues);
+  }
+  if (domains['flow-patterns'] !== undefined) {
+    importFlowPatterns(domains['flow-patterns'], mode, issues);
+  }
+  if (domains['architecture-templates'] !== undefined) {
+    importArchitectureTemplates(domains['architecture-templates'], mode, issues);
+  }
+  if (domains['cloud-services'] !== undefined) {
+    importCloudServices(domains['cloud-services'], mode, issues);
+  }
+  if (domains.catalog !== undefined) {
+    issues.push({
+      code: 'bundle_catalog_skipped',
+      message: 'catalog domain is not imported in v1 — use admin catalog publish separately',
+    });
+  }
+
+  const blocking = issues.filter(i => i.code !== 'bundle_catalog_skipped');
+  if (blocking.length > 0) return { ok: false, issues };
+  return { ok: true, issues };
+}

--- a/src/lib/admin/catalog-entities.ts
+++ b/src/lib/admin/catalog-entities.ts
@@ -1,0 +1,161 @@
+import { api } from '@/lib/api';
+import type { LegoDependencyStrength, LegoIntent, LegoVariant } from '@/lib/lego/types';
+import type { ConcernTag } from '@/lib/document/concerns';
+
+export type AdminScope = { id: string; labelEn: string; labelFr: string };
+
+export type AdminDependency = {
+  from: string;
+  to: string;
+  strength: LegoDependencyStrength;
+  why_en: string;
+  why_fr: string;
+  protocol_id: string;
+  kind: 'sync' | 'async' | 'batch';
+};
+
+export type AdminTechnology = { key: string; en: string; fr: string };
+
+export type ScopeCreateBody = { id?: string; labelEn: string; labelFr: string };
+export type IntentCreateBody = { id?: string; label: string; modes?: string[]; shapes?: string[] };
+export type VariantCreateBody = {
+  id?: string;
+  label: string;
+  intent: string;
+  mode: LegoVariant['mode'];
+  maps_to: string;
+};
+export type TechnologyCreateBody = { key?: string; en: string; fr: string };
+export type DependencyCreateBody = {
+  from: string;
+  to: string;
+  strength?: LegoDependencyStrength;
+  why_en?: string;
+  why_fr?: string;
+  protocol_id?: string;
+  kind?: 'sync' | 'async' | 'batch';
+};
+export type BrickCreateBody = {
+  id?: string;
+  icon?: string;
+  layer?: string;
+  defaultScope: string;
+  roleEn: string;
+  roleFr: string;
+  purposeEn?: string;
+  purposeFr?: string;
+  concernTags?: ConcernTag[];
+};
+
+export function fetchScopes(): Promise<AdminScope[]> {
+  return api.json<{ scopes: AdminScope[] }>('/api/admin/catalog/scopes').then(r => r.scopes);
+}
+
+export function createScope(body: ScopeCreateBody): Promise<{ ok: boolean; scopeId: string }> {
+  return api.json('/api/admin/catalog/scopes', { method: 'POST', body: JSON.stringify(body) });
+}
+
+export function patchScope(id: string, body: { labelEn?: string; labelFr?: string }): Promise<{ ok: boolean; scopeId: string }> {
+  return api.json(`/api/admin/catalog/scopes/${id}`, { method: 'PATCH', body: JSON.stringify(body) });
+}
+
+export function deleteScope(id: string): Promise<{ ok: boolean; scopeId: string }> {
+  return api.json(`/api/admin/catalog/scopes/${id}`, { method: 'DELETE' });
+}
+
+export function fetchIntents(): Promise<LegoIntent[]> {
+  return api.json<{ intents: LegoIntent[] }>('/api/admin/catalog/intents').then(r => r.intents);
+}
+
+export function fetchIntent(id: string): Promise<LegoIntent> {
+  return api.json<{ intent: LegoIntent }>(`/api/admin/catalog/intents/${id}`).then(r => r.intent);
+}
+
+export function createIntent(body: IntentCreateBody): Promise<{ ok: boolean; intentId: string }> {
+  return api.json('/api/admin/catalog/intents', { method: 'POST', body: JSON.stringify(body) });
+}
+
+export function patchIntent(id: string, body: { label?: string; modes?: string[]; shapes?: string[] }): Promise<{ ok: boolean; intentId: string }> {
+  return api.json(`/api/admin/catalog/intents/${id}`, { method: 'PATCH', body: JSON.stringify(body) });
+}
+
+export function deleteIntent(id: string): Promise<{ ok: boolean; intentId: string }> {
+  return api.json(`/api/admin/catalog/intents/${id}`, { method: 'DELETE' });
+}
+
+export function fetchVariants(): Promise<LegoVariant[]> {
+  return api.json<{ variants: LegoVariant[] }>('/api/admin/catalog/variants').then(r => r.variants);
+}
+
+export function createVariant(body: VariantCreateBody): Promise<{ ok: boolean; variantId: string }> {
+  return api.json('/api/admin/catalog/variants', { method: 'POST', body: JSON.stringify(body) });
+}
+
+export function patchVariant(id: string, body: Partial<Pick<LegoVariant, 'label' | 'intent' | 'mode' | 'maps_to'>>): Promise<{ ok: boolean; variantId: string }> {
+  return api.json(`/api/admin/catalog/variants/${id}`, { method: 'PATCH', body: JSON.stringify(body) });
+}
+
+export function deleteVariant(id: string): Promise<{ ok: boolean; variantId: string }> {
+  return api.json(`/api/admin/catalog/variants/${id}`, { method: 'DELETE' });
+}
+
+export function fetchDependencies(): Promise<AdminDependency[]> {
+  return api.json<{ dependencies: AdminDependency[] }>('/api/admin/catalog/dependencies').then(r => r.dependencies);
+}
+
+export function createDependency(body: DependencyCreateBody): Promise<{ ok: boolean; from: string; to: string }> {
+  return api.json('/api/admin/catalog/dependencies', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+export function patchDependency(from: string, to: string, body: Partial<Omit<AdminDependency, 'from' | 'to'>>): Promise<{ ok: boolean }> {
+  return api.json('/api/admin/catalog/dependencies', {
+    method: 'PATCH',
+    body: JSON.stringify({ from, to, ...body }),
+  });
+}
+
+export function deleteDependency(from: string, to: string): Promise<{ ok: boolean; from: string; to: string }> {
+  const qs = new URLSearchParams({ from, to });
+  return api.json(`/api/admin/catalog/dependencies?${qs}`, { method: 'DELETE' });
+}
+
+export function fetchTechnologies(): Promise<AdminTechnology[]> {
+  return api.json<{ technologies: Record<string, { en: string; fr: string }> }>('/api/admin/catalog/technologies')
+    .then(r => Object.entries(r.technologies).map(([key, value]) => ({ key, en: value.en, fr: value.fr })));
+}
+
+export function createTechnology(body: TechnologyCreateBody): Promise<{ ok: boolean; key: string }> {
+  return api.json('/api/admin/catalog/technologies', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+export function patchTechnology(key: string, body: { en?: string; fr?: string }): Promise<{ ok: boolean; key: string }> {
+  return api.json(`/api/admin/catalog/technologies/${encodeURIComponent(key)}`, {
+    method: 'PATCH',
+    body: JSON.stringify(body),
+  });
+}
+
+export function deleteTechnology(key: string): Promise<{ ok: boolean; key: string }> {
+  return api.json(`/api/admin/catalog/technologies/${encodeURIComponent(key)}`, {
+    method: 'DELETE',
+  });
+}
+
+export function createBrick(body: BrickCreateBody): Promise<{ ok: boolean; brickId: string }> {
+  return api.json('/api/admin/catalog/bricks', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+export function deleteBrick(id: string): Promise<{ ok: boolean; brickId: string }> {
+  return api.json(`/api/admin/catalog/bricks/${encodeURIComponent(id)}`, {
+    method: 'DELETE',
+  });
+}

--- a/src/lib/admin/catalog.ts
+++ b/src/lib/admin/catalog.ts
@@ -1,0 +1,82 @@
+import { api } from '@/lib/api';
+
+export type CatalogIssue = {
+  code: string;
+  message: string;
+  field?: string;
+  entityId?: string;
+};
+
+export type CatalogState = {
+  dirty: boolean;
+  publishedAt: string | null;
+  version: string;
+  issues?: CatalogIssue[];
+};
+
+export type BrickPatchBody = {
+  icon: string;
+  layer: string;
+  defaultScope: string;
+  concernTags: string[];
+  purposeEn: string;
+  purposeFr: string;
+  roleEn: string;
+  roleFr: string;
+};
+
+export function fetchCatalogState(options?: { validate?: boolean }): Promise<CatalogState> {
+  const qs = options?.validate ? '?validate=1' : '';
+  return api.json<CatalogState>(`/api/admin/catalog/state${qs}`);
+}
+
+export function patchBrick(
+  id: string,
+  body: BrickPatchBody
+): Promise<{ ok: boolean; brickId: string }> {
+  return api.json(`/api/admin/catalog/bricks/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify(body)
+  });
+}
+
+export function createBrick(body: {
+  id?: string;
+  icon?: string;
+  layer?: string;
+  defaultScope: string;
+  roleEn: string;
+  roleFr: string;
+  purposeEn?: string;
+  purposeFr?: string;
+  concernTags?: string[];
+}): Promise<{ ok: boolean; brickId: string }> {
+  return api.json('/api/admin/catalog/bricks', {
+    method: 'POST',
+    body: JSON.stringify(body)
+  });
+}
+
+export function deleteBrick(id: string): Promise<{ ok: boolean; brickId: string }> {
+  return api.json(`/api/admin/catalog/bricks/${encodeURIComponent(id)}`, {
+    method: 'DELETE'
+  });
+}
+
+export type PublishResult =
+  | { ok: true; publishedAt: string }
+  | { ok: false; error: string; issues: CatalogIssue[] };
+
+export async function publishCatalog(): Promise<PublishResult> {
+  const res = await fetch('/api/admin/catalog/publish', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' }
+  });
+  const body = await res.json().catch(() => ({}));
+  if (res.ok) return { ok: true, publishedAt: body.publishedAt as string };
+  return {
+    ok: false,
+    error: (body.error as string) || res.statusText,
+    issues: (body.issues as CatalogIssue[]) ?? []
+  };
+}

--- a/src/lib/admin/cloud-services.test.ts
+++ b/src/lib/admin/cloud-services.test.ts
@@ -1,0 +1,72 @@
+import { strict as assert } from 'node:assert';
+import { after, before, describe, test } from 'node:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const dbFile = path.join(os.tmpdir(), `archstudio-cloud-services-${process.pid}.db`);
+process.env.DATABASE_PATH = dbFile;
+
+let CS: typeof import('./cloud-services');
+let Svc: typeof import('../templates/services');
+
+before(async () => {
+  CS = await import('./cloud-services');
+  Svc = await import('../templates/services');
+});
+
+after(() => {
+  for (const f of [dbFile, `${dbFile}-wal`, `${dbFile}-shm`]) fs.rmSync(f, { force: true });
+});
+
+describe('cloud services admin', { concurrency: 1 }, () => {
+  test('seeds SERVICES object keys', () => {
+    CS.ensureCloudServicesDomain();
+    const list = CS.listCloudServicesAdmin();
+    for (const key of Object.keys(Svc.SERVICES)) {
+      assert.ok(list.some(s => s.roleKey === key), `missing seed ${key}`);
+    }
+  });
+
+  test('cloud service update persists a cell name', () => {
+    const current = CS.getCloudServiceAdmin('queue');
+    assert.ok(current);
+    const next = structuredClone(current!.payload);
+    next.aws = { ...next.aws, name: 'Amazon SQS (admin)' };
+    CS.updateCloudService('queue', next);
+    const saved = CS.getCloudServiceAdmin('queue');
+    assert.equal(
+      typeof saved!.payload.aws.name === 'string' ? saved!.payload.aws.name : saved!.payload.aws.name.en,
+      'Amazon SQS (admin)',
+    );
+  });
+
+  test('create and delete custom role; seeded re-seeds', () => {
+    const key = CS.createCloudService({
+      roleKey: 'customProbe',
+      payload: {
+        aws: { name: 'AWS Probe' },
+        gcp: { name: 'GCP Probe' },
+        azure: { name: 'Azure Probe' },
+        selfhosted: { name: 'Self Probe' },
+      },
+    });
+    assert.equal(key, 'customProbe');
+    CS.deleteCloudService(key);
+    assert.equal(CS.getCloudServiceAdmin(key), null);
+
+    CS.deleteCloudService('queue');
+    CS.ensureCloudServicesDomain();
+    assert.ok(CS.getCloudServiceAdmin('queue'));
+  });
+
+  test('publish ok', () => {
+    CS.ensureCloudServicesDomain();
+    const result = CS.publishCloudServices();
+    assert.equal(result.ok, true);
+    const published = CS.getPublishedServices();
+    assert.ok(published);
+    assert.ok(published!.services.queue);
+    assert.ok(published!.verifiedOn);
+  });
+});

--- a/src/lib/admin/cloud-services.ts
+++ b/src/lib/admin/cloud-services.ts
@@ -1,0 +1,287 @@
+import { slugify } from '../defaults';
+import { db, now, plain, plainAll } from '../db';
+import type { CatalogIssue } from '../lego/admin-catalog';
+import { SERVICES, SERVICES_VERIFIED_ON, type ServiceRow } from '../templates/services';
+import { RESOLVED_TARGETS, type L10n, type ResolvedTarget } from '../templates/types';
+
+export const CLOUD_SERVICES_DOMAIN = 'cloud-services';
+export const CLOUD_SERVICES_VERIFIED_KEY = 'cloud-services.verified-on';
+
+export const SEEDED_SERVICE_ROLE_KEYS = Object.keys(SERVICES) as (keyof typeof SERVICES)[];
+
+export type CloudServiceAdminState = {
+  dirty: boolean;
+  publishedAt: string | null;
+  serviceCount: number;
+  verifiedOn: string;
+  issueCount?: number;
+  issues?: CatalogIssue[];
+};
+
+export type PublishCloudServicesResult =
+  | { ok: true; publishedAt: string }
+  | { ok: false; issues: CatalogIssue[] };
+
+export type AdminCloudServiceItem = {
+  roleKey: string;
+  locked: boolean;
+  payload: ServiceRow;
+};
+
+export type CloudServiceCreate = {
+  roleKey?: string;
+  payload?: ServiceRow;
+};
+
+function getRow<T>(sql: string, ...params: (string | number | null)[]): T | null {
+  const raw = db.prepare(sql).get(...params);
+  if (!raw) return null;
+  return plain<T>(raw);
+}
+
+function rows<T>(sql: string, ...values: (string | number | null)[]): T[] {
+  return plainAll<T>(db.prepare(sql).all(...values));
+}
+
+function markDirty(): void {
+  db.prepare('UPDATE content_domains SET status=?, published_at=published_at WHERE id=?')
+    .run('draft', CLOUD_SERVICES_DOMAIN);
+}
+
+function parseRow(raw: string | null): ServiceRow {
+  if (!raw) throw new Error('cloud service payload_json is missing');
+  return JSON.parse(raw) as ServiceRow;
+}
+
+function blankCell(): ServiceRow[ResolvedTarget] {
+  return { name: '' };
+}
+
+function blankServiceRow(): ServiceRow {
+  return {
+    aws: blankCell(),
+    gcp: blankCell(),
+    azure: blankCell(),
+    selfhosted: blankCell(),
+  };
+}
+
+function cellName(v: L10n | undefined): string {
+  if (!v) return '';
+  if (typeof v === 'string') return v.trim();
+  return (v.en ?? v.fr ?? '').trim();
+}
+
+function validateServiceRow(roleKey: string, payload: ServiceRow): CatalogIssue[] {
+  const issues: CatalogIssue[] = [];
+  for (const target of RESOLVED_TARGETS) {
+    const cell = payload[target];
+    if (!cell) {
+      issues.push({
+        code: 'invalid_cloud_service',
+        message: `Service "${roleKey}" missing ${target} cell`,
+        entityId: roleKey,
+        field: target,
+      });
+      continue;
+    }
+    if (!cellName(cell.name)) {
+      issues.push({
+        code: 'invalid_cloud_service',
+        message: `Service "${roleKey}" ${target} needs a name`,
+        entityId: roleKey,
+        field: `${target}.name`,
+      });
+    }
+  }
+  return issues;
+}
+
+function readVerifiedOn(): string {
+  const row = getRow<{ value: string }>('SELECT value FROM settings WHERE key=?', CLOUD_SERVICES_VERIFIED_KEY);
+  const value = row?.value?.trim();
+  return value || SERVICES_VERIFIED_ON;
+}
+
+export function setCloudServicesVerifiedOn(value: string): void {
+  const next = value.trim() || SERVICES_VERIFIED_ON;
+  db.prepare(
+    `INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?)
+     ON CONFLICT(key) DO UPDATE SET value=excluded.value, updated_at=excluded.updated_at`
+  ).run(CLOUD_SERVICES_VERIFIED_KEY, next, now());
+  markDirty();
+}
+
+/** Ensures domain + seeds every SERVICES role key. Missing locked keys re-seed. */
+export function ensureCloudServicesDomain(): void {
+  const existing = getRow<{ id: string }>('SELECT id FROM content_domains WHERE id=?', CLOUD_SERVICES_DOMAIN);
+  if (!existing) {
+    db.prepare('INSERT INTO content_domains (id, status, published_at) VALUES (?, ?, NULL)')
+      .run(CLOUD_SERVICES_DOMAIN, 'draft');
+  }
+  if (!getRow<{ value: string }>('SELECT value FROM settings WHERE key=?', CLOUD_SERVICES_VERIFIED_KEY)) {
+    db.prepare(
+      'INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?)'
+    ).run(CLOUD_SERVICES_VERIFIED_KEY, SERVICES_VERIFIED_ON, now());
+  }
+  for (const roleKey of SEEDED_SERVICE_ROLE_KEYS) {
+    const row = getRow<{ role_key: string }>(
+      'SELECT role_key FROM cloud_services WHERE domain_id=? AND role_key=?',
+      CLOUD_SERVICES_DOMAIN,
+      roleKey,
+    );
+    if (row) continue;
+    db.prepare(
+      'INSERT INTO cloud_services (domain_id, role_key, payload_json) VALUES (?, ?, ?)'
+    ).run(CLOUD_SERVICES_DOMAIN, roleKey, JSON.stringify(SERVICES[roleKey]));
+    markDirty();
+  }
+}
+
+export function isSeededServiceRole(roleKey: string): boolean {
+  return (SEEDED_SERVICE_ROLE_KEYS as readonly string[]).includes(roleKey);
+}
+
+export function listCloudServicesAdmin(): AdminCloudServiceItem[] {
+  ensureCloudServicesDomain();
+  return rows<{ role_key: string; payload_json: string }>(
+    'SELECT role_key, payload_json FROM cloud_services WHERE domain_id=? ORDER BY role_key',
+    CLOUD_SERVICES_DOMAIN,
+  ).map(row => ({
+    roleKey: row.role_key,
+    locked: isSeededServiceRole(row.role_key),
+    payload: parseRow(row.payload_json),
+  }));
+}
+
+export function getCloudServiceAdmin(roleKey: string): AdminCloudServiceItem | null {
+  ensureCloudServicesDomain();
+  const row = getRow<{ role_key: string; payload_json: string }>(
+    'SELECT role_key, payload_json FROM cloud_services WHERE domain_id=? AND role_key=?',
+    CLOUD_SERVICES_DOMAIN,
+    roleKey,
+  );
+  if (!row) return null;
+  return {
+    roleKey: row.role_key,
+    locked: isSeededServiceRole(row.role_key),
+    payload: parseRow(row.payload_json),
+  };
+}
+
+export function createCloudService(input: CloudServiceCreate): string {
+  ensureCloudServicesDomain();
+  const taken = new Set(listCloudServicesAdmin().map(s => s.roleKey));
+  const raw = (input.roleKey?.trim() || 'service');
+  const camel = raw.replace(/[^a-zA-Z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+  const key = /^[a-zA-Z][a-zA-Z0-9_]*$/.test(camel) ? camel : slugify(raw, taken).replace(/-/g, '_');
+  if (!/^[a-zA-Z][a-zA-Z0-9_]*$/.test(key)) {
+    throw new Error('role_key must start with a letter and contain only letters, digits and underscores');
+  }
+  if (taken.has(key)) throw new Error(`cloud service "${key}" already exists`);
+  const payload = input.payload ?? blankServiceRow();
+  if (input.payload) {
+    const issues = validateServiceRow(key, payload);
+    if (issues.length > 0) throw new Error(issues[0]!.message);
+  }
+  db.prepare(
+    'INSERT INTO cloud_services (domain_id, role_key, payload_json) VALUES (?, ?, ?)'
+  ).run(CLOUD_SERVICES_DOMAIN, key, JSON.stringify(payload));
+  markDirty();
+  return key;
+}
+
+export function deleteCloudService(roleKey: string): void {
+  ensureCloudServicesDomain();
+  const result = db.prepare(
+    'DELETE FROM cloud_services WHERE domain_id=? AND role_key=?'
+  ).run(CLOUD_SERVICES_DOMAIN, roleKey);
+  if (!result.changes) throw new Error(`cloud service not found: ${roleKey}`);
+  markDirty();
+}
+
+export function updateCloudService(roleKey: string, payload: ServiceRow): void {
+  ensureCloudServicesDomain();
+  if (!getCloudServiceAdmin(roleKey)) throw new Error(`cloud service not found: ${roleKey}`);
+  const issues = validateServiceRow(roleKey, payload);
+  if (issues.length > 0) throw new Error(issues[0]!.message);
+  db.prepare(
+    'UPDATE cloud_services SET payload_json=? WHERE domain_id=? AND role_key=?'
+  ).run(JSON.stringify(payload), CLOUD_SERVICES_DOMAIN, roleKey);
+  markDirty();
+}
+
+export function validateCloudServicesPublish(): CatalogIssue[] {
+  ensureCloudServicesDomain();
+  const issues: CatalogIssue[] = [];
+  const rowsData = rows<{ role_key: string; payload_json: string }>(
+    'SELECT role_key, payload_json FROM cloud_services WHERE domain_id=?',
+    CLOUD_SERVICES_DOMAIN,
+  );
+  for (const expected of SEEDED_SERVICE_ROLE_KEYS) {
+    if (!rowsData.some(r => r.role_key === expected)) {
+      issues.push({
+        code: 'missing_cloud_service',
+        message: `Missing seeded cloud service "${expected}"`,
+        entityId: expected,
+      });
+    }
+  }
+  for (const row of rowsData) {
+    issues.push(...validateServiceRow(row.role_key, parseRow(row.payload_json)));
+  }
+  return issues;
+}
+
+export function publishCloudServices(): PublishCloudServicesResult {
+  const issues = validateCloudServicesPublish();
+  if (issues.length > 0) return { ok: false, issues };
+  const publishedAt = now();
+  db.prepare('UPDATE content_domains SET status=?, published_at=? WHERE id=?')
+    .run('published', publishedAt, CLOUD_SERVICES_DOMAIN);
+  return { ok: true, publishedAt };
+}
+
+export function getCloudServicesAdminState(options?: { validate?: boolean }): CloudServiceAdminState {
+  ensureCloudServicesDomain();
+  const domain = getRow<{ status: string; published_at: string | null }>(
+    'SELECT status, published_at FROM content_domains WHERE id=?',
+    CLOUD_SERVICES_DOMAIN,
+  );
+  const serviceCount = getRow<{ n: number }>(
+    'SELECT COUNT(*) AS n FROM cloud_services WHERE domain_id=?',
+    CLOUD_SERVICES_DOMAIN,
+  )?.n ?? 0;
+  const state: CloudServiceAdminState = {
+    dirty: domain?.status !== 'published',
+    publishedAt: domain?.published_at ?? null,
+    serviceCount,
+    verifiedOn: readVerifiedOn(),
+  };
+  if (!options?.validate) return state;
+  const issues = validateCloudServicesPublish();
+  return { ...state, issueCount: issues.length, issues };
+}
+
+export type PublishedServices = {
+  services: Record<string, ServiceRow>;
+  verifiedOn: string;
+};
+
+/** Runtime table when the domain is published. Null if draft. */
+export function getPublishedServices(): PublishedServices | null {
+  ensureCloudServicesDomain();
+  const domain = getRow<{ status: string }>(
+    'SELECT status FROM content_domains WHERE id=?',
+    CLOUD_SERVICES_DOMAIN,
+  );
+  if (domain?.status !== 'published') return null;
+  const services: Record<string, ServiceRow> = {};
+  for (const row of rows<{ role_key: string; payload_json: string }>(
+    'SELECT role_key, payload_json FROM cloud_services WHERE domain_id=?',
+    CLOUD_SERVICES_DOMAIN,
+  )) {
+    services[row.role_key] = parseRow(row.payload_json);
+  }
+  return { services, verifiedOn: readVerifiedOn() };
+}

--- a/src/lib/admin/cloud.ts
+++ b/src/lib/admin/cloud.ts
@@ -1,0 +1,63 @@
+import { api } from '@/lib/api';
+import type { CatalogIssue } from '@/lib/lego/admin-catalog';
+import type { ServiceRow } from '@/lib/templates/services';
+
+export type AdminCloudServiceItem = {
+  roleKey: string;
+  locked: boolean;
+  payload: ServiceRow;
+};
+
+export type CloudServiceAdminState = {
+  dirty: boolean;
+  publishedAt: string | null;
+  serviceCount: number;
+  verifiedOn: string;
+  issueCount?: number;
+  issues?: CatalogIssue[];
+};
+
+export function fetchCloudServices(): Promise<{ services: AdminCloudServiceItem[] }> {
+  return api.json('/api/admin/cloud-services');
+}
+
+export function fetchCloudServicesState(options?: { validate?: boolean }): Promise<CloudServiceAdminState> {
+  const qs = options?.validate ? '?validate=1' : '';
+  return api.json(`/api/admin/cloud-services/state${qs}`);
+}
+
+export function createCloudService(body: { roleKey?: string; payload?: ServiceRow }): Promise<{ ok: boolean; roleKey: string }> {
+  return api.json('/api/admin/cloud-services', { method: 'POST', body: JSON.stringify(body) });
+}
+
+export function updateCloudService(key: string, payload: ServiceRow): Promise<{ ok: boolean; roleKey: string }> {
+  return api.json(`/api/admin/cloud-services/${key}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ payload }),
+  });
+}
+
+export function deleteCloudService(key: string): Promise<{ ok: boolean; roleKey: string }> {
+  return api.json(`/api/admin/cloud-services/${key}`, { method: 'DELETE' });
+}
+
+export function patchCloudServicesVerifiedOn(verifiedOn: string): Promise<CloudServiceAdminState> {
+  return api.json('/api/admin/cloud-services/state', {
+    method: 'PATCH',
+    body: JSON.stringify({ verifiedOn }),
+  });
+}
+
+export async function publishCloudServices(): Promise<
+  | { ok: true; publishedAt: string }
+  | { ok: false; error: string; issues: CatalogIssue[] }
+> {
+  const res = await fetch('/api/admin/cloud-services/publish', { method: 'POST' });
+  const body = await res.json().catch(() => ({}));
+  if (res.ok) return { ok: true, publishedAt: body.publishedAt as string };
+  return {
+    ok: false,
+    error: (body.error as string) || res.statusText,
+    issues: (body.issues as CatalogIssue[]) ?? [],
+  };
+}

--- a/src/lib/admin/copy.ts
+++ b/src/lib/admin/copy.ts
@@ -1,0 +1,75 @@
+import { api } from '@/lib/api';
+import type { CatalogIssue } from '@/lib/lego/admin-catalog';
+
+export type SystemCopyEntry = {
+  key: string;
+  en: string;
+  fr: string;
+  seeded: boolean;
+};
+
+export type AdminSystemCopyItem = SystemCopyEntry;
+
+export type SystemCopyAdminState = {
+  dirty: boolean;
+  publishedAt: string | null;
+  keyCount: number;
+  issueCount?: number;
+  issues?: CatalogIssue[];
+};
+
+/** Group prefix for locale navigator (flow. / layer. / meta. / other). */
+export function copyKeyGroup(key: string): string {
+  const head = key.split('.')[0] ?? '';
+  if (head === 'flow' || head === 'layer' || head === 'meta') return head;
+  return 'other';
+}
+
+export function missingFr(entry: Pick<SystemCopyEntry, 'fr'>): boolean {
+  return !entry.fr?.trim();
+}
+
+export async function fetchSystemCopy(): Promise<{ entries: SystemCopyEntry[]; keys: SystemCopyEntry[] }> {
+  const body = await api.json<{ keys: SystemCopyEntry[] }>('/api/admin/system-copy');
+  const keys = body.keys ?? [];
+  return { entries: keys, keys };
+}
+
+export function fetchSystemCopyState(options?: { validate?: boolean }): Promise<SystemCopyAdminState> {
+  const qs = options?.validate ? '?validate=1' : '';
+  return api.json(`/api/admin/system-copy/state${qs}`);
+}
+
+export function createSystemCopy(body: { key: string; en?: string; fr?: string }): Promise<{ ok: boolean; key: string }> {
+  return api.json('/api/admin/system-copy', { method: 'POST', body: JSON.stringify(body) });
+}
+
+export function updateSystemCopy(key: string, pair: { en?: string; fr?: string }): Promise<{ ok: boolean; key: string }> {
+  return api.json(`/api/admin/system-copy/${encodeURIComponent(key)}`, {
+    method: 'PATCH',
+    body: JSON.stringify(pair),
+  });
+}
+
+/** Alias used by Locale admin page. */
+export function patchSystemCopy(key: string, pair: { en?: string; fr?: string }): Promise<{ ok: boolean; key: string }> {
+  return updateSystemCopy(key, pair);
+}
+
+export function deleteSystemCopyKey(key: string): Promise<{ ok: boolean; key: string }> {
+  return api.json(`/api/admin/system-copy/${encodeURIComponent(key)}`, { method: 'DELETE' });
+}
+
+export async function publishSystemCopy(): Promise<
+  | { ok: true; publishedAt: string }
+  | { ok: false; error: string; issues: CatalogIssue[] }
+> {
+  const res = await fetch('/api/admin/system-copy/publish', { method: 'POST' });
+  const body = await res.json().catch(() => ({}));
+  if (res.ok) return { ok: true, publishedAt: body.publishedAt as string };
+  return {
+    ok: false,
+    error: (body.error as string) || res.statusText || 'Publish failed',
+    issues: (body.issues as CatalogIssue[]) ?? [],
+  };
+}

--- a/src/lib/admin/flags.ts
+++ b/src/lib/admin/flags.ts
@@ -1,0 +1,4 @@
+/** Feature flags for progressive admin-content migration (ISA M0→M6). */
+export function contentFromAdmin(): boolean {
+  return process.env.CONTENT_FROM_ADMIN === '1';
+}

--- a/src/lib/admin/flow-copy.server.ts
+++ b/src/lib/admin/flow-copy.server.ts
@@ -1,0 +1,59 @@
+/**
+ * Server-only flow / layer copy helpers.
+ * Uses published system_copy when CONTENT_FROM_ADMIN=1; else code defaults.
+ *
+ * Do not import from client components — pulls sqlite via system-copy.
+ * Client canvas (FlowsEditor, ArchitectureDiagramSurface, place.ts) keeps
+ * displayLayerLabel / flowCopy code fallbacks; PDF/print stays on those
+ * until a client-safe content API exists.
+ */
+
+import { slugify } from '../defaults';
+import type { Architecture, Flow } from '../types';
+import { resolveFlowCopy, resolveLayerLabel, type ResolvedFlowCopy } from './system-copy.resolve.server';
+
+export { resolveFlowCopy, resolveLayerLabel };
+export type { ResolvedFlowCopy };
+
+/** Same shape as blankManualFlow, but prefers published system_copy. */
+export function blankManualFlowResolved(doc: Architecture): Flow {
+  const copy = resolveFlowCopy(doc.meta.lang);
+  const seeds = doc.components.slice(0, 2);
+  return {
+    id: slugify('flow', doc.flows.map(flow => flow.id)),
+    name: copy.name,
+    group: seeds[0]?.group,
+    sub: copy.sub,
+    note: copy.note,
+    steps: seeds.map((component, index) => ({
+      component: component.id,
+      title: index === 0 ? copy.firstStep : copy.nextStep,
+      description: copy.stepDescription,
+    })),
+  };
+}
+
+/** Fill missing flow fields from resolved (admin or code) copy. */
+export function fillFlowDefaultsResolved(flow: Flow, lang?: string): Flow {
+  const copy = resolveFlowCopy(lang);
+  return {
+    ...flow,
+    sub: flow.sub?.trim() ? flow.sub : copy.sub,
+    note: flow.note?.trim() ? flow.note : copy.note,
+    steps: (flow.steps || []).map(step => ({
+      ...step,
+      description: step.description?.trim() ? step.description : copy.stepDescription,
+    })),
+  };
+}
+
+/**
+ * Re-apply resolved defaults on flows that still carry empty/seed gaps.
+ * Safe after normalizeArchitecture on the server (create/instantiate).
+ */
+export function applyResolvedFlowCopy(doc: Architecture): Architecture {
+  return {
+    ...doc,
+    flows: (doc.flows || []).map(flow => fillFlowDefaultsResolved(flow, doc.meta.lang)),
+  };
+}

--- a/src/lib/admin/flow-patterns.test.ts
+++ b/src/lib/admin/flow-patterns.test.ts
@@ -1,0 +1,101 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import * as FP from './flow-patterns';
+import { FLOW_CATALOG } from '../flows/catalog';
+import { countMappableSteps } from '../flows/plate';
+import { matchSteps } from '../flows/match';
+import { legoCatalog } from '../lego/repository';
+import demoJson from '../seed/demo.json';
+import { normalizeArchitecture } from '../defaults';
+
+function locEn(v: unknown): string {
+  if (!v) return '';
+  if (typeof v === 'string') return v;
+  return (v as { en?: string }).en ?? '';
+}
+
+describe('flow-patterns admin', () => {
+  test('seeds locked library on ensure', () => {
+    FP.ensureFlowPatternsDomain();
+    const list = FP.listFlowPatternsAdmin();
+    assert.ok(list.length >= FLOW_CATALOG.length);
+    assert.ok(list.some(p => p.id === 'auth-login'));
+    assert.equal(list.find(p => p.id === 'auth-login')?.locked, true);
+  });
+
+  test('get and update bilingual pattern', () => {
+    const tpl = FP.getFlowPatternAdmin('auth-login');
+    assert.ok(tpl);
+    const next = structuredClone(tpl);
+    next.tagline = { ...(typeof next.tagline === 'string' ? { en: next.tagline, fr: next.tagline } : next.tagline), en: 'Sign-in journey (admin test)' };
+    FP.updateFlowPattern('auth-login', next);
+    const saved = FP.getFlowPatternAdmin('auth-login');
+    assert.equal(locEn(saved?.tagline), 'Sign-in journey (admin test)');
+  });
+
+  test('hint edit updates demo match count (ISC-A4)', () => {
+    const seed = FLOW_CATALOG.find(p => p.id === 'auth-login');
+    assert.ok(seed);
+    FP.updateFlowPattern('auth-login', structuredClone(seed));
+    const tpl = FP.getFlowPatternAdmin('auth-login');
+    assert.ok(tpl);
+    const doc = normalizeArchitecture(demoJson as Parameters<typeof normalizeArchitecture>[0]);
+    const catalog = legoCatalog('en');
+
+    const before = FP.templateToResolvedPattern(tpl, 'en');
+    const beforeMatched = matchSteps(before.steps, doc.components).filter(b => b.component).length;
+
+    const next = structuredClone(tpl);
+    const authStep = next.steps.find(s => s.key === 'auth');
+    assert.ok(authStep);
+    authStep.hint = { name: ['__no_match_xyz__'], avoid: ['identity', 'auth', 'web', 'api', 'gateway'] };
+
+    FP.updateFlowPattern('auth-login', next);
+    const after = FP.templateToResolvedPattern(FP.getFlowPatternAdmin('auth-login')!, 'en');
+    const afterMatched = matchSteps(after.steps, doc.components).filter(b => b.component).length;
+
+    assert.ok(countMappableSteps(after, catalog) >= 0);
+    assert.ok(beforeMatched > afterMatched, 'hint change should reduce demo bindings');
+  });
+
+  test('create and delete custom pattern', () => {
+    const id = FP.createFlowPattern({
+      nameEn: 'Ops handoff (test)',
+      nameFr: 'Handoff ops (test)',
+    });
+    assert.match(id, /^ops-handoff-test$/);
+    const detail = FP.getFlowPatternAdmin(id);
+    assert.ok(detail);
+    assert.equal(detail.steps.length, 2);
+    assert.equal(FP.listFlowPatternsAdmin().find(p => p.id === id)?.locked, false);
+    FP.updateFlowPattern(id, { ...detail, tagline: { en: 'Custom tagline', fr: 'Accroche' } });
+    assert.equal(locEn(FP.getFlowPatternAdmin(id)!.tagline), 'Custom tagline');
+    FP.deleteFlowPattern(id);
+    assert.equal(FP.getFlowPatternAdmin(id), null);
+  });
+
+  test('create rejects duplicate id', () => {
+    const id = FP.createFlowPattern({ nameEn: 'Duplicate probe flow' });
+    assert.throws(
+      () => FP.createFlowPattern({ id, nameEn: 'Another' }),
+      /already exists/,
+    );
+    FP.deleteFlowPattern(id);
+  });
+
+  test('deleted locked pattern is re-seeded on next read', () => {
+    FP.deleteFlowPattern('incident');
+    const restored = FP.getFlowPatternAdmin('incident');
+    assert.ok(restored);
+    assert.equal(restored.id, 'incident');
+  });
+
+  test('publish succeeds for seeded patterns', () => {
+    const result = FP.publishFlowPatterns();
+    assert.equal(result.ok, true);
+    if (result.ok) assert.ok(result.publishedAt);
+    const published = FP.getPublishedFlowCatalog('en');
+    assert.ok(published.length >= FLOW_CATALOG.length);
+    assert.equal(published[0]?.source, 'catalog');
+  });
+});

--- a/src/lib/admin/flow-patterns.ts
+++ b/src/lib/admin/flow-patterns.ts
@@ -1,0 +1,314 @@
+import { FLOW_CATALOG } from '../flows/catalog';
+import { slugify } from '../defaults';
+import { db, now, plain, plainAll } from '../db';
+import type { CatalogIssue } from '../lego/admin-catalog';
+import { resolveDeep, type Lang } from '../templates/types';
+import type { FlowPattern, FlowTemplate } from '../flows/types';
+
+export const FLOW_PATTERNS_DOMAIN = 'flow-patterns';
+
+export const LOCKED_FLOW_PATTERN_IDS = FLOW_CATALOG.map(p => p.id);
+
+export type FlowPatternAdminState = {
+  dirty: boolean;
+  publishedAt: string | null;
+  patternCount: number;
+  issueCount?: number;
+  issues?: CatalogIssue[];
+};
+
+export type PublishFlowPatternsResult =
+  | { ok: true; publishedAt: string }
+  | { ok: false; issues: CatalogIssue[] };
+
+export type FlowPatternCreate = {
+  id?: string;
+  icon?: string;
+  nameEn: string;
+  nameFr?: string;
+  taglineEn?: string;
+  taglineFr?: string;
+};
+
+export type AdminFlowListItem = {
+  id: string;
+  icon: string;
+  nameEn: string;
+  nameFr: string;
+  taglineEn: string;
+  taglineFr: string;
+  stepCount: number;
+  locked: boolean;
+  publishedAt?: string | null;
+};
+
+function getRow<T>(sql: string, ...params: (string | number | null)[]): T | null {
+  const raw = db.prepare(sql).get(...params);
+  if (!raw) return null;
+  return plain<T>(raw);
+}
+
+function rows<T>(sql: string, ...values: (string | number | null)[]): T[] {
+  return plainAll<T>(db.prepare(sql).all(...values));
+}
+
+
+export function isLockedFlowPattern(id: string): boolean {
+  return LOCKED_FLOW_PATTERN_IDS.includes(id);
+}
+
+function existingPatternIds(): Set<string> {
+  return new Set(rows<{ id: string }>(
+    'SELECT id FROM flow_patterns WHERE domain_id=?',
+    FLOW_PATTERNS_DOMAIN,
+  ).map(r => r.id));
+}
+
+function slugPatternId(raw: string, taken: Set<string>): string {
+  const id = slugify(raw.trim() || 'pattern', taken);
+  if (!/^[a-z0-9][a-z0-9-]*$/.test(id)) throw new Error('Pattern id must be lowercase letters, digits and hyphens');
+  return id;
+}
+
+function blankPattern(id: string, nameEn: string, nameFr: string, taglineEn: string, taglineFr: string, icon: string): FlowTemplate {
+  return {
+    id,
+    icon,
+    name: { en: nameEn, fr: nameFr },
+    tagline: { en: taglineEn, fr: taglineFr },
+    steps: [
+      {
+        key: 'start',
+        title: { en: 'Start', fr: 'Début' },
+        hint: { name: [id, 'start'] },
+      },
+      {
+        key: 'end',
+        title: { en: 'End', fr: 'Fin' },
+        hint: { name: [id, 'end'] },
+      },
+    ],
+  };
+}
+
+function parseTemplate(raw: string | null): FlowTemplate {
+  if (!raw) throw new Error('flow pattern payload_json is missing');
+  return JSON.parse(raw) as FlowTemplate;
+}
+
+
+function pair(v: { en?: string; fr?: string } | string | undefined): { en: string; fr: string } {
+  if (!v) return { en: '', fr: '' };
+  if (typeof v === 'string') return { en: v, fr: v };
+  return { en: v.en ?? '', fr: v.fr ?? '' };
+}
+
+function markDirty(): void {
+  db.prepare('UPDATE content_domains SET status=?, published_at=published_at WHERE id=?')
+    .run('draft', FLOW_PATTERNS_DOMAIN);
+}
+
+function validateTemplate(tpl: FlowTemplate): CatalogIssue[] {
+  const issues: CatalogIssue[] = [];
+  const req = (field: string, ok: boolean, message: string) => {
+    if (!ok) issues.push({ code: 'invalid_flow_pattern', message, entityId: tpl.id, field });
+  };
+  req('icon', !!tpl.icon?.trim(), `Pattern "${tpl.id}" needs an icon`);
+  req('name.en', !!pair(tpl.name).en.trim(), `Pattern "${tpl.id}" missing English name`);
+  req('name.fr', !!pair(tpl.name).fr.trim(), `Pattern "${tpl.id}" missing French name`);
+  req('tagline.en', !!pair(tpl.tagline).en.trim(), `Pattern "${tpl.id}" missing English tagline`);
+  req('tagline.fr', !!pair(tpl.tagline).fr.trim(), `Pattern "${tpl.id}" missing French tagline`);
+  if (!Array.isArray(tpl.steps) || tpl.steps.length < 2) {
+    issues.push({ code: 'invalid_flow_pattern', message: `Pattern "${tpl.id}" needs at least two steps`, entityId: tpl.id, field: 'steps' });
+    return issues;
+  }
+  const keys = new Set<string>();
+  tpl.steps.forEach((step, i) => {
+    if (!step.key?.trim()) {
+      issues.push({ code: 'invalid_flow_pattern', message: `Step ${i + 1} in "${tpl.id}" needs a key`, entityId: tpl.id, field: `steps.${i}.key` });
+    } else if (keys.has(step.key)) {
+      issues.push({ code: 'duplicate_step_key', message: `Duplicate step key "${step.key}" in "${tpl.id}"`, entityId: tpl.id, field: `steps.${i}.key` });
+    } else {
+      keys.add(step.key);
+    }
+    if (!pair(step.title).en.trim() || !pair(step.title).fr.trim()) {
+      issues.push({ code: 'invalid_flow_pattern', message: `Step "${step.key}" in "${tpl.id}" needs bilingual title`, entityId: tpl.id, field: `steps.${step.key}.title` });
+    }
+    const hint = step.hint ?? {};
+    const hasSignal = [hint.name, hint.tech, hint.layers, hint.icons].some(arr => Array.isArray(arr) && arr.length > 0);
+    if (!hasSignal) {
+      issues.push({ code: 'invalid_flow_pattern', message: `Step "${step.key}" in "${tpl.id}" needs at least one hint signal`, entityId: tpl.id, field: `steps.${step.key}.hint` });
+    }
+  });
+  return issues;
+}
+
+/** Ensures domain + seeds 8 locked patterns from code catalog. */
+export function ensureFlowPatternsDomain(): void {
+  const existing = getRow<{ id: string }>('SELECT id FROM content_domains WHERE id=?', FLOW_PATTERNS_DOMAIN);
+  if (!existing) {
+    db.prepare('INSERT INTO content_domains (id, status, published_at) VALUES (?, ?, NULL)')
+      .run(FLOW_PATTERNS_DOMAIN, 'draft');
+  }
+  for (const tpl of FLOW_CATALOG) {
+    const row = getRow<{ id: string }>(
+      'SELECT id FROM flow_patterns WHERE domain_id=? AND id=?',
+      FLOW_PATTERNS_DOMAIN,
+      tpl.id,
+    );
+    if (row) continue;
+    db.prepare(
+      'INSERT INTO flow_patterns (domain_id, id, payload_json) VALUES (?, ?, ?)'
+    ).run(FLOW_PATTERNS_DOMAIN, tpl.id, JSON.stringify(tpl));
+    markDirty();
+  }
+}
+
+export function listFlowPatternsAdmin(): AdminFlowListItem[] {
+  ensureFlowPatternsDomain();
+  const domain = getRow<{ published_at: string | null }>(
+    'SELECT published_at FROM content_domains WHERE id=?',
+    FLOW_PATTERNS_DOMAIN,
+  );
+  return rows<{ id: string; payload_json: string }>(
+    'SELECT id, payload_json FROM flow_patterns WHERE domain_id=? ORDER BY id',
+    FLOW_PATTERNS_DOMAIN,
+  ).map(row => {
+    const tpl = parseTemplate(row.payload_json);
+    return {
+      id: tpl.id,
+      icon: tpl.icon,
+      nameEn: pair(tpl.name).en,
+      nameFr: pair(tpl.name).fr,
+      taglineEn: pair(tpl.tagline).en,
+      taglineFr: pair(tpl.tagline).fr,
+      stepCount: tpl.steps.length,
+      locked: isLockedFlowPattern(tpl.id),
+      publishedAt: domain?.published_at ?? null,
+    };
+  });
+}
+
+export function getFlowPatternAdmin(id: string): FlowTemplate | null {
+  ensureFlowPatternsDomain();
+  const row = getRow<{ payload_json: string }>(
+    'SELECT payload_json FROM flow_patterns WHERE domain_id=? AND id=?',
+    FLOW_PATTERNS_DOMAIN,
+    id,
+  );
+  if (!row) return null;
+  return parseTemplate(row.payload_json);
+}
+
+export function createFlowPattern(input: FlowPatternCreate): string {
+  ensureFlowPatternsDomain();
+  const taken = existingPatternIds();
+  const nameEn = input.nameEn.trim();
+  if (!nameEn) throw new Error('English name is required');
+  const id = input.id?.trim()
+    ? slugPatternId(input.id.trim(), new Set())
+    : slugPatternId(nameEn, taken);
+  if (taken.has(id)) throw new Error(`Pattern "${id}" already exists`);
+  const nameFr = (input.nameFr?.trim() || nameEn).trim();
+  const taglineEn = (input.taglineEn?.trim() || nameEn).trim();
+  const taglineFr = (input.taglineFr?.trim() || nameFr).trim();
+  const icon = (input.icon?.trim() || 'route');
+  const tpl = blankPattern(id, nameEn, nameFr, taglineEn, taglineFr, icon);
+  db.prepare(
+    'INSERT INTO flow_patterns (domain_id, id, payload_json) VALUES (?, ?, ?)'
+  ).run(FLOW_PATTERNS_DOMAIN, id, JSON.stringify(tpl));
+  markDirty();
+  return id;
+}
+
+export function deleteFlowPattern(id: string): void {
+  ensureFlowPatternsDomain();
+  const result = db.prepare(
+    'DELETE FROM flow_patterns WHERE domain_id=? AND id=?'
+  ).run(FLOW_PATTERNS_DOMAIN, id);
+  if (!result.changes) throw new Error(`flow pattern not found: ${id}`);
+  markDirty();
+}
+
+export function updateFlowPattern(id: string, body: FlowTemplate): void {
+  ensureFlowPatternsDomain();
+  if (body.id !== id) throw new Error('flow pattern id mismatch');
+  if (!getFlowPatternAdmin(id)) throw new Error(`flow pattern not found: ${id}`);
+  const issues = validateTemplate(body);
+  if (issues.length > 0) throw new Error(issues[0]!.message);
+  db.prepare(
+    'UPDATE flow_patterns SET payload_json=? WHERE domain_id=? AND id=?'
+  ).run(JSON.stringify(body), FLOW_PATTERNS_DOMAIN, id);
+  markDirty();
+}
+
+export function validateFlowPatternsPublish(): CatalogIssue[] {
+  ensureFlowPatternsDomain();
+  const issues: CatalogIssue[] = [];
+  const rowsData = rows<{ id: string; payload_json: string }>(
+    'SELECT id, payload_json FROM flow_patterns WHERE domain_id=?',
+    FLOW_PATTERNS_DOMAIN,
+  );
+  for (const expectedId of LOCKED_FLOW_PATTERN_IDS) {
+    if (!rowsData.some(r => r.id === expectedId)) {
+      issues.push({ code: 'missing_flow_pattern', message: `Missing locked pattern "${expectedId}"`, entityId: expectedId });
+    }
+  }
+  for (const row of rowsData) {
+    issues.push(...validateTemplate(parseTemplate(row.payload_json)));
+  }
+  return issues;
+}
+
+export function publishFlowPatterns(): PublishFlowPatternsResult {
+  const issues = validateFlowPatternsPublish();
+  if (issues.length > 0) return { ok: false, issues };
+  const publishedAt = now();
+  db.prepare('UPDATE content_domains SET status=?, published_at=? WHERE id=?')
+    .run('published', publishedAt, FLOW_PATTERNS_DOMAIN);
+  return { ok: true, publishedAt };
+}
+
+export function getFlowPatternsAdminState(options?: { validate?: boolean }): FlowPatternAdminState {
+  ensureFlowPatternsDomain();
+  const domain = getRow<{ status: string; published_at: string | null }>(
+    'SELECT status, published_at FROM content_domains WHERE id=?',
+    FLOW_PATTERNS_DOMAIN,
+  );
+  const patternCount = getRow<{ n: number }>(
+    'SELECT COUNT(*) AS n FROM flow_patterns WHERE domain_id=?',
+    FLOW_PATTERNS_DOMAIN,
+  )?.n ?? 0;
+  const state: FlowPatternAdminState = {
+    dirty: domain?.status !== 'published',
+    publishedAt: domain?.published_at ?? null,
+    patternCount,
+  };
+  if (!options?.validate) return state;
+  const issues = validateFlowPatternsPublish();
+  return { ...state, issueCount: issues.length, issues };
+}
+
+/** Runtime read when domain is published (ISC-M4). */
+export function getPublishedFlowCatalog(lang: Lang): FlowPattern[] {
+  ensureFlowPatternsDomain();
+  const domain = getRow<{ status: string }>(
+    'SELECT status FROM content_domains WHERE id=?',
+    FLOW_PATTERNS_DOMAIN,
+  );
+  if (domain?.status !== 'published') return [];
+  return rows<{ payload_json: string }>(
+    'SELECT payload_json FROM flow_patterns WHERE domain_id=? ORDER BY id',
+    FLOW_PATTERNS_DOMAIN,
+  ).map(row => ({
+    ...resolveDeep<Omit<FlowPattern, 'source'>>(parseTemplate(row.payload_json), lang),
+    source: 'catalog' as const,
+  }));
+}
+
+export function templateToResolvedPattern(tpl: FlowTemplate, lang: Lang): FlowPattern {
+  return {
+    ...resolveDeep<Omit<FlowPattern, 'source'>>(tpl, lang),
+    source: 'catalog',
+  };
+}

--- a/src/lib/admin/flows.ts
+++ b/src/lib/admin/flows.ts
@@ -1,0 +1,82 @@
+import { api } from '@/lib/api';
+import type { CatalogIssue } from '@/lib/lego/admin-catalog';
+import type { FlowTemplate } from '@/lib/flows/types';
+
+export type AdminFlowListItem = {
+  id: string;
+  icon: string;
+  nameEn: string;
+  nameFr: string;
+  taglineEn: string;
+  taglineFr: string;
+  stepCount: number;
+  locked: boolean;
+  publishedAt?: string | null;
+};
+
+export type FlowLibraryState = {
+  dirty: boolean;
+  publishedAt: string | null;
+  patternCount: number;
+  issues?: CatalogIssue[];
+};
+
+export type FlowPreviewStats = {
+  id: string;
+  stepCount: number;
+  mappableSteps: number;
+  matchedOnDemo: number;
+};
+
+export function fetchFlowPatterns(): Promise<{ patterns: AdminFlowListItem[] }> {
+  return api.json('/api/admin/flows');
+}
+
+export function fetchFlowPattern(id: string): Promise<FlowTemplate> {
+  return api.json(`/api/admin/flows/${id}`);
+}
+
+export function updateFlowPattern(id: string, body: FlowTemplate): Promise<{ ok: boolean }> {
+  return api.json(`/api/admin/flows/${id}`, { method: 'PATCH', body: JSON.stringify(body) });
+}
+
+export function fetchFlowPatternState(options?: { validate?: boolean }): Promise<FlowLibraryState> {
+  const qs = options?.validate ? '?validate=1' : '';
+  return api.json(`/api/admin/flows/state${qs}`);
+}
+
+export async function publishFlowPatterns(): Promise<
+  | { ok: true; publishedAt: string }
+  | { ok: false; error: string; issues: CatalogIssue[] }
+> {
+  const res = await fetch('/api/admin/flows/publish', { method: 'POST' });
+  const body = await res.json().catch(() => ({}));
+  if (res.ok) return { ok: true, publishedAt: (body.publishedAt as string) ?? new Date().toISOString() };
+  return {
+    ok: false,
+    error: (body.error as string) || res.statusText || 'Publish failed',
+    issues: (body.issues as CatalogIssue[]) ?? [],
+  };
+}
+
+export function fetchFlowPatternPreview(id: string, lang: 'en' | 'fr' = 'en'): Promise<FlowPreviewStats> {
+  return api.json(`/api/admin/flows/${id}/preview?lang=${lang}`);
+}
+
+
+export type FlowPatternCreatePayload = {
+  id?: string;
+  icon?: string;
+  nameEn: string;
+  nameFr?: string;
+  taglineEn?: string;
+  taglineFr?: string;
+};
+
+export function createFlowPattern(body: FlowPatternCreatePayload): Promise<{ ok: boolean; id: string }> {
+  return api.json('/api/admin/flows', { method: 'POST', body: JSON.stringify(body) });
+}
+
+export function deleteFlowPattern(id: string): Promise<{ ok: boolean; id: string }> {
+  return api.json(`/api/admin/flows/${id}`, { method: 'DELETE' });
+}

--- a/src/lib/admin/isc-a3-a8.test.ts
+++ b/src/lib/admin/isc-a3-a8.test.ts
@@ -1,0 +1,150 @@
+/**
+ * ISC-A3 + Anti ISC-A8 (falsifiers).
+ * A3 probe: hydrate/resolvePresetSection title (not PDF generation).
+ */
+import assert from 'node:assert/strict';
+import { after, before, describe, test } from 'node:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const dbFile = path.join(os.tmpdir(), `archstudio-isc-a3-a8-${process.pid}.db`);
+process.env.DATABASE_PATH = dbFile;
+
+const PLACEHOLDERS = ['[…]', 'À estimer', 'To be estimated'] as const;
+const A3_MARKER_EN = 'ISC_A3_AUTH0_TITLE_EN_7f3c91';
+const A3_MARKER_FR = 'ISC_A3_AUTH0_TITLE_FR_7f3c91';
+
+let AS: typeof import('./add-sections');
+let PS: typeof import('./preset-sections.server');
+let Admin: typeof import('../lego/admin-catalog');
+let Repo: typeof import('../lego/repository');
+let Store: typeof import('../store');
+let Hydrate: typeof import('../document/hydrate');
+
+function scrubPlaceholders<T>(value: T): T {
+  let json = JSON.stringify(value);
+  for (const marker of PLACEHOLDERS) {
+    json = json.split(marker).join('filled');
+  }
+  return JSON.parse(json) as T;
+}
+
+before(async () => {
+  AS = await import('./add-sections');
+  PS = await import('./preset-sections.server');
+  Admin = await import('../lego/admin-catalog');
+  Repo = await import('../lego/repository');
+  Store = await import('../store');
+  Hydrate = await import('../document/hydrate');
+});
+
+after(() => {
+  for (const f of [dbFile, `${dbFile}-wal`, `${dbFile}-shm`]) {
+    fs.rmSync(f, { force: true });
+  }
+});
+
+describe('ISC-A3 + Anti ISC-A8', { concurrency: 1 }, () => {
+  test('ISC-A3: published add-iam title reaches hydrate when CONTENT_FROM_ADMIN=1', () => {
+    // Probe: resolvePresetSection + hydratePresetSection title (PDF gated Auth0 uses same path).
+    const prev = process.env.CONTENT_FROM_ADMIN;
+    process.env.CONTENT_FROM_ADMIN = '1';
+    try {
+      AS.ensureAddSectionsDomain();
+
+      for (const row of AS.listAddSectionsAdmin()) {
+        const detail = AS.getAddSectionAdmin(row.id);
+        assert.ok(detail, `missing section ${row.id}`);
+        const en = scrubPlaceholders(detail.en);
+        const fr = scrubPlaceholders(detail.fr);
+        if (row.id === 'add-iam') {
+          en.title = A3_MARKER_EN;
+          fr.title = A3_MARKER_FR;
+        }
+        AS.updateAddSection(row.id, { en, fr });
+      }
+
+      const published = AS.publishAddSections();
+      assert.equal(published.ok, true, published.ok ? '' : published.issues.map(i => i.message).join('; '));
+
+      const draft = AS.getAddSectionAdmin('add-iam');
+      assert.equal(draft?.en.title, A3_MARKER_EN);
+
+      const resolved = PS.resolvePresetSection('add-iam', 'en');
+      assert.ok(resolved, 'resolvePresetSection must return published add-iam');
+      assert.equal(resolved.title, A3_MARKER_EN);
+
+      const doc = {
+        meta: { name: 'ISC-A3', lang: 'en' as const },
+        groups: [{ id: 'core', name: 'Core' }],
+        layers: [{ id: 'edge', name: 'Edge' }],
+        components: [{
+          id: 'auth0',
+          name: 'Auth0',
+          group: 'core',
+          layer: 'edge',
+          brick: 'identity' as const,
+          concernTags: ['iam' as const],
+          purpose: 'Auth0',
+          tech: ['OIDC'],
+        }],
+        sections: [] as [],
+        flows: [] as [],
+        ui: { tabs: [] as string[] },
+      };
+
+      const hydrated = Hydrate.hydratePresetSection(resolved, doc as never, 'en');
+      assert.equal(hydrated.title, A3_MARKER_EN);
+      assert.match(JSON.stringify(hydrated), new RegExp(A3_MARKER_EN));
+    } finally {
+      if (prev === undefined) delete process.env.CONTENT_FROM_ADMIN;
+      else process.env.CONTENT_FROM_ADMIN = prev;
+    }
+  });
+
+  test('Anti ISC-A8: publishCatalog does not rewrite snapshotted component concernTags', () => {
+    Repo.ensureLegoCatalog();
+
+    const project = Store.createProject({
+      name: 'ISC-A8 snapshot',
+      data: {
+        meta: { name: 'ISC-A8', lang: 'en' },
+        groups: [{ id: 'core', name: 'Core' }],
+        layers: [{ id: 'edge', name: 'Edge' }],
+        components: [{
+          id: 'auth0',
+          name: 'Auth0',
+          group: 'core',
+          layer: 'edge',
+          brick: 'identity',
+          concernTags: ['iam'],
+          purpose: 'Auth0',
+        }],
+        sections: [],
+        flows: [],
+        ui: { tabs: [] },
+      },
+    });
+
+    const before = project.data.components.find(c => c.id === 'auth0')?.concernTags;
+    assert.deepEqual(before, ['iam']);
+
+    Admin.updateAdminBrick('identity', { concernTags: ['governance'] });
+    const catalogAfterUpdate = Repo.legoCatalog('en').bricks.identity?.concernTags;
+    assert.deepEqual([...(catalogAfterUpdate ?? [])].sort(), ['governance']);
+
+    const published = Admin.publishCatalog();
+    assert.equal(published.ok, true, published.ok ? '' : published.issues.map(i => i.message).join('; '));
+
+    const reloaded = Store.getProject(project.id);
+    assert.ok(reloaded);
+    const after = reloaded.data.components.find(c => c.id === 'auth0')?.concernTags;
+    assert.deepEqual(after, ['iam'], 'project component concernTags must stay snapshotted across catalog publish');
+    assert.notDeepEqual(
+      after,
+      Repo.legoCatalog('en').bricks.identity?.concernTags,
+      'catalog live tags diverge from snapshot',
+    );
+  });
+});

--- a/src/lib/admin/issue-routes.ts
+++ b/src/lib/admin/issue-routes.ts
@@ -1,0 +1,78 @@
+import type { CatalogIssue } from '@/lib/lego/admin-catalog';
+
+const ACME_TEMPLATE_ID = 'acme-v1';
+
+const BRICK_CODES = new Set(['missing_role', 'invalid_concern_tag', 'orphan_dependency']);
+
+const TEMPLATE_CODES = new Set([
+  'acme_component_count',
+  'acme_missing_section',
+  'no_components',
+  'placeholder_section',
+  'invalid_group',
+  'featured_count',
+  'no_templates',
+]);
+
+const FLOW_CODES = new Set([
+  'invalid_flow_pattern',
+  'duplicate_step_key',
+  'missing_flow_pattern',
+]);
+
+const ARCHITECTURE_CODES = new Set([
+  'invalid_architecture_template',
+  'missing_architecture_template',
+]);
+
+const CLOUD_SERVICE_CODES = new Set([
+  'invalid_cloud_service',
+  'missing_cloud_service',
+]);
+
+function fieldQuery(field?: string): string {
+  return field ? `?field=${encodeURIComponent(field)}` : '';
+}
+
+function looksLikeBrickId(entityId: string): boolean {
+  return entityId.includes('-') && !entityId.startsWith('acme-');
+}
+
+/** Deep-link from a validation issue to the admin editor field (ISC-UX2). */
+export function issueEditHref(issue: CatalogIssue): string | null {
+  const { code, field, entityId } = issue;
+
+  if (code === 'orphan_variant' && entityId) {
+    return `/admin/catalog/variants?variant=${encodeURIComponent(entityId)}`;
+  }
+
+  if (BRICK_CODES.has(code) && entityId) {
+    return `/admin/catalog/bricks/${encodeURIComponent(entityId)}${fieldQuery(field)}`;
+  }
+
+  if (TEMPLATE_CODES.has(code)) {
+    if (code === 'featured_count' && !entityId) {
+      return field ? `/admin/templates?${new URLSearchParams({ field }).toString()}` : '/admin/templates';
+    }
+    const templateId = entityId ?? ACME_TEMPLATE_ID;
+    return `/admin/templates/${encodeURIComponent(templateId)}${fieldQuery(field)}`;
+  }
+
+  if (FLOW_CODES.has(code) && entityId) {
+    return `/admin/flows/${encodeURIComponent(entityId)}${fieldQuery(field)}`;
+  }
+
+  if (ARCHITECTURE_CODES.has(code) && entityId) {
+    return `/admin/templates/${encodeURIComponent(entityId)}${fieldQuery(field)}`;
+  }
+
+  if (CLOUD_SERVICE_CODES.has(code) && entityId) {
+    return `/admin/catalog/cloud-services?role=${encodeURIComponent(entityId)}${field ? `&field=${encodeURIComponent(field)}` : ''}`;
+  }
+
+  if (entityId && looksLikeBrickId(entityId)) {
+    return `/admin/catalog/bricks/${encodeURIComponent(entityId)}${fieldQuery(field)}`;
+  }
+
+  return null;
+}

--- a/src/lib/admin/preset-sections.server.ts
+++ b/src/lib/admin/preset-sections.server.ts
@@ -1,0 +1,14 @@
+import { contentFromAdmin } from './flags';
+import { getPublishedAddSection } from './add-sections';
+import { presetSectionForId as presetSectionFromCode } from '../document/preset';
+import type { Section } from '../types';
+import type { Lang } from '../templates/types';
+
+/** Server-only: admin published section when flag on, else code preset. */
+export function resolvePresetSection(id: string, lang?: Lang): Section | undefined {
+  if (contentFromAdmin()) {
+    const fromAdmin = getPublishedAddSection(id, lang);
+    if (fromAdmin) return fromAdmin;
+  }
+  return presetSectionFromCode(id, lang);
+}

--- a/src/lib/admin/project-templates.test.ts
+++ b/src/lib/admin/project-templates.test.ts
@@ -1,0 +1,86 @@
+import { strict as assert } from 'node:assert';
+import { after, before, describe, test } from 'node:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import demo from '../seed/demo.json';
+import type { Architecture } from '../types';
+
+const dbFile = path.join(os.tmpdir(), `archstudio-project-templates-${process.pid}.db`);
+process.env.DATABASE_PATH = dbFile;
+
+let PT: typeof import('./project-templates');
+let Store: typeof import('../store');
+
+before(async () => {
+  PT = await import('./project-templates');
+  Store = await import('../store');
+});
+
+after(() => {
+  for (const f of [dbFile, `${dbFile}-wal`, `${dbFile}-shm`]) fs.rmSync(f, { force: true });
+});
+
+describe('project templates', { concurrency: 1 }, () => {
+  test('ISC-A6: Acme admin outline matches demo.json', () => {
+    PT.ensureProjectTemplatesDomain();
+    const acme = PT.getProjectTemplateAdmin('acme-v1');
+    assert.ok(acme);
+
+    const demoArch = demo as unknown as Architecture;
+    const adminOutline = PT.projectTemplateOutline(acme!.snapshot);
+    const demoOutline = PT.projectTemplateOutline(demoArch);
+
+    assert.equal(adminOutline.componentCount, 22);
+    assert.equal(adminOutline.componentCount, demoOutline.componentCount);
+    assert.deepEqual(adminOutline.sectionIds, demoOutline.sectionIds);
+    assert.equal(adminOutline.flowCount, demoOutline.flowCount);
+  });
+
+  test('ISC-A2: createProject from published template has 22 components', () => {
+    PT.ensureProjectTemplatesDomain();
+    const publish = PT.publishProjectTemplates();
+    assert.equal(publish.ok, true);
+
+    const tpl = PT.getPublishedProjectTemplate('acme-v1');
+    assert.ok(tpl);
+
+    const doc = PT.instantiateProjectTemplate(tpl!, 'Test Acme');
+    const project = Store.createProject({
+      name: 'Test Acme',
+      data: doc,
+    });
+
+    assert.equal(project.data.components?.length, 22);
+  });
+
+  test('publish rejects when featured count is not exactly one', () => {
+    PT.ensureProjectTemplatesDomain();
+    PT.updateProjectTemplate('acme-v1', { featured: false });
+    const result = PT.publishProjectTemplates();
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.ok(result.issues.some(i => i.code === 'featured_count'));
+    }
+    PT.updateProjectTemplate('acme-v1', { featured: true });
+  });
+
+  test('listAllAdminTemplates includes project and architecture templates', () => {
+    PT.ensureProjectTemplatesDomain();
+    const all = PT.listAllAdminTemplates();
+    assert.ok(all.some(t => t.id === 'acme-v1' && t.kind === 'project'));
+    assert.ok(all.some(t => t.id === 'serverless-mvp' && t.kind === 'architecture'));
+    assert.equal(all.filter(t => t.kind === 'architecture').length, 6);
+  });
+
+  test('create and delete project template', () => {
+    PT.ensureProjectTemplatesDomain();
+    const id = PT.createProjectTemplate({ id: 'test-template', nameEn: 'Test Template' });
+    assert.equal(id, 'test-template');
+    const created = PT.getProjectTemplateAdmin(id);
+    assert.ok(created);
+    assert.equal(created!.nameEn, 'Test Template');
+    PT.deleteProjectTemplate(id);
+    assert.equal(PT.getProjectTemplateAdmin(id), null);
+  });
+});

--- a/src/lib/admin/project-templates.ts
+++ b/src/lib/admin/project-templates.ts
@@ -1,0 +1,602 @@
+import demo from '../seed/demo.json';
+import { blankArchitecture, normalizeArchitecture } from '../defaults';
+import { db, now, plain, plainAll } from '../db';
+import type { Architecture, Section } from '../types';
+import type { CatalogIssue } from '../lego/admin-catalog';
+import type { CloudTarget, Lang, TemplateSummary } from '../templates/types';
+import { LANGS, TARGETS } from '../templates/types';
+import { getArchitectureTemplateAdmin, listArchitectureTemplatesAdmin } from './architecture-templates';
+
+export const PROJECT_TEMPLATES_DOMAIN = 'project-templates';
+
+const ACME_TEMPLATE_ID = 'acme-v1';
+const AUTHOR_SECTION_IDS = ['platforms', 'operations', 'roadmap', 'risks'] as const;
+
+export type ProjectTemplateMeta = {
+  icon: string;
+  accent: string;
+  accentDark?: string;
+  taglineEn: string;
+  taglineFr: string;
+  descriptionEn?: string;
+  descriptionFr?: string;
+  whenToUseEn: string[];
+  whenToUseFr: string[];
+  whenNotToUseEn: string[];
+  whenNotToUseFr: string[];
+  /** Project name used by ensureSeed when this template is featured. */
+  seedName?: string;
+};
+
+export type ProjectTemplateRow = {
+  id: string;
+  nameEn: string;
+  nameFr: string;
+  meta: ProjectTemplateMeta;
+  snapshot: Architecture;
+  sortOrder: number;
+  featured: boolean;
+};
+
+export type ProjectTemplateAdminState = {
+  dirty: boolean;
+  publishedAt: string | null;
+  templateCount: number;
+  issueCount?: number;
+  issues?: CatalogIssue[];
+};
+
+export type PublishProjectTemplatesResult =
+  | { ok: true; publishedAt: string }
+  | { ok: false; issues: CatalogIssue[] };
+
+const ACME_META: ProjectTemplateMeta = {
+  icon: 'cube',
+  accent: '#4F8AC6',
+  accentDark: '#00E5FF',
+  taglineEn: 'The reference example: a consumer platform and a business platform on separate stacks.',
+  taglineFr: 'L\'exemple de référence : une plateforme consommateur et une plateforme pro sur des stacks séparées.',
+  descriptionEn: 'The reference example: a consumer platform and a business platform on separate stacks.',
+  descriptionFr: 'L\'exemple de référence : une plateforme consommateur et une plateforme pro sur des stacks séparées.',
+  whenToUseEn: [
+    'You want a dense, print-ready ADD as a starting point.',
+    'Two-platform B2C/B2B split with a shared operational core.',
+  ],
+  whenToUseFr: [
+    'Vous voulez un ADD dense et prêt à imprimer comme point de départ.',
+    'Séparation B2C/B2B avec un socle opérationnel partagé.',
+  ],
+  whenNotToUseEn: [
+    'You need a single monolith or a blank canvas.',
+    'You want hyperscaler-specific service names out of the box.',
+  ],
+  whenNotToUseFr: [
+    'Vous partez d\'une page blanche ou d\'un monolithe unique.',
+    'Vous voulez des noms de services cloud prêts à l\'emploi.',
+  ],
+  seedName: 'Acme — two platforms',
+};
+
+
+function getRow<T>(sql: string, ...params: (string | number | null)[]): T | null {
+  const raw = db.prepare(sql).get(...params);
+  if (!raw) return null;
+  return plain<T>(raw);
+}
+
+function rows<T>(sql: string, ...values: (string | number | null)[]): T[] {
+  return plainAll<T>(db.prepare(sql).all(...values));
+}
+
+function parseMeta(raw: string | null): ProjectTemplateMeta {
+  if (!raw) throw new Error('Project template meta_json is missing');
+  return JSON.parse(raw) as ProjectTemplateMeta;
+}
+
+function parseSnapshot(raw: string | null): Architecture {
+  if (!raw) throw new Error('Project template snapshot_json is missing');
+  return normalizeArchitecture(JSON.parse(raw));
+}
+
+function rowToTemplate(row: {
+  id: string;
+  name_en: string | null;
+  name_fr: string | null;
+  meta_json: string | null;
+  snapshot_json: string | null;
+  sort_order: number | null;
+  featured: number | null;
+}): ProjectTemplateRow {
+  return {
+    id: row.id,
+    nameEn: row.name_en ?? row.id,
+    nameFr: row.name_fr ?? row.name_en ?? row.id,
+    meta: parseMeta(row.meta_json),
+    snapshot: parseSnapshot(row.snapshot_json),
+    sortOrder: row.sort_order ?? 0,
+    featured: Boolean(row.featured),
+  };
+}
+
+/** Ensures the content domain row and seeds Acme on first run. */
+export function ensureProjectTemplatesDomain(): void {
+  const existing = getRow<{ id: string }>('SELECT id FROM content_domains WHERE id=?', PROJECT_TEMPLATES_DOMAIN);
+  if (!existing) {
+    db.prepare('INSERT INTO content_domains (id, status, published_at) VALUES (?, ?, NULL)')
+      .run(PROJECT_TEMPLATES_DOMAIN, 'draft');
+  }
+
+  const acmeRow = getRow<{ id: string; meta_json: string | null; snapshot_json: string | null }>(
+    'SELECT id, meta_json, snapshot_json FROM project_templates WHERE domain_id=? AND id=?',
+    PROJECT_TEMPLATES_DOMAIN,
+    ACME_TEMPLATE_ID,
+  );
+  if (!acmeRow) {
+    importAcmeTemplate();
+  } else if (!acmeRow.meta_json || !acmeRow.snapshot_json) {
+    writeAcmeSeedRow();
+  }
+}
+
+function writeAcmeSeedRow(): void {
+  const snapshot = demo as unknown as Architecture;
+  db.prepare(
+    `UPDATE project_templates
+     SET name_en=?, name_fr=?, meta_json=?, snapshot_json=?, sort_order=?, featured=?
+     WHERE domain_id=? AND id=?`
+  ).run(
+    'Acme — two platforms',
+    'Acme — deux plateformes',
+    JSON.stringify(ACME_META),
+    JSON.stringify(snapshot),
+    0,
+    1,
+    PROJECT_TEMPLATES_DOMAIN,
+    ACME_TEMPLATE_ID,
+  );
+  markProjectTemplatesDirty();
+}
+
+function importAcmeTemplate(): string {
+  const snapshot = demo as unknown as Architecture;
+  db.prepare(
+    `INSERT INTO project_templates
+      (domain_id, id, name_en, name_fr, meta_json, snapshot_json, sort_order, featured)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run(
+    PROJECT_TEMPLATES_DOMAIN,
+    ACME_TEMPLATE_ID,
+    'Acme — two platforms',
+    'Acme — deux plateformes',
+    JSON.stringify(ACME_META),
+    JSON.stringify(snapshot),
+    0,
+    1,
+  );
+  markProjectTemplatesDirty();
+  return ACME_TEMPLATE_ID;
+}
+
+function markProjectTemplatesDirty(): void {
+  db.prepare(
+    'UPDATE content_domains SET status=?, published_at=published_at WHERE id=?'
+  ).run('draft', PROJECT_TEMPLATES_DOMAIN);
+}
+
+/** Lists all project templates in admin (draft layer). */
+export function listProjectTemplatesAdmin(): ProjectTemplateRow[] {
+  ensureProjectTemplatesDomain();
+  return rows<{
+    id: string;
+    name_en: string | null;
+    name_fr: string | null;
+    meta_json: string | null;
+    snapshot_json: string | null;
+    sort_order: number | null;
+    featured: number | null;
+  }>(
+    'SELECT id, name_en, name_fr, meta_json, snapshot_json, sort_order, featured FROM project_templates WHERE domain_id=? ORDER BY sort_order, id',
+    PROJECT_TEMPLATES_DOMAIN,
+  ).map(rowToTemplate);
+}
+
+/** Returns one admin template by id. */
+export function getProjectTemplateAdmin(id: string): ProjectTemplateRow | null {
+  ensureProjectTemplatesDomain();
+  const row = getRow<{
+    id: string;
+    name_en: string | null;
+    name_fr: string | null;
+    meta_json: string | null;
+    snapshot_json: string | null;
+    sort_order: number | null;
+    featured: number | null;
+  }>(
+    'SELECT id, name_en, name_fr, meta_json, snapshot_json, sort_order, featured FROM project_templates WHERE domain_id=? AND id=?',
+    PROJECT_TEMPLATES_DOMAIN,
+    id,
+  );
+  return row ? rowToTemplate(row) : null;
+}
+
+/** Published templates only — runtime picker and ensureSeed. */
+export function listPublishedProjectTemplates(): ProjectTemplateRow[] {
+  ensureProjectTemplatesDomain();
+  const domain = getRow<{ status: string }>('SELECT status FROM content_domains WHERE id=?', PROJECT_TEMPLATES_DOMAIN);
+  if (domain?.status !== 'published') return [];
+  return listProjectTemplatesAdmin();
+}
+
+/** Featured published template for ensureSeed. */
+export function getFeaturedPublishedProjectTemplate(): ProjectTemplateRow | null {
+  const published = listPublishedProjectTemplates();
+  return published.find(t => t.featured) ?? published[0] ?? null;
+}
+
+
+/** Returns one published template by id (runtime). */
+export function getPublishedProjectTemplate(id: string): ProjectTemplateRow | null {
+  ensureProjectTemplatesDomain();
+  const domain = getRow<{ status: string }>('SELECT status FROM content_domains WHERE id=?', PROJECT_TEMPLATES_DOMAIN);
+  if (domain?.status !== 'published') return null;
+  return getProjectTemplateAdmin(id);
+}
+
+/** Deep-copies a published snapshot into a new project document. */
+export function instantiateProjectTemplate(
+  template: ProjectTemplateRow,
+  projectName: string,
+): Architecture {
+  const doc = structuredClone(template.snapshot);
+  doc.meta = { ...doc.meta, name: projectName };
+  return normalizeArchitecture(doc);
+}
+
+export function projectTemplateSummaries(): TemplateSummary[] {
+  return listPublishedProjectTemplates().map(tpl => {
+    const count = tpl.snapshot.components?.length ?? 0;
+    const counts = Object.fromEntries(TARGETS.map(target => [target, count])) as Record<CloudTarget, number>;
+    const both = <T>(pick: (lang: Lang) => T) =>
+      Object.fromEntries(LANGS.map(lang => [lang, pick(lang)])) as Record<Lang, T>;
+
+    return {
+      id: tpl.id,
+      kind: 'project' as const,
+      icon: tpl.meta.icon,
+      accent: tpl.meta.accent,
+      accentDark: tpl.meta.accentDark ?? tpl.meta.accent,
+      name: both(lang => (lang === 'fr' ? tpl.nameFr : tpl.nameEn)),
+      tagline: both(lang => (lang === 'fr' ? tpl.meta.taglineFr : tpl.meta.taglineEn)),
+      whenToUse: both(lang => (lang === 'fr' ? tpl.meta.whenToUseFr : tpl.meta.whenToUseEn)),
+      whenNotToUse: both(lang => (lang === 'fr' ? tpl.meta.whenNotToUseFr : tpl.meta.whenNotToUseEn)),
+      supportedTargets: ['agnostic'],
+      counts,
+    };
+  });
+}
+
+function sectionHasPlaceholder(section: Section): boolean {
+  const blob = JSON.stringify(section);
+  return blob.includes('[…]') || blob.includes('À estimer') || blob.includes('To be estimated');
+}
+
+/** Publish validation — ISC-A6 Acme parity + structural checks. */
+export function validateProjectTemplatesPublish(): CatalogIssue[] {
+  ensureProjectTemplatesDomain();
+  const issues: CatalogIssue[] = [];
+  const templates = listProjectTemplatesAdmin();
+
+  if (templates.length === 0) {
+    issues.push({ code: 'no_templates', message: 'At least one project template is required' });
+    return issues;
+  }
+
+  const featured = templates.filter(t => t.featured);
+  if (featured.length !== 1) {
+    issues.push({
+      code: 'featured_count',
+      message: `Exactly one featured template required (found ${featured.length})`,
+      field: 'featured',
+    });
+  }
+
+  for (const tpl of templates) {
+    const { snapshot } = tpl;
+    const components = snapshot.components ?? [];
+    const groups = new Set((snapshot.groups ?? []).map(g => g.id));
+
+    if (components.length === 0) {
+      issues.push({ code: 'no_components', message: 'Template has no components', entityId: tpl.id });
+    }
+
+    for (const component of components) {
+      if (!groups.has(component.group)) {
+        issues.push({
+          code: 'invalid_group',
+          message: `Component "${component.id}" references unknown group "${component.group}"`,
+          entityId: tpl.id,
+          field: 'group',
+        });
+      }
+    }
+
+    for (const section of snapshot.sections ?? []) {
+      if (sectionHasPlaceholder(section)) {
+        issues.push({
+          code: 'placeholder_section',
+          message: `Section "${section.id}" contains placeholder content`,
+          entityId: tpl.id,
+          field: 'sections',
+        });
+      }
+    }
+
+    if (tpl.id === ACME_TEMPLATE_ID) {
+      if (components.length !== 22) {
+        issues.push({
+          code: 'acme_component_count',
+          message: `Acme template must have 22 components (found ${components.length})`,
+          entityId: tpl.id,
+        });
+      }
+      const sectionIds = new Set((snapshot.sections ?? []).map(s => s.id));
+      for (const required of AUTHOR_SECTION_IDS) {
+        if (!sectionIds.has(required)) {
+          issues.push({
+            code: 'acme_missing_section',
+            message: `Acme template missing author section "${required}"`,
+            entityId: tpl.id,
+            field: 'sections',
+          });
+        }
+      }
+    }
+  }
+
+  return issues;
+}
+
+export function getProjectTemplatesAdminState(options?: { validate?: boolean }): ProjectTemplateAdminState {
+  ensureProjectTemplatesDomain();
+  const domain = getRow<{ status: string; published_at: string | null }>(
+    'SELECT status, published_at FROM content_domains WHERE id=?',
+    PROJECT_TEMPLATES_DOMAIN,
+  );
+  const templateCount = getRow<{ n: number }>(
+    'SELECT COUNT(*) AS n FROM project_templates WHERE domain_id=?',
+    PROJECT_TEMPLATES_DOMAIN,
+  )?.n ?? 0;
+  const state: ProjectTemplateAdminState = {
+    dirty: domain?.status !== 'published',
+    publishedAt: domain?.published_at ?? null,
+    templateCount,
+  };
+  if (!options?.validate) return state;
+  const issues = validateProjectTemplatesPublish();
+  return { ...state, issueCount: issues.length, issues };
+}
+
+/** Validates and publishes project templates. */
+export function publishProjectTemplates(): PublishProjectTemplatesResult {
+  const issues = validateProjectTemplatesPublish();
+  if (issues.length > 0) return { ok: false, issues };
+
+  const publishedAt = now();
+  db.prepare('UPDATE content_domains SET status=?, published_at=? WHERE id=?')
+    .run('published', publishedAt, PROJECT_TEMPLATES_DOMAIN);
+  return { ok: true, publishedAt };
+}
+
+
+export type AdminTemplateKind = 'project' | 'architecture';
+
+export type AdminTemplateListItem = {
+  id: string;
+  kind: AdminTemplateKind;
+  editable: boolean;
+  nameEn: string;
+  nameFr: string;
+  sortOrder: number;
+  featured: boolean;
+  componentCount: number;
+  sectionCount: number;
+  flowCount: number;
+  accent: string;
+  icon: string;
+  taglineEn: string;
+  taglineFr: string;
+};
+
+const DEFAULT_PROJECT_META: ProjectTemplateMeta = {
+  icon: 'cube',
+  accent: '#0E7C8A',
+  accentDark: '#00E5FF',
+  taglineEn: 'A full architecture snapshot ready to instantiate.',
+  taglineFr: 'Un snapshot d\'architecture prêt à instancier.',
+  whenToUseEn: ['Starting from a documented reference architecture.'],
+  whenToUseFr: ['Partir d\'une architecture de référence documentée.'],
+  whenNotToUseEn: ['You need hyperscaler-specific service names (use an architecture template).'],
+  whenNotToUseFr: ['Vous voulez des noms de services cloud (utilisez un template architecture).'],
+};
+
+function slugTemplateId(raw: string): string {
+  const id = raw.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+  if (!id || !/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(id)) {
+    throw new Error('Template id must be lowercase letters, numbers and hyphens');
+  }
+  return id;
+}
+
+function templateExists(id: string): boolean {
+  return Boolean(getRow<{ id: string }>(
+    'SELECT id FROM project_templates WHERE domain_id=? AND id=?',
+    PROJECT_TEMPLATES_DOMAIN,
+    id,
+  ));
+}
+
+/** All templates visible in admin: project snapshots + architecture hyperscaler templates. */
+export function listAllAdminTemplates(): AdminTemplateListItem[] {
+  const project = listProjectTemplatesAdmin().map(tpl => ({
+    id: tpl.id,
+    kind: 'project' as const,
+    editable: true,
+    nameEn: tpl.nameEn,
+    nameFr: tpl.nameFr,
+    sortOrder: tpl.sortOrder,
+    featured: tpl.featured,
+    componentCount: tpl.snapshot.components?.length ?? 0,
+    sectionCount: tpl.snapshot.sections?.length ?? 0,
+    flowCount: tpl.snapshot.flows?.length ?? 0,
+    accent: tpl.meta.accent,
+    icon: tpl.meta.icon,
+    taglineEn: tpl.meta.taglineEn,
+    taglineFr: tpl.meta.taglineFr,
+  }));
+
+  const arch = listArchitectureTemplatesAdmin().map(tpl => ({
+    id: tpl.id,
+    kind: 'architecture' as const,
+    editable: true,
+    nameEn: tpl.nameEn,
+    nameFr: tpl.nameFr,
+    sortOrder: tpl.sortOrder,
+    featured: false as const,
+    componentCount: tpl.componentCount,
+    sectionCount: tpl.sectionCount,
+    flowCount: tpl.flowCount,
+    accent: tpl.accent,
+    icon: tpl.icon,
+    taglineEn: tpl.taglineEn,
+    taglineFr: tpl.taglineFr,
+  }));
+
+  return [...project.sort((a, b) => a.sortOrder - b.sortOrder || a.id.localeCompare(b.id)), ...arch];
+}
+
+export type ProjectTemplateCreate = {
+  id: string;
+  nameEn: string;
+  nameFr?: string;
+  meta?: Partial<ProjectTemplateMeta>;
+  snapshot?: Architecture;
+  featured?: boolean;
+  sortOrder?: number;
+};
+
+/** Creates a new editable project template. */
+export function createProjectTemplate(input: ProjectTemplateCreate): string {
+  ensureProjectTemplatesDomain();
+  const id = slugTemplateId(input.id);
+  if (templateExists(id)) throw new Error(`Project template "${id}" already exists`);
+  const nameFr = input.nameFr?.trim() || input.nameEn;
+  const snapshot = input.snapshot ? normalizeArchitecture(input.snapshot) : blankArchitecture(input.nameEn);
+  const meta: ProjectTemplateMeta = { ...DEFAULT_PROJECT_META, ...input.meta };
+  const sortOrder = input.sortOrder ?? (getRow<{ m: number | null }>(
+    'SELECT MAX(sort_order) AS m FROM project_templates WHERE domain_id=?',
+    PROJECT_TEMPLATES_DOMAIN,
+  )?.m ?? -1) + 1;
+  const featured = Boolean(input.featured);
+  if (featured) {
+    db.prepare('UPDATE project_templates SET featured=0 WHERE domain_id=?').run(PROJECT_TEMPLATES_DOMAIN);
+  }
+  db.prepare(
+    `INSERT INTO project_templates
+      (domain_id, id, name_en, name_fr, meta_json, snapshot_json, sort_order, featured)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run(
+    PROJECT_TEMPLATES_DOMAIN,
+    id,
+    input.nameEn.trim(),
+    nameFr,
+    JSON.stringify(meta),
+    JSON.stringify(snapshot),
+    sortOrder,
+    featured ? 1 : 0,
+  );
+  markProjectTemplatesDirty();
+  return id;
+}
+
+/** Deletes a project template. Architecture templates (code registry) cannot be deleted here. */
+export function deleteProjectTemplate(id: string): void {
+  ensureProjectTemplatesDomain();
+  if (!templateExists(id)) throw new Error(`Project template "${id}" does not exist`);
+  const wasFeatured = getRow<{ featured: number }>(
+    'SELECT featured FROM project_templates WHERE domain_id=? AND id=?',
+    PROJECT_TEMPLATES_DOMAIN,
+    id,
+  )?.featured;
+  db.prepare('DELETE FROM project_templates WHERE domain_id=? AND id=?').run(PROJECT_TEMPLATES_DOMAIN, id);
+  if (wasFeatured) {
+    const next = getRow<{ id: string }>(
+      'SELECT id FROM project_templates WHERE domain_id=? ORDER BY sort_order, id LIMIT 1',
+      PROJECT_TEMPLATES_DOMAIN,
+    );
+    if (next) {
+      db.prepare('UPDATE project_templates SET featured=1 WHERE domain_id=? AND id=?')
+        .run(PROJECT_TEMPLATES_DOMAIN, next.id);
+    }
+  }
+  markProjectTemplatesDirty();
+}
+
+export { getArchitectureTemplateAdmin };
+
+export type ProjectTemplateUpdate = {
+  nameEn?: string;
+  nameFr?: string;
+  sortOrder?: number;
+  featured?: boolean;
+  meta?: Partial<ProjectTemplateMeta>;
+  snapshot?: Architecture;
+};
+
+/** Updates template metadata (not snapshot body in v1). */
+export function updateProjectTemplate(id: string, patch: ProjectTemplateUpdate): string {
+  ensureProjectTemplatesDomain();
+  const current = getProjectTemplateAdmin(id);
+  if (!current) throw new Error(`Project template "${id}" does not exist`);
+
+  const nameEn = patch.nameEn ?? current.nameEn;
+  const nameFr = patch.nameFr ?? current.nameFr;
+  const sortOrder = patch.sortOrder ?? current.sortOrder;
+  const featured = patch.featured ?? current.featured;
+  const meta: ProjectTemplateMeta = { ...current.meta, ...patch.meta };
+  const snapshot = patch.snapshot ? normalizeArchitecture(patch.snapshot) : current.snapshot;
+
+  if (featured) {
+    db.prepare('UPDATE project_templates SET featured=0 WHERE domain_id=?').run(PROJECT_TEMPLATES_DOMAIN);
+  }
+
+  db.prepare(
+    `UPDATE project_templates
+     SET name_en=?, name_fr=?, meta_json=?, snapshot_json=?, sort_order=?, featured=?
+     WHERE domain_id=? AND id=?`
+  ).run(nameEn, nameFr, JSON.stringify(meta), JSON.stringify(snapshot), sortOrder, featured ? 1 : 0, PROJECT_TEMPLATES_DOMAIN, id);
+
+  markProjectTemplatesDirty();
+  return id;
+}
+
+/** Re-imports Acme snapshot from demo.json (admin repair). */
+export function reimportAcmeTemplate(): string {
+  ensureProjectTemplatesDomain();
+  const exists = getRow<{ id: string }>(
+    'SELECT id FROM project_templates WHERE domain_id=? AND id=?',
+    PROJECT_TEMPLATES_DOMAIN,
+    ACME_TEMPLATE_ID,
+  );
+  if (exists) writeAcmeSeedRow();
+  else importAcmeTemplate();
+  return ACME_TEMPLATE_ID;
+}
+
+/** Outline shape for ISC-A6 snapshot comparison. */
+export function projectTemplateOutline(snapshot: Architecture) {
+  return {
+    componentCount: snapshot.components?.length ?? 0,
+    sectionIds: (snapshot.sections ?? []).map(s => s.id).sort(),
+    flowCount: snapshot.flows?.length ?? 0,
+  };
+}

--- a/src/lib/admin/publish.test.ts
+++ b/src/lib/admin/publish.test.ts
@@ -1,0 +1,48 @@
+import { strict as assert } from 'node:assert';
+import { describe, test } from 'node:test';
+import {
+  domainsForScope,
+  filterIssuesByScope,
+  type PublishScope,
+} from './publish';
+import type { CatalogIssue } from '@/lib/lego/admin-catalog';
+
+const issue = (message: string): CatalogIssue => ({ code: 'test', message });
+
+describe('publish scope helpers', () => {
+  test('domainsForScope(all) lists every domain', () => {
+    assert.deepEqual(domainsForScope('all'), [
+      'catalog',
+      'templates',
+      'architecture',
+      'sections',
+      'flows',
+      'cloud',
+      'system_copy',
+    ]);
+  });
+
+  test('domainsForScope(single) returns that domain only', () => {
+    const scopes: PublishScope[] = [
+      'catalog',
+      'templates',
+      'architecture',
+      'sections',
+      'flows',
+      'cloud',
+      'system_copy',
+    ];
+    for (const scope of scopes) {
+      assert.deepEqual(domainsForScope(scope), [scope]);
+    }
+  });
+
+  test('filterIssuesByScope keeps matching source / all', () => {
+    const issues = [issue('a')];
+    assert.equal(filterIssuesByScope(issues, 'all', 'catalog').length, 1);
+    assert.equal(filterIssuesByScope(issues, 'catalog', 'catalog').length, 1);
+    assert.equal(filterIssuesByScope(issues, 'templates', 'catalog').length, 0);
+    assert.equal(filterIssuesByScope(issues, 'system_copy', 'system_copy').length, 1);
+    assert.equal(filterIssuesByScope(issues, 'architecture', 'flows').length, 0);
+  });
+});

--- a/src/lib/admin/publish.ts
+++ b/src/lib/admin/publish.ts
@@ -1,0 +1,47 @@
+export type { CatalogIssue } from '@/lib/lego/admin-catalog';
+export type { CatalogState } from '@/lib/admin/catalog';
+export type { ProjectTemplateState } from '@/lib/admin/templates';
+export type { ArchitectureLibraryState } from '@/lib/admin/architecture';
+export type { SectionLibraryState } from '@/lib/admin/sections';
+export type { FlowLibraryState } from '@/lib/admin/flows';
+export type { CloudServiceAdminState } from '@/lib/admin/cloud';
+export type { SystemCopyAdminState } from '@/lib/admin/copy';
+
+export type PublishScope =
+  | 'catalog'
+  | 'templates'
+  | 'architecture'
+  | 'sections'
+  | 'flows'
+  | 'cloud'
+  | 'system_copy'
+  | 'all';
+
+export type PublishDomainSource = Exclude<PublishScope, 'all'>;
+
+const ALL_SOURCES: PublishDomainSource[] = [
+  'catalog',
+  'templates',
+  'architecture',
+  'sections',
+  'flows',
+  'cloud',
+  'system_copy',
+];
+
+/** Domains included for a given scope selection. */
+export function domainsForScope(scope: PublishScope): PublishDomainSource[] {
+  if (scope === 'all') return [...ALL_SOURCES];
+  return [scope];
+}
+
+/** Keeps issues visible only when their source matches the selected publish scope. */
+export function filterIssuesByScope(
+  issues: import('@/lib/lego/admin-catalog').CatalogIssue[],
+  scope: PublishScope,
+  source: PublishDomainSource,
+): import('@/lib/lego/admin-catalog').CatalogIssue[] {
+  if (scope === 'all') return issues;
+  if (scope === source) return issues;
+  return [];
+}

--- a/src/lib/admin/regression-api.test.ts
+++ b/src/lib/admin/regression-api.test.ts
@@ -1,0 +1,142 @@
+/**
+ * F-REG API route contracts (R1, R2, R4).
+ *
+ * Admin routes under src/app/api/admin/** are thin NextResponse wrappers around
+ * domain functions (publishCatalog, publishAddSections, …). Prefer exercising
+ * those domain functions here — Next Request mocking is unnecessary.
+ */
+import { strict as assert } from 'node:assert';
+import { describe, test } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { publishAddSections } from './add-sections';
+import {
+  publishCatalog,
+  variantRefIssues,
+} from '@/lib/lego/admin-catalog';
+import * as Repo from '@/lib/lego/repository';
+import * as DB from '@/lib/db';
+
+const repoRoot = path.resolve(import.meta.dirname, '../../..');
+const adminApiRoot = path.join(repoRoot, 'src/app/api/admin');
+const adminCatalogSrc = path.join(repoRoot, 'src/lib/lego/admin-catalog.ts');
+
+function walkTsFiles(dir: string): string[] {
+  if (!fs.existsSync(dir)) return [];
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walkTsFiles(full));
+    else if (entry.isFile() && entry.name.endsWith('.ts')) out.push(full);
+  }
+  return out;
+}
+
+describe('F-REG R1: catalog publish contract (domain + thin route)', () => {
+  test('orphan_variant issue shape is what catalog publish validation uses', () => {
+    const issues = variantRefIssues(
+      [{ id: 'api-reg-orphan', maps_to: 'missing-brick' }],
+      new Set(['identity']),
+    );
+    assert.ok(issues.some(i => i.code === 'orphan_variant'));
+    const src = fs.readFileSync(adminCatalogSrc, 'utf8');
+    assert.match(src, /variantRefIssues/);
+    assert.match(src, /if \(issues\.length > 0\) return \{ ok: false, issues \}/);
+  });
+
+  test('publishCatalog returns ok:false with issue codes when catalog is invalid', () => {
+    Repo.ensureLegoCatalog();
+    const saved = DB.plain<{ role: string }>(
+      DB.db
+        .prepare(
+          'SELECT role FROM lego_brick_texts WHERE catalog_version=? AND brick_id=? AND lang=?',
+        )
+        .get(Repo.LEGO_CATALOG_VERSION, 'identity', 'en'),
+    );
+    assert.ok(saved?.role);
+
+    DB.db
+      .prepare(
+        'UPDATE lego_brick_texts SET role=? WHERE catalog_version=? AND brick_id=? AND lang=?',
+      )
+      .run('', Repo.LEGO_CATALOG_VERSION, 'identity', 'en');
+
+    try {
+      const result = publishCatalog();
+      assert.equal(result.ok, false);
+      if (!result.ok) {
+        assert.ok(result.issues.length > 0);
+        assert.ok(
+          result.issues.some(i => i.code === 'missing_role'),
+          `expected missing_role, got: ${result.issues.map(i => i.code).join(',')}`,
+        );
+      }
+    } finally {
+      DB.db
+        .prepare(
+          'UPDATE lego_brick_texts SET role=? WHERE catalog_version=? AND brick_id=? AND lang=?',
+        )
+        .run(saved!.role, Repo.LEGO_CATALOG_VERSION, 'identity', 'en');
+    }
+  });
+
+  test('catalog publish route is thin wrapper over publishCatalog', () => {
+    const route = fs.readFileSync(
+      path.join(adminApiRoot, 'catalog/publish/route.ts'),
+      'utf8',
+    );
+    assert.match(route, /from ['"]@\/lib\/lego\/admin-catalog['"]/);
+    assert.match(route, /publishCatalog/);
+    assert.match(route, /NextResponse\.json/);
+    assert.match(route, /issues/);
+  });
+});
+
+describe('F-REG R4: sections publish placeholder path', () => {
+  test('publishAddSections → ok:false + placeholder_section', () => {
+    const result = publishAddSections();
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.ok(result.issues.some(i => i.code === 'placeholder_section'));
+    }
+  });
+
+  test('sections publish route is thin wrapper over publishAddSections', () => {
+    const route = fs.readFileSync(
+      path.join(adminApiRoot, 'sections/publish/route.ts'),
+      'utf8',
+    );
+    assert.match(route, /publishAddSections/);
+    assert.match(route, /ok:\s*false|result\.issues/);
+  });
+});
+
+describe('F-REG R2: no projects CRUD under /api/admin', () => {
+  test('admin API tree has no projects route or projects.data CRUD', () => {
+    const files = walkTsFiles(adminApiRoot);
+    assert.ok(files.length > 0, 'expected admin API routes');
+
+    const projectPaths = files.filter(f => {
+      const rel = path.relative(adminApiRoot, f).split(path.sep);
+      return rel.some(seg => seg === 'projects' || seg.startsWith('projects.'));
+    });
+    assert.deepEqual(
+      projectPaths,
+      [],
+      `unexpected projects paths under /api/admin: ${projectPaths.join(', ')}`,
+    );
+
+    const hits: string[] = [];
+    for (const file of files) {
+      const text = fs.readFileSync(file, 'utf8');
+      if (
+        /projects\.data/.test(text) ||
+        /\b(create|update|delete|list)Project\b/.test(text) ||
+        /\/api\/admin\/projects/.test(text)
+      ) {
+        hits.push(path.relative(repoRoot, file));
+      }
+    }
+    assert.deepEqual(hits, [], `projects CRUD surface in admin API: ${hits.join(', ')}`);
+  });
+});

--- a/src/lib/admin/regression-backend.test.ts
+++ b/src/lib/admin/regression-backend.test.ts
@@ -1,0 +1,46 @@
+/**
+ * F-REG backend regression (R1, R4).
+ * Thin, named assertions that fail loudly if orphan_variant / placeholder_section
+ * gates are removed from domain publish paths.
+ */
+import { strict as assert } from 'node:assert';
+import { describe, test } from 'node:test';
+import { publishAddSections } from './add-sections';
+import { variantRefIssues } from '@/lib/lego/admin-catalog';
+
+describe('F-REG R1: catalog publish rejects orphan_variant', () => {
+  test('variantRefIssues emits orphan_variant when maps_to brick is missing', () => {
+    const issues = variantRefIssues(
+      [{ id: 'reg-orphan-variant', maps_to: 'no-such-brick' }],
+      new Set(['identity']),
+    );
+    assert.ok(
+      issues.some(
+        issue =>
+          issue.code === 'orphan_variant' && issue.entityId === 'reg-orphan-variant',
+      ),
+      'expected orphan_variant issue — catalog publish gate must not be removed',
+    );
+  });
+
+  test('variantRefIssues stays quiet when maps_to brick exists', () => {
+    const issues = variantRefIssues(
+      [{ id: 'ok-variant', maps_to: 'identity' }],
+      new Set(['identity']),
+    );
+    assert.equal(issues.some(issue => issue.code === 'orphan_variant'), false);
+  });
+});
+
+describe('F-REG R4: ADD/sections publish blocked on placeholder_section', () => {
+  test('publishAddSections returns ok:false with placeholder_section', () => {
+    const result = publishAddSections();
+    assert.equal(result.ok, false, 'seed sections still contain placeholders');
+    if (!result.ok) {
+      assert.ok(
+        result.issues.some(i => i.code === 'placeholder_section'),
+        'expected placeholder_section — sections publish gate must not be removed',
+      );
+    }
+  });
+});

--- a/src/lib/admin/regression-ui.test.ts
+++ b/src/lib/admin/regression-ui.test.ts
@@ -1,0 +1,82 @@
+/**
+ * F-REG UI static regression (R2 + UX anti).
+ * Source-text scans only — no Playwright / RTL / Vitest.
+ */
+import { strict as assert } from 'node:assert';
+import { describe, test } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = path.resolve(import.meta.dirname, '../../..');
+const adminAppDir = path.join(repoRoot, 'src/app/admin');
+const adminComponentsDir = path.join(repoRoot, 'src/components/admin');
+
+const FORBIDDEN_IMPORT_RE =
+  /from\s+['"](?:lucide-react|lucide|@radix-ui\/[^'"]+|@heroicons\/[^'"]+|heroicons|@\/components\/ui(?:\/[^'"]*)?)['"]|require\(\s*['"](?:lucide-react|lucide|@radix-ui\/|@heroicons\/|heroicons|@\/components\/ui)/;
+
+const PROJECTS_CRUD_RE =
+  /projects\.data|\/api\/admin\/projects\b|\b(?:create|update|delete)Project\b|admin\/projects\b/;
+
+/** Emoji pictographic block U+1F300–U+1FAFF (same as F-UX7 / ISC-UX11). */
+const EMOJI_RE = /[\u{1F300}-\u{1FAFF}]/u;
+
+function walkSourceFiles(dir: string): string[] {
+  if (!fs.existsSync(dir)) return [];
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walkSourceFiles(full));
+    else if (entry.isFile() && /\.(tsx?|jsx?|css)$/.test(entry.name)) out.push(full);
+  }
+  return out;
+}
+
+function collectHits(files: string[], re: RegExp): string[] {
+  const hits: string[] = [];
+  for (const file of files) {
+    const text = fs.readFileSync(file, 'utf8');
+    if (re.test(text)) hits.push(path.relative(repoRoot, file));
+  }
+  return hits;
+}
+
+describe('F-REG R2: admin UI has no projects CRUD surface', () => {
+  test('0 matches for projects.data / admin project CRUD in admin app+components', () => {
+    const files = [...walkSourceFiles(adminAppDir), ...walkSourceFiles(adminComponentsDir)];
+    assert.ok(files.length > 0);
+    const hits = collectHits(files, PROJECTS_CRUD_RE);
+    assert.deepEqual(hits, [], `projects CRUD in admin UI: ${hits.join(', ')}`);
+  });
+});
+
+describe('F-REG UX anti: no lucide/radix/shadcn/heroicons/ui kit', () => {
+  test('0 forbidden UI-kit imports in admin app+components', () => {
+    const files = [...walkSourceFiles(adminAppDir), ...walkSourceFiles(adminComponentsDir)];
+    const hits = collectHits(files, FORBIDDEN_IMPORT_RE);
+    assert.deepEqual(hits, [], `forbidden UI imports: ${hits.join(', ')}`);
+  });
+});
+
+describe('F-REG UX anti: no emoji U+1F300–U+1FAFF', () => {
+  test('0 emoji in admin app+components source', () => {
+    const files = [...walkSourceFiles(adminAppDir), ...walkSourceFiles(adminComponentsDir)];
+    const hits = collectHits(files, EMOJI_RE);
+    assert.deepEqual(hits, [], `emoji in admin sources: ${hits.join(', ')}`);
+  });
+});
+
+describe('F-REG: IssueList keys include list index', () => {
+  test('IssueList key template suffixes map index (prevents duplicate keys)', () => {
+    const issueListPath = path.join(adminComponentsDir, 'IssueList.tsx');
+    const src = fs.readFileSync(issueListPath, 'utf8');
+    // Must keep index in React key — same code+entityId can appear twice.
+    const hasIndexInKey =
+      /key\s*=\s*\{[^}]*\$\{i\}/.test(src) ||
+      /const key = `[^`]*\$\{i\}`/.test(src) ||
+      /`-\$\{i\}`|-\$\{i\}/.test(src);
+    assert.ok(
+      hasIndexInKey,
+      'IssueList key must include list index (${i}) to avoid duplicate-key regression',
+    );
+  });
+});

--- a/src/lib/admin/sections.ts
+++ b/src/lib/admin/sections.ts
@@ -1,0 +1,84 @@
+import { api } from '@/lib/api';
+import type { CatalogIssue } from '@/lib/lego/admin-catalog';
+import type { Section, SectionType } from '@/lib/types';
+
+export type AdminSectionListItem = {
+  id: string;
+  type: SectionType;
+  titleEn: string;
+  titleFr: string;
+  tabEn?: string;
+  tabFr?: string;
+  subtitleEn?: string;
+  subtitleFr?: string;
+  itemCount?: number;
+  publishedAt?: string | null;
+};
+
+export type AdminSectionDetail = {
+  id: string;
+  en: Section;
+  fr: Section;
+};
+
+export type SectionUpdatePayload = {
+  en: Section;
+  fr: Section;
+};
+
+export type SectionLibraryState = {
+  dirty: boolean;
+  publishedAt: string | null;
+  sectionCount: number;
+  issues?: CatalogIssue[];
+};
+
+export function fetchSections(): Promise<{ sections: AdminSectionListItem[] }> {
+  return api.json('/api/admin/sections');
+}
+
+export function fetchSection(id: string): Promise<AdminSectionDetail> {
+  return api.json(`/api/admin/sections/${id}`);
+}
+
+export function updateSection(id: string, body: SectionUpdatePayload): Promise<{ ok: boolean }> {
+  return api.json(`/api/admin/sections/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify(body),
+  });
+}
+
+export function fetchSectionState(options?: { validate?: boolean }): Promise<SectionLibraryState> {
+  const qs = options?.validate ? '?validate=1' : '';
+  return api.json(`/api/admin/sections/state${qs}`);
+}
+
+export async function publishSections(): Promise<
+  | { ok: true; publishedAt: string }
+  | { ok: false; error: string; issues: CatalogIssue[] }
+> {
+  const res = await fetch('/api/admin/sections/publish', { method: 'POST' });
+  const body = await res.json().catch(() => ({}));
+  if (res.ok) return { ok: true, publishedAt: body.publishedAt as string };
+  return {
+    ok: false,
+    error: (body.error as string) || res.statusText || 'Publish failed',
+    issues: (body.issues as CatalogIssue[]) ?? [],
+  };
+}
+
+
+export type SectionCreatePayload = {
+  id?: string;
+  type: SectionType;
+  titleEn: string;
+  titleFr?: string;
+};
+
+export function createSection(body: SectionCreatePayload): Promise<{ ok: boolean; id: string }> {
+  return api.json('/api/admin/sections', { method: 'POST', body: JSON.stringify(body) });
+}
+
+export function deleteSection(id: string): Promise<{ ok: boolean; id: string }> {
+  return api.json(`/api/admin/sections/${id}`, { method: 'DELETE' });
+}

--- a/src/lib/admin/system-copy.resolve.server.ts
+++ b/src/lib/admin/system-copy.resolve.server.ts
@@ -1,0 +1,68 @@
+import { contentFromAdmin } from './flags';
+import { getPublishedSystemCopy } from './system-copy';
+import { DEFAULT_FLOW_COPY, flowCopy } from '../defaults';
+import { displayLayerLabel } from '../layers';
+
+type Lang = 'en' | 'fr';
+
+export type ResolvedFlowCopy = {
+  name: string;
+  firstStep: string;
+  nextStep: string;
+  newStep: string;
+  sub: string;
+  note: string;
+  stepDescription: string;
+};
+
+const FLOW_FIELDS = Object.keys(DEFAULT_FLOW_COPY.en) as (keyof ResolvedFlowCopy)[];
+
+function publishedFlowCopy(lang: Lang): ResolvedFlowCopy | null {
+  const published = getPublishedSystemCopy();
+  if (Object.keys(published).length === 0) return null;
+  const slice: ResolvedFlowCopy = { ...DEFAULT_FLOW_COPY[lang] };
+  let hit = false;
+  for (const field of FLOW_FIELDS) {
+    const pair = published[`flow.default.${field}`];
+    if (!pair) continue;
+    const text = (lang === 'fr' ? pair.fr : pair.en).trim();
+    if (!text) continue;
+    slice[field] = text;
+    hit = true;
+  }
+  return hit ? slice : null;
+}
+
+/**
+ * Server-only flow copy resolve.
+ * When CONTENT_FROM_ADMIN=1 and system-copy is published, uses admin strings;
+ * otherwise falls back to DEFAULT_FLOW_COPY via flowCopy().
+ *
+ * Client modules (defaults.ts) keep code fallbacks — do not import this file
+ * into client bundles. Callers that already run server-side (API routes, seed)
+ * should prefer this helper.
+ */
+export function resolveFlowCopy(lang?: string): ResolvedFlowCopy {
+  const normalized: Lang = lang === 'fr' ? 'fr' : 'en';
+  if (contentFromAdmin()) {
+    const fromAdmin = publishedFlowCopy(normalized);
+    if (fromAdmin) return fromAdmin;
+  }
+  return { ...flowCopy(normalized) };
+}
+
+/**
+ * Server-only layer label resolve.
+ * Falls back to displayLayerLabel (code LAYER_DISPLAY) when flag off or unpublished.
+ */
+export function resolveLayerLabel(id: string, lang: Lang = 'en'): string {
+  if (contentFromAdmin()) {
+    const published = getPublishedSystemCopy();
+    const pair = published[`layer.${id}`];
+    if (pair) {
+      const text = (lang === 'fr' ? pair.fr : pair.en).trim();
+      if (text) return text;
+    }
+  }
+  return displayLayerLabel(id, lang);
+}

--- a/src/lib/admin/system-copy.test.ts
+++ b/src/lib/admin/system-copy.test.ts
@@ -1,0 +1,89 @@
+import { strict as assert } from 'node:assert';
+import { after, before, describe, test } from 'node:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const dbFile = path.join(os.tmpdir(), `archstudio-system-copy-${process.pid}.db`);
+process.env.DATABASE_PATH = dbFile;
+
+after(() => {
+  for (const f of [dbFile, `${dbFile}-wal`, `${dbFile}-shm`]) fs.rmSync(f, { force: true });
+});
+
+describe('system copy admin', { concurrency: 1 }, () => {
+  let SC: typeof import('./system-copy');
+
+  before(async () => {
+    SC = await import('./system-copy');
+  });
+
+  test('seed keys include flow defaults + layer.clients', () => {
+    SC.ensureSystemCopyDomain();
+    const list = SC.listSystemCopy();
+    const keys = new Set(list.map(row => row.key));
+    assert.ok(keys.has('flow.default.name'));
+    assert.ok(keys.has('flow.default.firstStep'));
+    assert.ok(keys.has('layer.clients'));
+    assert.ok(keys.has('meta.tagline'));
+    assert.equal(list.find(r => r.key === 'flow.default.name')?.seeded, true);
+    assert.equal(list.find(r => r.key === 'layer.clients')?.seeded, true);
+  });
+
+  test('upsert + publish → getPublished returns new fr', () => {
+    SC.ensureSystemCopyDomain();
+    SC.upsertSystemCopy('flow.default.name', { en: 'New flow', fr: 'Parcours admin' });
+    const result = SC.publishSystemCopy();
+    assert.equal(result.ok, true);
+    const published = SC.getPublishedSystemCopy();
+    assert.equal(published['flow.default.name']?.fr, 'Parcours admin');
+  });
+
+  test('resolveFlowCopy returns published override when CONTENT_FROM_ADMIN=1', async () => {
+    const prev = process.env.CONTENT_FROM_ADMIN;
+    process.env.CONTENT_FROM_ADMIN = '1';
+    try {
+      SC.ensureSystemCopyDomain();
+      SC.upsertSystemCopy('flow.default.name', { en: 'Admin New flow', fr: 'Parcours admin override' });
+      SC.upsertSystemCopy('flow.default.sub', { en: 'Admin sub', fr: 'Sous-titre admin' });
+      const published = SC.publishSystemCopy();
+      assert.equal(published.ok, true);
+
+      const { resolveFlowCopy } = await import('./system-copy.resolve.server');
+      const fr = resolveFlowCopy('fr');
+      assert.equal(fr.name, 'Parcours admin override');
+      assert.equal(fr.sub, 'Sous-titre admin');
+
+      const en = resolveFlowCopy('en');
+      assert.equal(en.name, 'Admin New flow');
+      assert.equal(en.sub, 'Admin sub');
+    } finally {
+      if (prev === undefined) delete process.env.CONTENT_FROM_ADMIN;
+      else process.env.CONTENT_FROM_ADMIN = prev;
+    }
+  });
+
+  test('resolveFlowCopy falls back to DEFAULT_FLOW_COPY when flag off', async () => {
+    const prev = process.env.CONTENT_FROM_ADMIN;
+    delete process.env.CONTENT_FROM_ADMIN;
+    try {
+      const { resolveFlowCopy } = await import('./system-copy.resolve.server');
+      const { DEFAULT_FLOW_COPY } = await import('../defaults');
+      const en = resolveFlowCopy('en');
+      assert.equal(en.name, DEFAULT_FLOW_COPY.en.name);
+    } finally {
+      if (prev === undefined) delete process.env.CONTENT_FROM_ADMIN;
+      else process.env.CONTENT_FROM_ADMIN = prev;
+    }
+  });
+
+  test('locked/seeded keys reappear after delete+ensure', () => {
+    SC.deleteSystemCopy('layer.clients');
+    SC.ensureSystemCopyDomain();
+    const restored = SC.getSystemCopy('layer.clients');
+    assert.ok(restored);
+    assert.equal(restored!.seeded, true);
+    assert.ok(restored!.en.trim());
+    assert.ok(restored!.fr.trim());
+  });
+});

--- a/src/lib/admin/system-copy.ts
+++ b/src/lib/admin/system-copy.ts
@@ -1,0 +1,262 @@
+import { DEFAULT_FLOW_COPY } from '../defaults';
+import { db, now, plain, plainAll } from '../db';
+import { LAYER_DISPLAY } from '../layers';
+import type { CatalogIssue } from '../lego/admin-catalog';
+
+export const SYSTEM_COPY_DOMAIN = 'system-copy';
+
+export type SystemCopyPair = { en: string; fr: string };
+
+export type AdminSystemCopyItem = {
+  key: string;
+  en: string;
+  fr: string;
+  seeded: boolean;
+};
+
+export type SystemCopyAdminState = {
+  dirty: boolean;
+  publishedAt: string | null;
+  keyCount: number;
+  issueCount?: number;
+  issues?: CatalogIssue[];
+};
+
+export type PublishSystemCopyResult =
+  | { ok: true; publishedAt: string }
+  | { ok: false; issues: CatalogIssue[] };
+
+const FLOW_FIELDS = Object.keys(DEFAULT_FLOW_COPY.en) as (keyof typeof DEFAULT_FLOW_COPY.en)[];
+
+/** Canonical seed map: flow defaults, layer labels, blank-doc meta. */
+export function buildSeededSystemCopy(): Record<string, SystemCopyPair> {
+  const seed: Record<string, SystemCopyPair> = {};
+  for (const field of FLOW_FIELDS) {
+    seed[`flow.default.${field}`] = {
+      en: DEFAULT_FLOW_COPY.en[field],
+      fr: DEFAULT_FLOW_COPY.fr[field],
+    };
+  }
+  for (const [id, labels] of Object.entries(LAYER_DISPLAY)) {
+    seed[`layer.${id}`] = { en: labels.en, fr: labels.fr };
+  }
+  seed['meta.tagline'] = {
+    en: 'Architecture Explorer',
+    fr: 'Architecture Explorer',
+  };
+  return seed;
+}
+
+export const SEEDED_SYSTEM_COPY_KEYS = Object.keys(buildSeededSystemCopy());
+
+function getRow<T>(sql: string, ...params: (string | number | null)[]): T | null {
+  const raw = db.prepare(sql).get(...params);
+  if (!raw) return null;
+  return plain<T>(raw);
+}
+
+function rows<T>(sql: string, ...values: (string | number | null)[]): T[] {
+  return plainAll<T>(db.prepare(sql).all(...values));
+}
+
+function markDirty(): void {
+  db.prepare('UPDATE content_domains SET status=?, published_at=published_at WHERE id=?')
+    .run('draft', SYSTEM_COPY_DOMAIN);
+}
+
+function normalizePair(input: SystemCopyPair): SystemCopyPair {
+  return {
+    en: typeof input.en === 'string' ? input.en : '',
+    fr: typeof input.fr === 'string' ? input.fr : '',
+  };
+}
+
+function validateKey(key: string): void {
+  if (!/^[a-z][a-z0-9._-]*$/i.test(key)) {
+    throw new Error('system copy key must start with a letter and contain only letters, digits, dots, underscores or hyphens');
+  }
+}
+
+export function isSeededSystemCopyKey(key: string): boolean {
+  return SEEDED_SYSTEM_COPY_KEYS.includes(key);
+}
+
+/** Ensures domain + seeds code constants. Missing seeded keys re-seed. */
+export function ensureSystemCopyDomain(): void {
+  const existing = getRow<{ id: string }>('SELECT id FROM content_domains WHERE id=?', SYSTEM_COPY_DOMAIN);
+  if (!existing) {
+    db.prepare('INSERT INTO content_domains (id, status, published_at) VALUES (?, ?, NULL)')
+      .run(SYSTEM_COPY_DOMAIN, 'draft');
+  }
+  const seed = buildSeededSystemCopy();
+  for (const [key, pair] of Object.entries(seed)) {
+    const row = getRow<{ key: string }>(
+      'SELECT key FROM system_copy WHERE domain_id=? AND key=?',
+      SYSTEM_COPY_DOMAIN,
+      key,
+    );
+    if (row) continue;
+    db.prepare(
+      'INSERT INTO system_copy (domain_id, key, en, fr) VALUES (?, ?, ?, ?)'
+    ).run(SYSTEM_COPY_DOMAIN, key, pair.en, pair.fr);
+    markDirty();
+  }
+}
+
+export function listSystemCopy(): AdminSystemCopyItem[] {
+  ensureSystemCopyDomain();
+  return rows<{ key: string; en: string; fr: string }>(
+    'SELECT key, en, fr FROM system_copy WHERE domain_id=? ORDER BY key',
+    SYSTEM_COPY_DOMAIN,
+  ).map(row => ({
+    key: row.key,
+    en: row.en,
+    fr: row.fr,
+    seeded: isSeededSystemCopyKey(row.key),
+  }));
+}
+
+export function getSystemCopy(key: string): AdminSystemCopyItem | null {
+  ensureSystemCopyDomain();
+  const row = getRow<{ key: string; en: string; fr: string }>(
+    'SELECT key, en, fr FROM system_copy WHERE domain_id=? AND key=?',
+    SYSTEM_COPY_DOMAIN,
+    key,
+  );
+  if (!row) return null;
+  return {
+    key: row.key,
+    en: row.en,
+    fr: row.fr,
+    seeded: isSeededSystemCopyKey(row.key),
+  };
+}
+
+export function upsertSystemCopy(key: string, pair: SystemCopyPair): void {
+  ensureSystemCopyDomain();
+  const trimmed = key.trim();
+  validateKey(trimmed);
+  const next = normalizePair(pair);
+  db.prepare(
+    `INSERT INTO system_copy (domain_id, key, en, fr) VALUES (?, ?, ?, ?)
+     ON CONFLICT(domain_id, key) DO UPDATE SET en=excluded.en, fr=excluded.fr`
+  ).run(SYSTEM_COPY_DOMAIN, trimmed, next.en, next.fr);
+  markDirty();
+}
+
+export function deleteSystemCopy(key: string): void {
+  ensureSystemCopyDomain();
+  const result = db.prepare(
+    'DELETE FROM system_copy WHERE domain_id=? AND key=?'
+  ).run(SYSTEM_COPY_DOMAIN, key);
+  if (!result.changes) throw new Error(`system copy key not found: ${key}`);
+  markDirty();
+}
+
+export function validateSystemCopyPublish(): CatalogIssue[] {
+  ensureSystemCopyDomain();
+  const issues: CatalogIssue[] = [];
+  const present = new Set(
+    rows<{ key: string }>('SELECT key FROM system_copy WHERE domain_id=?', SYSTEM_COPY_DOMAIN).map(r => r.key),
+  );
+  for (const key of SEEDED_SYSTEM_COPY_KEYS) {
+    if (!present.has(key)) {
+      issues.push({
+        code: 'missing_system_copy',
+        message: `Missing seeded system copy "${key}"`,
+        entityId: key,
+      });
+    }
+  }
+  for (const row of listSystemCopy()) {
+    if (!row.en.trim()) {
+      issues.push({
+        code: 'invalid_system_copy',
+        message: `System copy "${row.key}" missing English text`,
+        entityId: row.key,
+        field: 'en',
+      });
+    }
+    if (!row.fr.trim()) {
+      issues.push({
+        code: 'invalid_system_copy',
+        message: `System copy "${row.key}" missing French text`,
+        entityId: row.key,
+        field: 'fr',
+      });
+    }
+  }
+  return issues;
+}
+
+export function publishSystemCopy(): PublishSystemCopyResult {
+  const issues = validateSystemCopyPublish();
+  if (issues.length > 0) return { ok: false, issues };
+  const publishedAt = now();
+  db.prepare('UPDATE content_domains SET status=?, published_at=? WHERE id=?')
+    .run('published', publishedAt, SYSTEM_COPY_DOMAIN);
+  return { ok: true, publishedAt };
+}
+
+export function getSystemCopyState(options?: { validate?: boolean }): SystemCopyAdminState {
+  ensureSystemCopyDomain();
+  const domain = getRow<{ status: string; published_at: string | null }>(
+    'SELECT status, published_at FROM content_domains WHERE id=?',
+    SYSTEM_COPY_DOMAIN,
+  );
+  const keyCount = getRow<{ n: number }>(
+    'SELECT COUNT(*) AS n FROM system_copy WHERE domain_id=?',
+    SYSTEM_COPY_DOMAIN,
+  )?.n ?? 0;
+  const state: SystemCopyAdminState = {
+    dirty: domain?.status !== 'published',
+    publishedAt: domain?.published_at ?? null,
+    keyCount,
+  };
+  if (!options?.validate) return state;
+  const issues = validateSystemCopyPublish();
+  return { ...state, issueCount: issues.length, issues };
+}
+
+/** Runtime map when domain is published; empty object if still draft. */
+export function getPublishedSystemCopy(): Record<string, SystemCopyPair> {
+  ensureSystemCopyDomain();
+  const domain = getRow<{ status: string }>(
+    'SELECT status FROM content_domains WHERE id=?',
+    SYSTEM_COPY_DOMAIN,
+  );
+  if (domain?.status !== 'published') return {};
+  const out: Record<string, SystemCopyPair> = {};
+  for (const row of rows<{ key: string; en: string; fr: string }>(
+    'SELECT key, en, fr FROM system_copy WHERE domain_id=?',
+    SYSTEM_COPY_DOMAIN,
+  )) {
+    out[row.key] = { en: row.en, fr: row.fr };
+  }
+  return out;
+}
+
+/** Draft map for export/import (editable state). */
+export function getDraftSystemCopyMap(): Record<string, SystemCopyPair> {
+  ensureSystemCopyDomain();
+  const out: Record<string, SystemCopyPair> = {};
+  for (const row of listSystemCopy()) {
+    out[row.key] = { en: row.en, fr: row.fr };
+  }
+  return out;
+}
+
+/** Replace all draft rows (used by bundle replace). Seeded gaps filled by ensure. */
+export function replaceSystemCopyMap(map: Record<string, SystemCopyPair>): void {
+  ensureSystemCopyDomain();
+  db.prepare('DELETE FROM system_copy WHERE domain_id=?').run(SYSTEM_COPY_DOMAIN);
+  for (const [key, pair] of Object.entries(map)) {
+    const next = normalizePair(pair);
+    validateKey(key);
+    db.prepare(
+      'INSERT INTO system_copy (domain_id, key, en, fr) VALUES (?, ?, ?, ?)'
+    ).run(SYSTEM_COPY_DOMAIN, key, next.en, next.fr);
+  }
+  markDirty();
+  ensureSystemCopyDomain();
+}

--- a/src/lib/admin/templates.ts
+++ b/src/lib/admin/templates.ts
@@ -1,0 +1,118 @@
+import { api } from '@/lib/api';
+import type { Architecture } from '@/lib/types';
+import type { CatalogIssue } from '@/lib/lego/admin-catalog';
+import type { AdminTemplateKind, ProjectTemplateCreate, ProjectTemplateMeta, ProjectTemplateUpdate } from '@/lib/admin/project-templates';
+import type { Template } from '@/lib/templates/types';
+
+export type AdminTemplateListItem = {
+  id: string;
+  kind: AdminTemplateKind;
+  editable: boolean;
+  nameEn: string;
+  nameFr: string;
+  sortOrder: number;
+  featured: boolean;
+  componentCount: number;
+  sectionCount: number;
+  flowCount: number;
+  accent: string;
+  icon: string;
+  taglineEn: string;
+  taglineFr: string;
+};
+
+export type ProjectTemplateDetail = {
+  kind: 'project';
+  editable: true;
+  id: string;
+  nameEn: string;
+  nameFr: string;
+  sortOrder: number;
+  featured: boolean;
+  meta: ProjectTemplateMeta;
+  outline: { componentCount: number; sectionIds: string[]; flowCount: number };
+  snapshot?: Architecture;
+};
+
+export type ArchitectureTemplateDetail = {
+  kind: 'architecture';
+  editable: true;
+  locked?: boolean;
+  id: string;
+  nameEn: string;
+  nameFr: string;
+  meta: ProjectTemplateMeta & {
+    whenToUseEn: string[];
+    whenToUseFr: string[];
+    whenNotToUseEn: string[];
+    whenNotToUseFr: string[];
+  };
+  supportedTargets: string[];
+  spec?: Template;
+  outline: { componentCount: number; sectionIds: string[]; flowCount: number };
+  snapshot?: Architecture;
+};
+
+export type TemplateDetail = ProjectTemplateDetail | ArchitectureTemplateDetail;
+
+export type ProjectTemplateState = {
+  dirty: boolean;
+  publishedAt: string | null;
+  templateCount: number;
+  issueCount?: number;
+  issues?: CatalogIssue[];
+};
+
+export function fetchProjectTemplateState(options?: { validate?: boolean }): Promise<ProjectTemplateState> {
+  const qs = options?.validate ? '?validate=1' : '';
+  return api.json<ProjectTemplateState>(`/api/admin/templates/state${qs}`);
+}
+
+export function fetchAllTemplates(): Promise<{ templates: AdminTemplateListItem[] }> {
+  return api.json('/api/admin/templates');
+}
+
+export function fetchProjectTemplates(): Promise<{ templates: AdminTemplateListItem[] }> {
+  return fetchAllTemplates();
+}
+
+export function fetchTemplate(id: string): Promise<TemplateDetail> {
+  return api.json(`/api/admin/templates/${id}`);
+}
+
+export function createTemplate(body: ProjectTemplateCreate): Promise<{ ok: boolean; id: string }> {
+  return api.json('/api/admin/templates', { method: 'POST', body: JSON.stringify(body) });
+}
+
+export function updateTemplate(
+  id: string,
+  body: ProjectTemplateUpdate & { spec?: Template; snapshot?: Architecture },
+): Promise<{ ok: boolean; id: string }> {
+  return api.json(`/api/admin/templates/${id}`, { method: 'PATCH', body: JSON.stringify(body) });
+}
+
+export function deleteTemplate(id: string): Promise<{ ok: boolean; id: string }> {
+  return api.json(`/api/admin/templates/${id}`, { method: 'DELETE' });
+}
+
+export function importTemplateSnapshot(id: string, snapshot: Architecture): Promise<{ ok: boolean; id: string }> {
+  return updateTemplate(id, { snapshot });
+}
+
+export async function publishProjectTemplates(): Promise<
+  | { ok: true; publishedAt: string }
+  | { ok: false; error: string; issues: CatalogIssue[] }
+> {
+  const res = await fetch('/api/admin/templates/publish', { method: 'POST' });
+  const body = await res.json().catch(() => ({}));
+  if (res.ok) return { ok: true, publishedAt: body.publishedAt as string };
+  return {
+    ok: false,
+    error: (body.error as string) || res.statusText,
+    issues: (body.issues as CatalogIssue[]) ?? [],
+  };
+}
+
+export function reimportAcmeTemplate(): Promise<{ ok: boolean; id: string }> {
+  return api.json('/api/admin/templates/reimport-acme', { method: 'POST' });
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -10,9 +10,11 @@ import { DatabaseSync } from 'node:sqlite';
 import fs from 'node:fs';
 import path from 'node:path';
 
-const DB_PATH = process.env.DATABASE_PATH
-  ? path.resolve(process.env.DATABASE_PATH)
-  : path.join(process.cwd(), 'data', 'studio.db');
+function resolveDbPath(): string {
+  return process.env.DATABASE_PATH
+    ? path.resolve(process.env.DATABASE_PATH)
+    : path.join(process.cwd(), 'data', 'studio.db');
+}
 
 const SCHEMA = `
 PRAGMA journal_mode = WAL;
@@ -108,9 +110,18 @@ CREATE TABLE IF NOT EXISTS lego_brick_texts (
   role TEXT NOT NULL,
   responsibilities_json TEXT NOT NULL,
   notes_json TEXT NOT NULL,
+  purpose TEXT NOT NULL DEFAULT '',
   PRIMARY KEY (catalog_version, brick_id, lang),
   FOREIGN KEY (catalog_version, brick_id) REFERENCES lego_bricks(catalog_version, id) ON DELETE CASCADE
 );
+CREATE TABLE IF NOT EXISTS lego_brick_concern_tags (
+  catalog_version TEXT NOT NULL,
+  brick_id TEXT NOT NULL,
+  tag TEXT NOT NULL,
+  PRIMARY KEY (catalog_version, brick_id, tag),
+  FOREIGN KEY (catalog_version, brick_id) REFERENCES lego_bricks(catalog_version, id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_lego_concern_tags_brick ON lego_brick_concern_tags(catalog_version, brick_id);
 CREATE TABLE IF NOT EXISTS lego_brick_scope_affinities (
   catalog_version TEXT NOT NULL,
   brick_id TEXT NOT NULL,
@@ -181,16 +192,75 @@ CREATE TABLE IF NOT EXISTS lego_dependencies (
   PRIMARY KEY (catalog_version, from_brick, to_brick)
 );
 CREATE INDEX IF NOT EXISTS idx_lego_dependencies_from ON lego_dependencies(catalog_version, from_brick);
+
+CREATE TABLE IF NOT EXISTS admin_catalog_state (
+  catalog_version TEXT PRIMARY KEY REFERENCES lego_catalog_versions(version),
+  dirty INTEGER NOT NULL DEFAULT 0,
+  published_at TEXT,
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Admin content tables (M2+). Schema only — no runtime wiring in M0.
+CREATE TABLE IF NOT EXISTS content_domains (
+  id TEXT PRIMARY KEY,
+  status TEXT CHECK(status IN ('draft', 'published')),
+  published_at TEXT
+);
+CREATE TABLE IF NOT EXISTS project_templates (
+  domain_id TEXT NOT NULL,
+  id TEXT NOT NULL,
+  name_en TEXT,
+  name_fr TEXT,
+  meta_json TEXT,
+  snapshot_json TEXT,
+  sort_order INTEGER,
+  featured INTEGER,
+  PRIMARY KEY (domain_id, id)
+);
+CREATE TABLE IF NOT EXISTS add_sections (
+  domain_id TEXT NOT NULL,
+  id TEXT NOT NULL,
+  type TEXT,
+  payload_json TEXT,
+  PRIMARY KEY (domain_id, id)
+);
+CREATE TABLE IF NOT EXISTS flow_patterns (
+  domain_id TEXT NOT NULL,
+  id TEXT NOT NULL,
+  payload_json TEXT,
+  PRIMARY KEY (domain_id, id)
+);
+CREATE TABLE IF NOT EXISTS architecture_templates (
+  domain_id TEXT NOT NULL,
+  id TEXT NOT NULL,
+  payload_json TEXT,
+  PRIMARY KEY (domain_id, id)
+);
+CREATE TABLE IF NOT EXISTS cloud_services (
+  domain_id TEXT NOT NULL,
+  role_key TEXT NOT NULL,
+  payload_json TEXT,
+  PRIMARY KEY (domain_id, role_key)
+);
+CREATE TABLE IF NOT EXISTS system_copy (
+  domain_id TEXT NOT NULL,
+  key TEXT NOT NULL,
+  en TEXT NOT NULL,
+  fr TEXT NOT NULL,
+  PRIMARY KEY (domain_id, key)
+);
 `;
 
 declare global {
   // eslint-disable-next-line no-var
   var __studioDb: DatabaseSync | undefined;
+  // eslint-disable-next-line no-var
+  var __studioDbPath: string | undefined;
 }
 
-function open(): DatabaseSync {
-  fs.mkdirSync(path.dirname(DB_PATH), { recursive: true });
-  const db = new DatabaseSync(DB_PATH);
+function open(resolvedPath: string): DatabaseSync {
+  fs.mkdirSync(path.dirname(resolvedPath), { recursive: true });
+  const db = new DatabaseSync(resolvedPath);
   db.exec(SCHEMA);
   return db;
 }
@@ -200,14 +270,31 @@ function open(): DatabaseSync {
  * so a new table like `lego_dependencies` would otherwise never appear. */
 function ensureSchema(database: DatabaseSync): DatabaseSync {
   database.exec(SCHEMA);
+  /* Additive migration for DBs created before `purpose` landed on lego_brick_texts. */
+  const brickTextCols = plainAll<{ name: string }>(database.prepare('PRAGMA table_info(lego_brick_texts)').all());
+  if (brickTextCols.length > 0 && !brickTextCols.some(col => col.name === 'purpose')) {
+    database.exec("ALTER TABLE lego_brick_texts ADD COLUMN purpose TEXT NOT NULL DEFAULT ''");
+  }
+  const projectTplCols = plainAll<{ name: string }>(database.prepare('PRAGMA table_info(project_templates)').all());
+  if (projectTplCols.length > 0 && !projectTplCols.some(col => col.name === 'meta_json')) {
+    database.exec('ALTER TABLE project_templates ADD COLUMN meta_json TEXT');
+  }
   return database;
 }
 
 /* Cached on globalThis so Next's dev-mode module reloading does not open a new
  * handle on every hot update. SCHEMA still re-runs so additive tables land. */
 function connect(): DatabaseSync {
-  if (globalThis.__studioDb) return ensureSchema(globalThis.__studioDb);
-  return (globalThis.__studioDb = open());
+  const resolved = resolveDbPath();
+  if (globalThis.__studioDb && globalThis.__studioDbPath === resolved) {
+    return ensureSchema(globalThis.__studioDb);
+  }
+  if (globalThis.__studioDb) {
+    try { globalThis.__studioDb.close(); } catch { /* test isolation */ }
+    globalThis.__studioDb = undefined;
+  }
+  globalThis.__studioDbPath = resolved;
+  return (globalThis.__studioDb = open(resolved));
 }
 
 /* Opened on first query, never at import time.
@@ -234,7 +321,7 @@ export const db: DatabaseSync = new Proxy({} as DatabaseSync, {
   getPrototypeOf: () => Object.getPrototypeOf(connect())
 });
 
-export const dbPath = DB_PATH;
+export function getDbPath(): string { return resolveDbPath(); }
 
 export const now = () => new Date().toISOString().replace('T', ' ').slice(0, 19);
 

--- a/src/lib/defaults.test.ts
+++ b/src/lib/defaults.test.ts
@@ -168,3 +168,17 @@ test('deleting a component keeps empty authored flows', () => {
   assert.equal(doc.components[0].links, undefined);
   assert.deepEqual(doc.components[0].deps, []);
 });
+
+
+test('backfills concernTags from brick on normalize', () => {
+  const next = normalizeArchitecture({
+    meta: { name: 'Legacy', lang: 'fr', tagline: '', title: '', intro: '', facts: [] },
+    groups: [{ id: 'core', name: 'Core' }],
+    layers: [{ id: 'edge', name: 'Edge' }],
+    components: [{ id: 'auth', name: 'Auth0', group: 'core', layer: 'edge', brick: 'identity' }]
+  });
+  const auth = next.components[0];
+  assert.ok(auth.concernTags?.includes('iam'));
+  assert.ok(auth.purpose);
+  assert.ok(next.sections.some(s => s.id === 'add-iam' && s.doc?.gated));
+});

--- a/src/lib/defaults.ts
+++ b/src/lib/defaults.ts
@@ -1,5 +1,8 @@
 import { LINK_KINDS, linkIsEmpty } from './links';
 import { displayLayerLabel } from './layers';
+import { syncGatedPresetSections } from './document/preset';
+import { isBrickId } from './lego/bricks';
+import { buildCatalogSnapshot } from './lego/seed-data';
 import type { Architecture, Flow, Group, Link, Section, SectionType } from './types';
 
 /* The Atelier scope palette: five cool hues, `oklch(0.62 0.11 h)` for
@@ -130,6 +133,7 @@ export function deleteComponent(doc: Architecture, componentId: string): void {
     steps: flow.steps.filter(step => step.component !== componentId)
   }));
   pruneUnusedLayersAndScopes(doc);
+  syncGatedPresetSections(doc);
 }
 
 /** A new project starts empty on the diagram — layers and scopes appear when
@@ -164,7 +168,8 @@ export function blankArchitecture(name = 'New architecture'): Architecture {
     components: [],
     technologies: [],
     flows: [],
-    sections: []
+    sections: [],
+    decisions: []
   };
 }
 
@@ -211,17 +216,29 @@ export function normalizeArchitecture(input: Partial<Architecture>): Architectur
     components: input.components || [],
     technologies: input.technologies || [],
     flows: input.flows || [],
-    sections: input.sections || []
+    sections: input.sections || [],
+    decisions: input.decisions ?? []
   };
 
   const groupIds = new Set(doc.groups.map(g => g.id));
   const layerIds = new Set(doc.layers.map(l => l.id));
   const compIds = new Set(doc.components.map(c => c.id));
 
+  const lang = doc.meta.lang === 'fr' ? 'fr' : 'en';
+  const catalog = buildCatalogSnapshot(lang);
+
   doc.components = doc.components.map(c => {
     const deps = (c.deps || []).filter(d => compIds.has(d) && d !== c.id);
+    const brickId = (c.brick && isBrickId(c.brick) ? c.brick : undefined)
+      || (c.role && isBrickId(c.role) ? c.role : undefined);
+    const brick = brickId ? catalog.bricks[brickId] : undefined;
     return {
       ...c,
+      brick: c.brick ?? brickId,
+      purpose: c.purpose || brick?.purpose,
+      concernTags: c.concernTags?.length
+        ? c.concernTags
+        : (brick?.concernTags?.length ? [...brick.concernTags] : undefined),
       group: groupIds.has(c.group) ? c.group : (doc.groups[0]?.id ?? c.group),
       layer: layerIds.has(c.layer) ? c.layer : (doc.layers[0]?.id ?? c.layer),
       tech: c.tech || [],
@@ -235,11 +252,13 @@ export function normalizeArchitecture(input: Partial<Architecture>): Architectur
   /* A step pointing at a deleted component would crash the viewer, so those go.
    * A flow with no steps left is kept: it is almost always one being authored,
    * and dropping it here would delete the user's work on the next autosave. */
-  const lang = doc.meta.lang === 'fr' ? 'fr' : 'en';
   doc.flows = doc.flows
     .map(f => ({ ...f, steps: (f.steps || []).filter(s => compIds.has(s.component)) }))
     .map(f => fillFlowDefaults(f, lang));
 
+  /* Add missing gated chapters / drop stale ones — do not refresh bodies, or
+   * every autosave would wipe edits in Sections. Place/delete pass refresh. */
+  syncGatedPresetSections(doc, undefined, { refresh: false });
   return doc;
 }
 

--- a/src/lib/document/concerns.test.ts
+++ b/src/lib/document/concerns.test.ts
@@ -1,0 +1,231 @@
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+
+import { blankArchitecture } from '../defaults';
+import { buildCatalogSnapshot } from '../lego/seed-data';
+import { buildOutline } from './plan';
+import {
+  aggregateConcerns,
+  componentDescription,
+  deriveGates
+} from './concerns';
+
+test('aggregateConcerns unions tags from placed components', () => {
+  const doc = blankArchitecture('Test');
+  doc.components = [
+    { id: 'auth', name: 'Auth', group: 'core', layer: 'edge', concernTags: ['iam', 'security'] },
+    { id: 'db', name: 'DB', group: 'core', layer: 'data', concernTags: ['data', 'dr'] }
+  ];
+  const concerns = aggregateConcerns(doc);
+  assert.ok(concerns.has('iam'));
+  assert.ok(concerns.has('data'));
+  assert.equal(concerns.has('network'), false);
+});
+
+test('deriveGates maps iam to add-iam', () => {
+  const gates = deriveGates(new Set(['iam']));
+  assert.ok(gates.has('add-iam'));
+  assert.equal(gates.has('add-data'), false);
+});
+
+test('deriveGates returns empty when no component tags', () => {
+  assert.equal(deriveGates(new Set()).size, 0);
+  assert.equal(deriveGates(aggregateConcerns(blankArchitecture('Test'))).size, 0);
+});
+
+test('buildOutline includes add-iam when identity brick placed with iam tag', () => {
+  const doc = blankArchitecture('Test');
+  doc.groups = [{ id: 'core', name: 'Core' }];
+  doc.layers = [{ id: 'edge', name: 'Edge' }];
+  doc.components = [{
+    id: 'auth',
+    name: 'Auth0',
+    group: 'core',
+    layer: 'edge',
+    brick: 'identity',
+    concernTags: ['iam', 'security'],
+    purpose: 'Proves who callers are and issues tokens other services trust.'
+  }];
+  const sectionIds = buildOutline(doc).parts.flatMap(p => p.entries.flatMap(e =>
+    e.body.kind === 'section' ? [e.body.section.id] : []
+  ));
+  assert.ok(sectionIds.includes('add-iam'));
+});
+
+test('buildOutline omits CAF preset when no components placed', () => {
+  const doc = blankArchitecture('Test');
+  doc.meta.intro = 'An introduction.';
+  const sectionIds = buildOutline(doc).parts.flatMap(p => p.entries.flatMap(e =>
+    e.body.kind === 'section' ? [e.body.section.id] : []
+  ));
+  assert.equal(sectionIds.some(id => id.startsWith('add-')), false);
+});
+
+test('identity seed brick exposes iam and security concern tags', () => {
+  const brick = buildCatalogSnapshot('en').bricks.identity;
+  assert.ok(brick.purpose?.length);
+  assert.ok(brick.concernTags?.includes('iam'));
+  assert.ok(brick.concernTags?.includes('security'));
+});
+
+test('Context prefers component purpose over role', () => {
+  assert.equal(
+    componentDescription({ purpose: 'Catalog purpose text', role: 'Generic role' }),
+    'Catalog purpose text'
+  );
+  assert.equal(componentDescription({ role: 'Generic role' }), 'Generic role');
+});
+
+test('hydrated add-iam has no TODO placeholders', async () => {
+  const { hydratePresetSection, TODO } = await import('./hydrate');
+  const { presetSectionForId } = await import('./preset');
+  const doc = blankArchitecture('Test');
+  doc.meta.lang = 'fr';
+  doc.components = [{
+    id: 'auth',
+    name: 'Auth0',
+    group: 'core',
+    layer: 'edge',
+    brick: 'identity',
+    concernTags: ['iam', 'security'],
+    purpose: 'Prouve qui sont les appelants et émet des jetons que d’autres services font confiance.',
+    features: ['Prouver qui est l’appelant (connexion, jetons)'],
+    notes: ['Durée des jetons, MFA et révocation de session restent des décisions produit.'],
+    tech: ['OIDC', 'JWT', 'Auth0']
+  }];
+  const hydrated = hydratePresetSection(presetSectionForId('add-iam', 'fr')!, doc, 'fr');
+  const json = JSON.stringify(hydrated);
+  assert.equal(json.includes(TODO), false);
+  assert.ok(json.includes('Auth0'));
+  assert.ok(json.includes('Composants concernés'));
+});
+
+test('syncGatedPresetSections adds hydrated add-iam when identity brick placed', async () => {
+  const { syncGatedPresetSections } = await import('./preset');
+  const { TODO } = await import('./hydrate');
+  const doc = blankArchitecture('Test');
+  doc.meta.lang = 'fr';
+  doc.components = [{
+    id: 'auth', name: 'Auth0', group: 'core', layer: 'edge', brick: 'identity',
+    concernTags: ['iam', 'security'],
+    purpose: 'Prouve qui sont les appelants.',
+    features: ['Prouver qui est l’appelant'],
+    tech: ['OIDC', 'JWT']
+  }];
+  const result = syncGatedPresetSections(doc);
+  assert.deepEqual(result.added, ['add-iam']);
+  const section = doc.sections.find(s => s.id === 'add-iam');
+  assert.ok(section?.doc?.gated);
+  assert.equal(JSON.stringify(section).includes(TODO), false);
+});
+
+test('syncGatedPresetSections removes gated section when last opener deleted', async () => {
+  const { syncGatedPresetSections } = await import('./preset');
+  const { deleteComponent } = await import('../defaults');
+  const doc = blankArchitecture('Test');
+  doc.components = [{
+    id: 'auth', name: 'Auth0', group: 'core', layer: 'edge',
+    concernTags: ['iam'], purpose: 'Auth'
+  }];
+  syncGatedPresetSections(doc);
+  assert.ok(doc.sections.some(s => s.id === 'add-iam'));
+  deleteComponent(doc, 'auth');
+  assert.equal(doc.sections.some(s => s.id === 'add-iam'), false);
+});
+
+test('syncGatedPresetSections re-hydrates when a second opener is added', async () => {
+  const { syncGatedPresetSections } = await import('./preset');
+  const doc = blankArchitecture('Test');
+  doc.meta.lang = 'fr';
+  doc.components = [{
+    id: 'auth', name: 'Auth0', group: 'core', layer: 'edge', brick: 'identity',
+    concernTags: ['iam'], purpose: 'Auth0', tech: ['OIDC']
+  }];
+  syncGatedPresetSections(doc);
+  doc.components.push({
+    id: 'cog', name: 'Cognito', group: 'core', layer: 'edge', brick: 'identity',
+    concernTags: ['iam'], purpose: 'Cognito', tech: ['JWT']
+  });
+  const result = syncGatedPresetSections(doc);
+  assert.deepEqual(result.updated, ['add-iam']);
+  const json = JSON.stringify(doc.sections.find(s => s.id === 'add-iam'));
+  assert.ok(json.includes('Auth0'));
+  assert.ok(json.includes('Cognito'));
+});
+
+test('syncGatedPresetSections drops removed opener from gated section text', async () => {
+  const { syncGatedPresetSections } = await import('./preset');
+  const { deleteComponent } = await import('../defaults');
+  const doc = blankArchitecture('Test');
+  doc.components = [
+    { id: 'auth', name: 'Auth0', group: 'core', layer: 'edge', concernTags: ['iam'], purpose: 'Auth0' },
+    { id: 'cog', name: 'Cognito', group: 'core', layer: 'edge', concernTags: ['iam'], purpose: 'Cognito' }
+  ];
+  syncGatedPresetSections(doc);
+  deleteComponent(doc, 'cog');
+  const json = JSON.stringify(doc.sections.find(s => s.id === 'add-iam'));
+  assert.ok(json.includes('Auth0'));
+  assert.equal(json.includes('Cognito'), false);
+});
+
+
+test('deriveGates ignores unknown concern tags', () => {
+  const gates = deriveGates(['iam', 'bogus', '__proto__'] as unknown as import('./concerns').ConcernTag[]);
+  assert.ok(gates.has('add-iam'));
+  assert.equal(gates.has('bogus'), false);
+});
+
+test('gated compare and timeline chapters persist without TODO', async () => {
+  const { syncGatedPresetSections } = await import('./preset');
+  const { TODO } = await import('./hydrate');
+  const doc = blankArchitecture('Test');
+  doc.components = [{
+    id: 'k8s', name: 'EKS', group: 'core', layer: 'services', brick: 'kubernetes',
+    concernTags: ['ops', 'tenancy'], purpose: 'Orchestrates containers'
+  }];
+  syncGatedPresetSections(doc);
+  const ids = doc.sections.map(s => s.id);
+  assert.ok(ids.includes('add-tenancy'));
+  assert.ok(ids.includes('add-scale'));
+  assert.ok(ids.includes('add-cicd'));
+  for (const section of doc.sections) {
+    assert.equal(JSON.stringify(section).includes(TODO), false, section.id);
+  }
+});
+
+test('normalizeArchitecture does not clobber edited gated section', async () => {
+  const { syncGatedPresetSections } = await import('./preset');
+  const { normalizeArchitecture } = await import('../defaults');
+  const doc = blankArchitecture('Test');
+  doc.components = [{
+    id: 'auth', name: 'Auth0', group: 'core', layer: 'edge',
+    concernTags: ['iam'], purpose: 'Auth0'
+  }];
+  syncGatedPresetSections(doc);
+  const iam = doc.sections.find(s => s.id === 'add-iam')!;
+  iam.title = 'Edited by hand';
+  const next = normalizeArchitecture(doc);
+  assert.equal(next.sections.find(s => s.id === 'add-iam')!.title, 'Edited by hand');
+});
+
+
+test('adopts a manual preset chapter still full of TODO when the gate opens', async () => {
+  const { applyDesignDocumentPreset, syncGatedPresetSections } = await import('./preset');
+  const { TODO } = await import('./hydrate');
+  const doc = blankArchitecture('Test');
+  doc.meta.lang = 'fr';
+  applyDesignDocumentPreset(doc, 'fr');
+  const raw = doc.sections.find(s => s.id === 'add-iam')!;
+  assert.equal(raw.doc?.gated, undefined);
+  assert.ok(JSON.stringify(raw).includes(TODO));
+  doc.components = [{
+    id: 'auth', name: 'Auth0', group: 'core', layer: 'edge', brick: 'identity',
+    concernTags: ['iam'], purpose: 'Auth0', tech: ['OIDC']
+  }];
+  const result = syncGatedPresetSections(doc, 'fr', { refresh: false });
+  assert.ok(result.updated?.includes('add-iam'));
+  const iam = doc.sections.find(s => s.id === 'add-iam')!;
+  assert.equal(iam.doc?.gated, true);
+  assert.equal(JSON.stringify(iam).includes(TODO), false);
+  assert.ok(JSON.stringify(iam).includes('Auth0'));
+});

--- a/src/lib/document/concerns.ts
+++ b/src/lib/document/concerns.ts
@@ -1,0 +1,62 @@
+import type { Architecture, Component } from '../types';
+
+/** Closed concern vocabulary — single gating lever for CAF preset chapters. */
+export type ConcernTag =
+  | 'data'
+  | 'iam'
+  | 'tenancy'
+  | 'network'
+  | 'security'
+  | 'ops'
+  | 'dr'
+  | 'observability'
+  | 'governance'
+  | 'cost'
+  | 'decision:irreversible';
+
+/** Maps each concern tag to zero or more preset section ids (1:n allowed). */
+export const TAG_TO_PRESET: Record<ConcernTag, readonly string[]> = {
+  data: ['add-data'],
+  iam: ['add-iam'],
+  security: ['add-iam'],
+  tenancy: ['add-tenancy'],
+  network: ['add-network'],
+  ops: ['add-scale', 'add-cicd'],
+  dr: ['add-dr'],
+  observability: ['add-observability'],
+  governance: ['add-governance'],
+  cost: ['add-cost-mgmt'],
+  'decision:irreversible': []
+};
+
+export function isConcernTag(value: unknown): value is ConcernTag {
+  return typeof value === 'string' && Object.hasOwn(TAG_TO_PRESET, value);
+}
+
+/** Union of snapshotted concern tags from every placed component. */
+export function aggregateConcerns(doc: Pick<Architecture, 'components'>): Set<ConcernTag> {
+  const tags = new Set<ConcernTag>();
+  for (const component of doc.components) {
+    for (const tag of component.concernTags ?? []) {
+      if (isConcernTag(tag)) tags.add(tag);
+    }
+  }
+  return tags;
+}
+
+/** Derive gated preset section ids from an aggregated concern set. */
+export function deriveGates(concerns: Iterable<ConcernTag | string>): Set<string> {
+  const gates = new Set<string>();
+  for (const tag of concerns) {
+    if (!isConcernTag(tag)) continue;
+    for (const id of TAG_TO_PRESET[tag]) {
+      gates.add(id);
+    }
+  }
+  return gates;
+}
+
+/** Printable description: catalog purpose wins over legacy role prose. */
+export function componentDescription(component: Pick<Component, 'purpose' | 'role'>): string | undefined {
+  return component.purpose || component.role;
+}

--- a/src/lib/document/document.test.ts
+++ b/src/lib/document/document.test.ts
@@ -4,7 +4,7 @@ import { test } from 'node:test';
 import { blankArchitecture, normalizeArchitecture } from '../defaults';
 import { instantiate, getTemplate } from '../templates';
 import { tabRows } from '../tabs';
-import type { Architecture, Section } from '../types';
+import type { Architecture, ArchitectureDecision, Flow, Section } from '../types';
 import { buildOutline, partOf, slotKey, supportLayerId, toc } from './plan';
 import { PRESET_SECTION_IDS, applyDesignDocumentPreset, missingPresetSections } from './preset';
 
@@ -18,6 +18,28 @@ const withSections = (sections: Section[]): Architecture => {
   doc.sections = sections;
   return doc;
 };
+
+const kindsOf = (entries: { body: { kind: string } }[]): string[] =>
+  entries.map(e => e.body.kind);
+
+const placedCanvas = (): Architecture => {
+  const doc = blankArchitecture('Test');
+  doc.groups = [{ id: 'core', name: 'Core' }];
+  doc.layers = [{ id: 'services', name: 'Services' }];
+  doc.components = [
+    { id: 'web', name: 'Web app', group: 'core', layer: 'services' },
+    { id: 'api', name: 'API', group: 'core', layer: 'services' }
+  ];
+  doc.technologies = [{ name: 'Postgres' }];
+  return doc;
+};
+
+const journey = (id: string, name: string): Flow => ({
+  id, name, steps: [{ component: 'web', title: 'Start' }]
+});
+
+const flowIdsOf = (entries: { body: { kind: string; flow?: Flow } }[]) =>
+  entries.filter(e => e.body.kind === 'flow').map(e => e.body.flow!.id);
 
 /* ------------------------------------------------------------------ slots */
 
@@ -85,9 +107,10 @@ test('flows and the stack table close the appendices', () => {
   const doc = instantiate(getTemplate('multi-service')!, {
     target: 'aws', lang: 'fr', projectName: 'Demo', today: '2026-08-14'
   });
-  const kinds = buildOutline(doc).parts.at(-1)!.entries.map(e => e.body.kind);
+  const kinds = kindsOf(buildOutline(doc).parts.at(-1)!.entries);
+  /* multi-service has two named flows: they move to the application part. */
+  assert.equal(kinds.filter(k => k === 'flow').length, 0);
   assert.equal(kinds.at(-1), 'stack');
-  assert.ok(kinds.includes('flow'));
 });
 
 test('the outline speaks the document’s language', () => {
@@ -114,6 +137,160 @@ test('the support layer follows the viewer’s rule', () => {
 
   four.ui.supportLayer = false;
   assert.equal(supportLayerId(four), null);
+});
+
+test('a canvas with groups or components gets a Context chapter in the introduction', () => {
+  const groupsOnly = blankArchitecture('Test');
+  groupsOnly.groups = [{ id: 'core', name: 'Core' }];
+  const fromGroups = buildOutline(groupsOnly);
+  const introG = fromGroups.parts.find(p => p.title === 'Introduction');
+  assert.ok(introG);
+  assert.ok(kindsOf(introG.entries).includes('context'));
+  assert.ok(introG.entries.some(e => /Context|Contexte/.test(e.title)));
+  assert.equal(JSON.stringify(fromGroups).includes('[…]'), false);
+
+  const withComponents = placedCanvas();
+  const introC = buildOutline(withComponents).parts.find(p => p.title === 'Introduction');
+  assert.ok(introC);
+  assert.ok(kindsOf(introC.entries).includes('context'));
+  assert.ok(introC.entries.some(e => /Context/.test(e.title)));
+
+  const fr = instantiate(getTemplate('serverless-mvp')!, {
+    target: 'gcp', lang: 'fr', projectName: 'Demo', today: '2026-08-14'
+  });
+  const introFr = buildOutline(fr).parts.find(p => p.title === 'Introduction')!;
+  assert.ok(introFr.entries.some(e => /Contexte/.test(e.title)));
+  assert.equal(JSON.stringify(introFr.entries.find(e => /Contexte/.test(e.title))).includes('[…]'), false);
+});
+
+test('an empty canvas omits Context, glossary, and ADR index', () => {
+  const doc = blankArchitecture('Test');
+  doc.meta.intro = 'An introduction.';
+  const outline = buildOutline(doc);
+  const kinds = outline.parts.flatMap(p => kindsOf(p.entries));
+  const titles = toc(outline).map(r => r.title);
+  assert.equal(kinds.includes('context'), false);
+  assert.equal(kinds.includes('glossary'), false);
+  assert.equal(kinds.includes('adr-index'), false);
+  assert.equal(titles.some(t => /Context|Contexte/.test(t)), false);
+});
+
+test('one to five named flows sit after the inventory, not in the appendices', () => {
+  for (const id of ['multi-service', 'serverless-mvp'] as const) {
+    const doc = instantiate(getTemplate(id)!, {
+      target: 'aws', lang: 'en', projectName: 'Demo', today: '2026-08-14'
+    });
+    const named = doc.flows.filter(f => f.name.trim());
+    assert.ok(named.length >= 1 && named.length <= 5);
+    const outline = buildOutline(doc);
+    const app = outline.parts.find(p => p.title.includes('Application'))!;
+    const appendix = outline.parts.at(-1)!;
+    const appKinds = kindsOf(app.entries);
+    assert.equal(appKinds[0], 'inventory');
+    const flowCount = appKinds.filter(k => k === 'flow').length;
+    assert.equal(flowCount, named.length);
+    assert.ok(appKinds.slice(1, 1 + flowCount).every(k => k === 'flow'));
+    assert.equal(kindsOf(appendix.entries).includes('flow'), false);
+  }
+});
+
+test('named flows fall back to appendices when no components are placed', () => {
+  const doc = blankArchitecture('Test');
+  doc.flows = [
+    journey('signup', 'Sign up'),
+    journey('checkout', 'Checkout')
+  ];
+  const outline = buildOutline(doc);
+  const appendix = outline.parts.at(-1)!;
+  const app = outline.parts.find(p => p.title.includes('Application'));
+  assert.equal(app, undefined);
+  assert.equal(kindsOf(appendix.entries).filter(k => k === 'flow').length, 2);
+  assert.ok(flowIdsOf(appendix.entries).includes('signup'));
+  assert.ok(flowIdsOf(appendix.entries).includes('checkout'));
+});
+
+test('six or more named flows stay in the appendices', () => {
+  const doc = placedCanvas();
+  doc.flows = Array.from({ length: 6 }, (_, i) => journey(`flow-${i + 1}`, `Journey ${i + 1}`));
+  const outline = buildOutline(doc);
+  const app = outline.parts.find(p => p.title.includes('Application'))!;
+  const appendix = outline.parts.at(-1)!;
+  assert.equal(kindsOf(app.entries).includes('flow'), false);
+  assert.equal(kindsOf(appendix.entries).filter(k => k === 'flow').length, 6);
+});
+
+test('unnamed flows stay in the appendices', () => {
+  const doc = placedCanvas();
+  doc.flows = [
+    journey('checkout', 'Checkout'),
+    journey('draft', ''),
+    journey('spaces', '   ')
+  ];
+  const outline = buildOutline(doc);
+  const app = outline.parts.find(p => p.title.includes('Application'))!;
+  const appendix = outline.parts.at(-1)!;
+  const inApp = flowIdsOf(app.entries);
+  const inAppendix = flowIdsOf(appendix.entries);
+  assert.ok(inApp.includes('checkout'));
+  assert.equal(inApp.includes('draft'), false);
+  assert.equal(inApp.includes('spaces'), false);
+  assert.ok(inAppendix.includes('draft'));
+  assert.ok(inAppendix.includes('spaces'));
+  assert.equal(inAppendix.includes('checkout'), false);
+});
+
+test('the glossary lists every placed component and sits before the stack', () => {
+  const doc = instantiate(getTemplate('serverless-mvp')!, {
+    target: 'gcp', lang: 'en', projectName: 'Demo', today: '2026-08-14'
+  });
+  const appendix = buildOutline(doc).parts.at(-1)!;
+  const kinds = kindsOf(appendix.entries);
+  const gi = kinds.indexOf('glossary');
+  const si = kinds.indexOf('stack');
+  assert.ok(gi >= 0);
+  assert.ok(si >= 0);
+  assert.ok(gi < si);
+  const glossary = appendix.entries[gi];
+  for (const c of doc.components) {
+    assert.ok(JSON.stringify(glossary).includes(c.name), c.name);
+  }
+  assert.equal(JSON.stringify(glossary).includes('[…]'), false);
+});
+
+test('the ADR index appears only when decisions exist and never contains a TODO', () => {
+  const empty = placedCanvas();
+  const emptyKinds = buildOutline(empty).parts.flatMap(p => kindsOf(p.entries));
+  assert.equal(emptyKinds.includes('adr-index'), false);
+
+  const decision: ArchitectureDecision = {
+    id: 'adr-1',
+    title: 'Pick a bus',
+    context: 'Services must not call each other directly.',
+    decision: 'Publish events.',
+    consequences: 'Consumers stay independent.',
+    status: 'accepted'
+  };
+  const withDecisions = { ...placedCanvas(), decisions: [decision] };
+  const outline = buildOutline(withDecisions);
+  const intro = outline.parts.find(p => p.title === 'Introduction');
+  assert.ok(intro);
+  const kinds = kindsOf(intro.entries);
+  const ci = kinds.indexOf('context');
+  const ai = kinds.indexOf('adr-index');
+  assert.ok(ai >= 0);
+  assert.ok(ci >= 0 && ci < ai);
+  const adr = intro.entries[ai];
+  assert.equal(JSON.stringify(adr).includes('TODO'), false);
+  assert.equal(JSON.stringify(adr).includes('[…]'), false);
+  assert.ok(JSON.stringify(adr).includes(decision.title));
+});
+
+test('a blank outline never includes the CAF preset chapters', () => {
+  const outline = buildOutline(blankArchitecture('Test'));
+  const sectionIds = outline.parts.flatMap(p => p.entries.flatMap(e =>
+    e.body.kind === 'section' ? [e.body.section.id] : []
+  ));
+  assert.ok(PRESET_SECTION_IDS.every(id => !sectionIds.includes(id)));
 });
 
 /* ----------------------------------------------------------------- preset */
@@ -166,7 +343,14 @@ test('the generated deployment table becomes the service-selection chapter', () 
   assert.equal(doc.sections.find(s => s.id === 'deployment')!.doc?.chapter, '2.1');
 
   const part = buildOutline(doc).parts.find(p => p.number === '2')!;
-  assert.deepEqual(part.entries.slice(0, 2).map(e => e.body.kind), ['inventory', 'section']);
+  const kinds = kindsOf(part.entries);
+  assert.equal(kinds[0], 'inventory');
+  const firstSection = kinds.indexOf('section');
+  assert.ok(firstSection >= 2);
+  assert.ok(kinds.slice(1, firstSection).every(k => k === 'flow'));
+  const chapter = part.entries[firstSection];
+  assert.equal(chapter.body.kind, 'section');
+  if (chapter.body.kind === 'section') assert.equal(chapter.body.section.id, 'deployment');
 });
 
 test('the preset is translated, and only in the document’s language', () => {

--- a/src/lib/document/hydrate.ts
+++ b/src/lib/document/hydrate.ts
@@ -1,0 +1,257 @@
+/* Fill gated preset chapters from placed components — catalog purpose, features,
+ * and names replace template placeholders; bullets that stay empty are dropped. */
+
+import type { Architecture, Component, Section } from '../types';
+import type { Lang } from '../templates/types';
+import { TAG_TO_PRESET, type ConcernTag, componentDescription } from './concerns';
+
+export const TODO = '[…]';
+
+/** Components whose snapshotted concern tags open this preset chapter. */
+export function componentsForPreset(doc: Pick<Architecture, 'components'>, presetId: string): Component[] {
+  const tags = new Set<ConcernTag>();
+  for (const [tag, presets] of Object.entries(TAG_TO_PRESET) as [ConcernTag, readonly string[]][]) {
+    if (presets.includes(presetId)) tags.add(tag);
+  }
+  if (!tags.size) return [];
+  return doc.components.filter(c => (c.concernTags ?? []).some(t => tags.has(t)));
+}
+
+function hasTodo(text: string): boolean {
+  return text.includes(TODO);
+}
+
+function replaceTodos(text: string, ...values: (string | undefined)[]): string {
+  let i = 0;
+  return text.replace(/\[\…\]/g, () => {
+    const v = values[i++];
+    return v?.trim() ? v : TODO;
+  });
+}
+
+function clean(text: string | undefined): string | undefined {
+  if (!text?.trim() || hasTodo(text)) return undefined;
+  return text;
+}
+
+function names(components: Component[]): string | undefined {
+  const list = components.map(c => c.name.trim()).filter(Boolean);
+  return list.length ? list.join(', ') : undefined;
+}
+
+function escapePlain(text: string): string {
+  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function joinTech(components: Component[]): string | undefined {
+  const tech = [...new Set(components.flatMap(c => c.tech ?? []).map(t => t.trim()).filter(Boolean))];
+  return tech.length ? tech.join(' · ') : undefined;
+}
+
+function scopeBullets(components: Component[]): string[] {
+  const out: string[] = [];
+  for (const c of components) {
+    const desc = componentDescription(c);
+    if (desc) out.push(`${escapePlain(c.name)} — ${escapePlain(desc)}`);
+    for (const f of c.features ?? []) out.push(`${escapePlain(c.name)} : ${escapePlain(f)}`);
+  }
+  return out;
+}
+
+function scopeCard(components: Component[], lang: Lang) {
+  const bullets = scopeBullets(components);
+  if (!bullets.length) return undefined;
+  return {
+    icon: 'box',
+    title: lang === 'fr' ? 'Composants concernés' : 'Components in scope',
+    bullets
+  };
+}
+
+function filterBullets(bullets: string[] | undefined): string[] {
+  return (bullets ?? []).map(clean).filter((b): b is string => !!b);
+}
+
+function hydrateAddIam(section: Section, components: Component[], lang: Lang): Section {
+  const identity = components.filter(c => c.concernTags?.includes('iam') || c.brick === 'identity');
+  if (!identity.length) return scopeOnly(section, components, lang);
+  const scoped = identity;
+  const provider = names(scoped);
+  const tech = joinTech(scoped);
+  const items = [...(section.items as { icon?: string; title: string; bullets?: string[] }[])];
+
+  const hydrated = items.map(item => {
+    const title = item.title.toLowerCase();
+    let bullets = [...(item.bullets ?? [])];
+
+    if (title.includes('human') || title.includes('humaines')) {
+      bullets = bullets.map(b => {
+        if (b.includes('Provisioned from') || b.includes('Provisionnées depuis')) {
+          return replaceTodos(b, provider);
+        }
+        if (b.includes('Production access') || b.includes('accès à la production')) return undefined;
+        return b;
+      }).filter((b): b is string => !!b);
+      for (const c of scoped) {
+        for (const note of c.notes ?? []) bullets.push(note);
+      }
+      if (tech) {
+        bullets.push(lang === 'fr'
+          ? `Technologies d'identité : ${tech}`
+          : `Identity technologies: ${tech}`);
+      }
+    }
+
+    if (title.includes('machine')) {
+      if (tech) {
+        bullets.push(lang === 'fr'
+          ? `Validation des jetons via ${tech}`
+          : `Token validation via ${tech}`);
+      }
+    }
+
+    if (title.includes('secret')) {
+      bullets = bullets.map(b => {
+        if (b.includes('Stored in') || b.includes('Stockés dans')) return undefined;
+        if (b.includes('Rotation')) return undefined;
+        return b;
+      }).filter((b): b is string => !!b);
+      const secretNote = scoped.flatMap(c => c.notes ?? []).find(n =>
+        /secret|jeton|MFA|token/i.test(n)
+      );
+      if (secretNote) bullets.push(secretNote);
+    }
+
+    if (title.includes('review') || title.includes('revue')) {
+      return undefined;
+    }
+
+    return { ...item, bullets: filterBullets(bullets) };
+  }).filter((item): item is NonNullable<typeof item> => !!item && (item.bullets?.length ?? 0) > 0);
+
+  const card = scopeCard(scoped, lang);
+  if (card) hydrated.unshift(card);
+
+  return { ...section, items: hydrated };
+}
+
+const DATA_ROW_BRICKS: Record<string, string[]> = {
+  transactional: ['sql'],
+  cache: ['cache'],
+  objects: ['objects', 'staticHosting']
+};
+
+function hydrateAddData(section: Section, components: Component[], lang: Lang): Section {
+  const dataBricks = components.filter(c => c.concernTags?.includes('data'));
+  const rows = [...(section.rows as string[][])];
+  const used = new Set<string>();
+
+  const hydratedRows = rows.map(row => {
+    const kind = row[0]?.toLowerCase() ?? '';
+    let brickKeys: string[] = [];
+    if (kind.includes('transaction') || kind.includes('transactionnel')) brickKeys = DATA_ROW_BRICKS.transactional;
+    else if (kind.includes('session') || kind.includes('cache')) brickKeys = DATA_ROW_BRICKS.cache;
+    else if (kind.includes('file') || kind.includes('fichier') || kind.includes('media')) brickKeys = DATA_ROW_BRICKS.objects;
+
+    const matches = dataBricks.filter(c => c.brick && brickKeys.includes(c.brick));
+    if (!matches.length) return null;
+    matches.forEach(c => used.add(c.id));
+
+    const store = names(matches)!;
+    const why = matches.map(c => componentDescription(c)).filter(Boolean).join(' ') || row[2];
+    const next = [...row];
+    next[1] = store;
+    next[2] = why;
+    next[3] = replaceTodos(next[3] ?? TODO);
+    if (hasTodo(next[3]!)) next[3] = lang === 'fr' ? 'À estimer' : 'To be estimated';
+    return next;
+  }).filter((row): row is string[] => !!row);
+
+  for (const c of dataBricks) {
+    if (used.has(c.id)) continue;
+    hydratedRows.push([
+      c.name,
+      c.name,
+      componentDescription(c) ?? c.name,
+      lang === 'fr' ? 'À estimer' : 'To be estimated'
+    ]);
+  }
+
+  const card = scopeCard(dataBricks.length ? dataBricks : components, lang);
+  if (card && hydratedRows.length === 0) {
+    return { ...section, type: 'cards', items: [card], rows: undefined, columns: undefined };
+  }
+
+  return { ...section, rows: hydratedRows.length ? hydratedRows : rows };
+}
+
+function hydrateTextBlocks(section: Section, components: Component[], lang: Lang): Section {
+  const provider = names(components);
+  const tech = joinTech(components);
+  const blocks = (section.blocks as { title?: string; body?: string | string[] }[] | undefined)?.map(block => {
+    const body = Array.isArray(block.body)
+      ? block.body.map(p => clean(replaceTodos(p, provider, tech, provider))).filter((p): p is string => !!p)
+      : clean(replaceTodos(String(block.body ?? ''), provider, tech, provider));
+    if (Array.isArray(block.body) && !body?.length) return undefined;
+    if (!Array.isArray(block.body) && !body) return undefined;
+    return { ...block, body: body ?? block.body };
+  }).filter(Boolean);
+
+  return {
+    ...section,
+    blocks: blocks?.length ? blocks : []
+  };
+}
+
+function hydrateTable(section: Section, components: Component[], lang: Lang): Section {
+  const filled = (section.rows as string[][] | undefined)?.map(row =>
+    row.map((cell, i) => {
+      if (i === 0 || !hasTodo(String(cell))) return cell;
+      return replaceTodos(String(cell), names(components), componentDescription(components[0]), names(components));
+    })
+  ).filter(row => !row.some(cell => hasTodo(String(cell))));
+  return { ...section, rows: filled ?? [] };
+}
+
+function scopeOnly(section: Section, components: Component[], lang: Lang): Section {
+  const card = scopeCard(components, lang);
+  return {
+    id: section.id,
+    type: 'cards',
+    title: section.title,
+    subtitle: section.subtitle,
+    note: section.note,
+    doc: section.doc,
+    items: card ? [card] : []
+  };
+}
+
+function finalize(section: Section, components: Component[], lang: Lang): Section {
+  return JSON.stringify(section).includes(TODO) ? scopeOnly(section, components, lang) : section;
+}
+
+const HYDRATORS: Record<string, (s: Section, c: Component[], lang: Lang) => Section> = {
+  'add-iam': hydrateAddIam,
+  'add-data': hydrateAddData
+};
+
+/** Project a preset section filled from components that opened its gate. */
+export function hydratePresetSection(section: Section, doc: Architecture, lang: Lang): Section {
+  const components = componentsForPreset(doc, section.id);
+  if (!components.length) return scopeOnly(section, [], lang);
+
+  let next: Section;
+  if (Object.hasOwn(HYDRATORS, section.id)) {
+    next = HYDRATORS[section.id](section, components, lang);
+  } else if (section.type === 'text') {
+    next = hydrateTextBlocks(section, components, lang);
+  } else if (section.type === 'table') {
+    next = hydrateTable(section, components, lang);
+  } else if (section.type === 'cards') {
+    const card = scopeCard(components, lang);
+    next = card ? { ...section, items: [card] } : scopeOnly(section, components, lang);
+  } else {
+    next = scopeOnly(section, components, lang);
+  }
+  return finalize(next, components, lang);
+}

--- a/src/lib/document/plan.ts
+++ b/src/lib/document/plan.ts
@@ -10,19 +10,28 @@
  * recovery one becomes 2.4 — no holes, no renumbering by hand.
  */
 
-import type { Architecture, Flow, Section } from '../types';
+import type { Architecture, ArchitectureDecision, Flow, Section } from '../types';
 import { t, type L10n, type Lang } from '../templates/types';
+import { aggregateConcerns, deriveGates } from './concerns';
+import { hydratePresetSection } from './hydrate';
+import { PRESET_SECTION_IDS, presetSectionForId } from './preset';
 
 /* ------------------------------------------------------------------- model */
 
 export type DocBody =
   /** meta.intro, the header facts, and the principle callout. */
   | { kind: 'intro' }
+  /** Scopes and building blocks — C4 context without a second diagram. */
+  | { kind: 'context' }
+  /** Index of architecture decision records on the canvas. */
+  | { kind: 'adr-index'; decisions: ArchitectureDecision[] }
   | { kind: 'diagram' }
   /** Every component, by layer — the reference table for the diagram. */
   | { kind: 'inventory' }
   | { kind: 'section'; section: Section }
   | { kind: 'flow'; flow: Flow }
+  /** Product glossary — one row per placed component. */
+  | { kind: 'glossary'; names: string[] }
   | { kind: 'stack' };
 
 export interface DocEntry {
@@ -64,6 +73,21 @@ const SPINE = ['1', '2', '3', '4', '5', '6'];
 const APPENDIX = '6';
 
 const GENERATED: Record<string, L10n> = {
+  context: { en: 'Context', fr: 'Contexte' },
+  contextSub: {
+    en: 'Scopes and building blocks that sit around the product.',
+    fr: 'Périmètres et blocs qui entourent le produit.'
+  },
+  adrIndex: { en: 'Architecture decision records', fr: 'Décisions d\'architecture' },
+  adrIndexSub: {
+    en: 'Recorded choices and their consequences.',
+    fr: 'Choix enregistrés et leurs conséquences.'
+  },
+  glossary: { en: 'Glossary', fr: 'Glossaire' },
+  glossarySub: {
+    en: 'Product terms used in this document.',
+    fr: 'Termes produit utilisés dans ce document.'
+  },
   inventory: { en: 'Component inventory', fr: 'Inventaire des composants' },
   inventorySub: {
     en: 'Every component on the diagram above, with the scope that owns it and the technologies it runs on.',
@@ -121,7 +145,39 @@ export function buildOutline(doc: Architecture): Outline {
   doc.sections.forEach((section, index) => {
     buckets.get(partOf(section))!.push({ section, key: slotKey(section.doc?.chapter), index });
   });
+
+  if (doc.components.length > 0) {
+    const gateIds = deriveGates(aggregateConcerns(doc));
+    const have = new Set(doc.sections.map(section => section.id));
+    PRESET_SECTION_IDS.forEach((id, presetIndex) => {
+      if (!gateIds.has(id) || have.has(id)) return;
+      const raw = presetSectionForId(id, lang);
+      if (!raw) return;
+      const section = hydratePresetSection(raw, doc, lang);
+      buckets.get(partOf(section))!.push({
+        section,
+        key: slotKey(section.doc?.chapter),
+        index: doc.sections.length + presetIndex
+      });
+    });
+  }
+
   buckets.forEach(list => list.sort((a, b) => compareKeys(a.key, b.key, a.index, b.index)));
+
+  const namedFlows = doc.flows.filter(f => f.name.trim());
+  const unnamedFlows = doc.flows.filter(f => !f.name.trim());
+  const canPromote = doc.components.length > 0
+    && namedFlows.length >= 1 && namedFlows.length <= 5;
+  const bodyFlows = canPromote ? namedFlows : [];
+  const appendixFlows = canPromote ? unnamedFlows : doc.flows;
+
+  const flowEntry = (flow: Flow): DocEntry => ({
+    number: '',
+    title: s(GENERATED.flow).replace('{name}', flow.name),
+    subtitle: flow.sub,
+    note: flow.note,
+    body: { kind: 'flow', flow }
+  });
 
   const sectionEntries = (part: string): DocEntry[] =>
     buckets.get(part)!.map(({ section }) => ({
@@ -133,29 +189,45 @@ export function buildOutline(doc: Architecture): Outline {
     }));
 
   const hasIntro = !!(doc.meta.intro || doc.meta.principle || doc.meta.facts?.length);
+  const hasContext = !!(doc.groups.length || doc.components.length);
   const parts: DocPart[] = SPINE.map(part => {
     const lead: DocBody[] = [];
     const entries: DocEntry[] = [];
 
-    if (part === '1' && hasIntro) lead.push({ kind: 'intro' });
+    if (part === '1') {
+      if (hasIntro) lead.push({ kind: 'intro' });
+      if (hasContext) {
+        entries.push({
+          number: '', title: s(GENERATED.context), subtitle: s(GENERATED.contextSub),
+          body: { kind: 'context' }
+        });
+      }
+      if (doc.decisions.length) {
+        entries.push({
+          number: '', title: s(GENERATED.adrIndex), subtitle: s(GENERATED.adrIndexSub),
+          body: { kind: 'adr-index', decisions: doc.decisions }
+        });
+      }
+    }
     if (part === '2' && doc.components.length) {
       lead.push({ kind: 'diagram' });
       entries.push({
         number: '', title: s(GENERATED.inventory), subtitle: s(GENERATED.inventorySub),
         body: { kind: 'inventory' }
       });
+      bodyFlows.forEach(flow => entries.push(flowEntry(flow)));
     }
 
     entries.push(...sectionEntries(part));
 
     if (part === APPENDIX) {
-      doc.flows.forEach(flow => entries.push({
-        number: '',
-        title: s(GENERATED.flow).replace('{name}', flow.name),
-        subtitle: flow.sub,
-        note: flow.note,
-        body: { kind: 'flow', flow }
-      }));
+      appendixFlows.forEach(flow => entries.push(flowEntry(flow)));
+      if (doc.components.length) {
+        entries.push({
+          number: '', title: s(GENERATED.glossary), subtitle: s(GENERATED.glossarySub),
+          body: { kind: 'glossary', names: doc.components.map(c => c.name) }
+        });
+      }
       if (doc.technologies.length) entries.push({
         number: '', title: s(GENERATED.stack), subtitle: s(GENERATED.stackSub),
         body: { kind: 'stack' }

--- a/src/lib/document/preset.ts
+++ b/src/lib/document/preset.ts
@@ -25,8 +25,10 @@
 import { naturalTabs } from '../tabs';
 import type { Architecture, DocSlot, Section } from '../types';
 import { resolveDeep, type Lang, type TemplateSection } from '../templates/types';
+import { aggregateConcerns, deriveGates } from './concerns';
+import { hydratePresetSection } from './hydrate';
 
-type PresetSection = TemplateSection & { doc: DocSlot };
+export type PresetSection = TemplateSection & { doc: DocSlot };
 
 /** Marks a value the author still has to supply. */
 const TODO = '[…]';
@@ -534,15 +536,36 @@ export interface PresetResult {
   added: string[];
   /** Ids that were already there — left untouched, edits and all. */
   kept: string[];
+  /** Auto-gated sections re-hydrated from the current component set. */
+  updated?: string[];
+  /** Auto-gated section ids removed because no component opens the gate anymore. */
+  removed?: string[];
 }
 
 /** Ids the preset owns, in plan order. */
 export const PRESET_SECTION_IDS = SECTIONS.map(s => s.id);
 
+/** Bilingual preset chapter specs for admin seed (M3). */
+export function allPresetSectionSpecs(): readonly PresetSection[] {
+  return SECTIONS;
+}
+
 /** How many preset chapters `doc` is still missing. */
 export function missingPresetSections(doc: Architecture): number {
   const have = new Set(doc.sections.map(s => s.id));
   return PRESET_SECTION_IDS.filter(id => !have.has(id)).length;
+}
+
+/** Chapters the placed bricks open that are not yet persisted (or still template `[…]`). */
+export function missingGatedPresetSections(doc: Architecture): number {
+  const gates = deriveGates(aggregateConcerns(doc));
+  let n = 0;
+  for (const id of gates) {
+    const existing = doc.sections.find(s => s.id === id);
+    if (!existing) { n++; continue; }
+    if (!existing.doc?.gated && JSON.stringify(existing).includes(TODO)) n++;
+  }
+  return n;
 }
 
 /**
@@ -553,6 +576,89 @@ export function missingPresetSections(doc: Architecture): number {
  * that never pinned its tabs would grow the tab bar by thirteen. Writing the
  * current tabs down explicitly keeps the viewer exactly as it was.
  */
+
+/** Read-only projection of one preset chapter — does not mutate `doc`. */
+export function presetSectionForId(id: string, lang?: Lang): Section | undefined {
+  const spec = SECTIONS.find(section => section.id === id);
+  if (!spec) return undefined;
+  const l: Lang = lang ?? 'en';
+  return resolveDeep<Section>(spec, l);
+}
+
+/**
+ * Add, refresh, or remove preset chapters driven by placed components' concern tags.
+ * Gated sections are hydrated from catalog metadata on every sync — adding Cognito
+ * updates the IAM chapter; removing it drops Cognito from the text.
+ * Manual preset chapters (no `gated` flag) are never touched.
+ */
+export function syncGatedPresetSections(
+  doc: Architecture,
+  lang?: Lang,
+  opts?: { refresh?: boolean }
+): PresetResult {
+  const l: Lang = lang ?? (doc.meta?.lang === 'fr' ? 'fr' : 'en');
+  const refresh = opts?.refresh !== false;
+  const gates = deriveGates(aggregateConcerns(doc));
+  const removed: string[] = [];
+
+  doc.sections = doc.sections.filter(section => {
+    if (!section.doc?.gated) return true;
+    if (gates.has(section.id)) return true;
+    removed.push(section.id);
+    return false;
+  });
+
+  const added: string[] = [];
+  const kept: string[] = [];
+  const updated: string[] = [];
+
+  PRESET_SECTION_IDS.forEach(id => {
+    if (!gates.has(id)) return;
+    const existingIdx = doc.sections.findIndex(s => s.id === id);
+
+    if (existingIdx >= 0) {
+      const existing = doc.sections[existingIdx];
+      const templateLike = JSON.stringify(existing).includes(TODO);
+      if (!existing.doc?.gated) {
+        if (!templateLike) {
+          kept.push(id);
+          return;
+        }
+        /* Manual CAF pack still full of placeholders — adopt as gated and fill. */
+      } else if (!refresh && !templateLike) {
+        kept.push(id);
+        return;
+      }
+      const raw = presetSectionForId(id, l);
+      if (!raw) return;
+      const hydrated = hydratePresetSection(raw, doc, l);
+      doc.sections[existingIdx] = {
+        ...hydrated,
+        id,
+        doc: { chapter: hydrated.doc?.chapter, gated: true }
+      };
+      updated.push(id);
+      return;
+    }
+
+    const raw = presetSectionForId(id, l);
+    if (!raw) return;
+    const hydrated = hydratePresetSection(raw, doc, l);
+    doc.sections.push({
+      ...hydrated,
+      doc: { chapter: hydrated.doc?.chapter, gated: true }
+    });
+    added.push(id);
+  });
+
+  return {
+    added,
+    kept,
+    updated: updated.length ? updated : undefined,
+    removed: removed.length ? removed : undefined
+  };
+}
+
 export function applyDesignDocumentPreset(doc: Architecture, lang?: Lang): PresetResult {
   const l: Lang = lang ?? (doc.meta?.lang === 'fr' ? 'fr' : 'en');
 

--- a/src/lib/flows/catalog.ts
+++ b/src/lib/flows/catalog.ts
@@ -587,9 +587,12 @@ export const FLOW_CATALOG: FlowTemplate[] = [
  * whole structure, so hints — which are plain string arrays — pass through
  * untouched while every `{ en, fr }` pair collapses to its variant.
  */
-export function resolveCatalog(lang: Lang): FlowPattern[] {
+export function resolveCatalogFromCode(lang: Lang): FlowPattern[] {
   return FLOW_CATALOG.map(tpl => ({
     ...resolveDeep<Omit<FlowPattern, 'source'>>(tpl, lang),
     source: 'catalog' as const
   }));
 }
+
+/** @deprecated import resolve-catalog.server for runtime; tests use code catalog */
+export const resolveCatalog = resolveCatalogFromCode;

--- a/src/lib/flows/resolve-catalog.server.ts
+++ b/src/lib/flows/resolve-catalog.server.ts
@@ -1,0 +1,14 @@
+import { contentFromAdmin } from '../admin/flags';
+import { getPublishedFlowCatalog } from '../admin/flow-patterns';
+import { resolveCatalogFromCode } from './catalog';
+import type { FlowPattern } from './types';
+import type { Lang } from '../templates/types';
+
+/** Runtime catalogue — admin published when flag on, else code seed. */
+export function resolveCatalog(lang: Lang): FlowPattern[] {
+  if (contentFromAdmin()) {
+    const fromAdmin = getPublishedFlowCatalog(lang);
+    if (fromAdmin.length > 0) return fromAdmin;
+  }
+  return resolveCatalogFromCode(lang);
+}

--- a/src/lib/layers.ts
+++ b/src/lib/layers.ts
@@ -2,7 +2,8 @@
 
 type Lang = 'en' | 'fr';
 
-const LAYER_DISPLAY: Record<string, { en: string; fr: string }> = {
+/** Pack layer ids → bilingual display labels (admin system_copy seed source). */
+export const LAYER_DISPLAY: Record<string, { en: string; fr: string }> = {
   clients: { en: 'Clients', fr: 'Clients' },
   edge: { en: 'Edge & API', fr: 'Edge & API' },
   services: { en: 'Services', fr: 'Services' },
@@ -20,7 +21,12 @@ const LAYER_DISPLAY: Record<string, { en: string; fr: string }> = {
   destinations: { en: 'Destinations', fr: 'Destinations' }
 };
 
-/** Title-case free-form names; pack ids resolve to locked labels. */
+/**
+ * Title-case free-form names; pack ids resolve to locked labels.
+ * Code fallback for client canvas / place.ts. Server paths that need
+ * published system_copy overrides should call resolveLayerLabel from
+ * system-copy.resolve.server.ts (CONTENT_FROM_ADMIN=1 + published).
+ */
 export function displayLayerLabel(idOrName: string, lang: Lang = 'en'): string {
   if (!idOrName) return idOrName;
   const known = LAYER_DISPLAY[idOrName];

--- a/src/lib/lego/admin-catalog.test.ts
+++ b/src/lib/lego/admin-catalog.test.ts
@@ -1,0 +1,315 @@
+import { strict as assert } from 'node:assert';
+import { after, before, describe, test } from 'node:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const dbFile = path.join(os.tmpdir(), `archstudio-admin-catalog-${process.pid}.db`);
+process.env.DATABASE_PATH = dbFile;
+
+let Admin: typeof import('./admin-catalog');
+let Repo: typeof import('./repository');
+let DB: typeof import('../db');
+
+before(async () => {
+  Admin = await import('./admin-catalog');
+  Repo = await import('./repository');
+  DB = await import('../db');
+});
+
+after(() => {
+  for (const f of [dbFile, `${dbFile}-wal`, `${dbFile}-shm`]) fs.rmSync(f, { force: true });
+});
+
+describe('admin catalog', { concurrency: 1 }, () => {
+  test('ISC-A1: updateAdminBrick purposeFr is returned by legoCatalog(fr)', () => {
+    Repo.ensureLegoCatalog();
+    const purposeFr = 'Identité révisée pour le catalogue admin.';
+    Admin.updateAdminBrick('identity', { purposeFr });
+
+    const fr = Repo.legoCatalog('fr');
+    assert.equal(fr.bricks.identity?.purpose, purposeFr);
+  });
+
+  test('updateAdminBrick persists concernTags to lego_brick_concern_tags', () => {
+    Repo.ensureLegoCatalog();
+    Admin.updateAdminBrick('identity', { concernTags: ['iam', 'governance'] });
+
+    const tags = DB.plainAll<{ tag: string }>(
+      DB.db.prepare(
+        'SELECT tag FROM lego_brick_concern_tags WHERE catalog_version=? AND brick_id=? ORDER BY tag'
+      ).all(Repo.LEGO_CATALOG_VERSION, 'identity')
+    ).map(row => row.tag);
+
+    assert.deepEqual(tags.sort(), ['governance', 'iam']);
+    assert.deepEqual([...(Repo.legoCatalog('en').bricks.identity?.concernTags ?? [])].sort(), ['governance', 'iam']);
+  });
+
+  test('updateAdminBrick marks catalog dirty', () => {
+    Repo.ensureLegoCatalog();
+    Admin.updateAdminBrick('identity', { purposeEn: 'Revised identity purpose.' });
+    const state = Admin.getCatalogAdminState();
+    assert.equal(state.dirty, true);
+  });
+
+  test('ISC-A5: orphan variant maps_to missing brick is rejected at publish', () => {
+    Repo.ensureLegoCatalog();
+    const brickIds = new Set(['identity']);
+    const orphanIssues = Admin.variantRefIssues(
+      [{ id: 'orphan-test-variant', maps_to: 'missing-brick-id' }],
+      brickIds,
+    );
+    assert.ok(orphanIssues.some(issue => issue.code === 'orphan_variant' && issue.entityId === 'orphan-test-variant'));
+    assert.equal(Admin.validateCatalogPublish().some(issue => issue.code === 'orphan_variant'), false);
+
+    const saved = DB.plain<{ role: string }>(
+      DB.db.prepare(
+        'SELECT role FROM lego_brick_texts WHERE catalog_version=? AND brick_id=? AND lang=?'
+      ).get(Repo.LEGO_CATALOG_VERSION, 'identity', 'fr')
+    );
+    DB.db.prepare(
+      'UPDATE lego_brick_texts SET role=? WHERE catalog_version=? AND brick_id=? AND lang=?'
+    ).run('', Repo.LEGO_CATALOG_VERSION, 'identity', 'fr');
+
+    const publishResult = Admin.publishCatalog();
+    assert.equal(publishResult.ok, false);
+    if (!publishResult.ok) {
+      assert.ok(publishResult.issues.some(issue => issue.code === 'missing_role'));
+    }
+
+    DB.db.prepare(
+      'UPDATE lego_brick_texts SET role=? WHERE catalog_version=? AND brick_id=? AND lang=?'
+    ).run(saved.role, Repo.LEGO_CATALOG_VERSION, 'identity', 'fr');
+  });
+
+  test('validateCatalogPublish has no orphan dependencies on fresh seed', () => {
+    Repo.ensureLegoCatalog();
+    const issues = Admin.validateCatalogPublish();
+    assert.equal(
+      issues.filter(issue => issue.code === 'orphan_dependency').length,
+      0,
+      issues.map(issue => issue.message).join('; '),
+    );
+  });
+
+  test('publishCatalog clears dirty flag when catalog is valid', () => {
+    Repo.ensureLegoCatalog();
+    Admin.updateAdminBrick('identity', { purposeFr: 'But révisé pour publication.' });
+    assert.equal(Admin.getCatalogAdminState().dirty, true);
+
+    const result = Admin.publishCatalog();
+    assert.equal(result.ok, true, !result.ok ? result.issues.map(issue => issue.message).join('; ') : '');
+    const state = Admin.getCatalogAdminState();
+    assert.equal(state.dirty, false);
+    if (result.ok) assert.ok(state.publishedAt);
+  });
+
+  test('validateAdminBrick rejects missing roles before save', () => {
+    Repo.ensureLegoCatalog();
+    const saved = DB.plain<{ role: string }>(
+      DB.db.prepare(
+        'SELECT role FROM lego_brick_texts WHERE catalog_version=? AND brick_id=? AND lang=?'
+      ).get(Repo.LEGO_CATALOG_VERSION, 'identity', 'fr')
+    );
+    DB.db.prepare(
+      'UPDATE lego_brick_texts SET role=? WHERE catalog_version=? AND brick_id=? AND lang=?'
+    ).run('', Repo.LEGO_CATALOG_VERSION, 'identity', 'fr');
+
+    const issues = Admin.validateAdminBrick('identity');
+    assert.ok(issues.some(issue => issue.code === 'missing_role' && issue.field === 'roleFr'));
+    assert.throws(() => Admin.updateAdminBrick('identity', { purposeFr: 'Sans rôle FR.' }));
+
+    DB.db.prepare(
+      'UPDATE lego_brick_texts SET role=? WHERE catalog_version=? AND brick_id=? AND lang=?'
+    ).run(saved.role, Repo.LEGO_CATALOG_VERSION, 'identity', 'fr');
+  });
+
+  test('ensureLegoCatalog yields 40 bricks', () => {
+    Repo.ensureLegoCatalog();
+    const counts = Repo.legoCatalogCounts();
+    assert.equal(counts.lego_bricks, 40);
+  });
+
+  test('updateScope persists and marks dirty', () => {
+    Repo.ensureLegoCatalog();
+    Admin.updateScope('product', { labelEn: 'Product revised', labelFr: 'Produit révisé' });
+    const scope = Admin.listScopes().find(row => row.id === 'product');
+    assert.equal(scope?.labelEn, 'Product revised');
+    assert.equal(scope?.labelFr, 'Produit révisé');
+    assert.equal(Admin.getCatalogAdminState().dirty, true);
+  });
+
+  test('create and delete custom scope; locked scope re-seeds', () => {
+    Repo.ensureLegoCatalog();
+    const id = Admin.createScope({ labelEn: 'Custom scope probe', labelFr: 'Scope perso' });
+    assert.ok(id);
+    assert.equal(Admin.isLockedScope(id), false);
+    assert.ok(Admin.listScopes().some(row => row.id === id));
+    Admin.deleteScope(id);
+    assert.equal(Admin.listScopes().some(row => row.id === id), false);
+
+    Admin.deleteScope('edge');
+    const gone = !DB.db.prepare('SELECT 1 FROM lego_scopes WHERE catalog_version=? AND id=?')
+      .get(Repo.LEGO_CATALOG_VERSION, 'edge');
+    assert.equal(gone, true);
+    Repo.ensureLegoCatalog();
+    assert.ok(Admin.listScopes().some(row => row.id === 'edge'));
+    assert.equal(Admin.isLockedScope('edge'), true);
+  });
+
+  test('create and delete custom intent; locked intent re-seeds', () => {
+    Repo.ensureLegoCatalog();
+    const id = Admin.createIntent({
+      label: 'Custom intent probe',
+      modes: ['cloud', 'selfhosted'],
+      shapes: ['gateway'],
+    });
+    assert.ok(id);
+    assert.equal(Admin.isLockedIntent(id), false);
+    const created = Admin.getIntent(id);
+    assert.equal(created?.label, 'Custom intent probe');
+    assert.deepEqual(created?.modes, ['cloud', 'selfhosted']);
+    assert.deepEqual(created?.shapes, ['gateway']);
+    Admin.deleteIntent(id);
+    assert.equal(Admin.getIntent(id), null);
+
+    Admin.deleteIntent('cdn');
+    const gone = !DB.db.prepare('SELECT 1 FROM lego_intents WHERE catalog_version=? AND id=?')
+      .get(Repo.LEGO_CATALOG_VERSION, 'cdn');
+    assert.equal(gone, true);
+    Repo.ensureLegoCatalog();
+    assert.ok(Admin.getIntent('cdn'));
+    assert.equal(Admin.isLockedIntent('cdn'), true);
+  });
+
+  test('create and delete custom variant; locked variant re-seeds', () => {
+    Repo.ensureLegoCatalog();
+    const id = Admin.createVariant({
+      label: 'Custom variant probe',
+      intent: 'web-app',
+      mode: 'client',
+      maps_to: 'webApp',
+    });
+    assert.ok(id);
+    assert.equal(Admin.isLockedVariant(id), false);
+    assert.ok(Admin.listVariants().some(row => row.id === id && row.maps_to === 'webApp'));
+    Admin.deleteVariant(id);
+    assert.equal(Admin.listVariants().some(row => row.id === id), false);
+
+    Admin.deleteVariant('nextjs');
+    const gone = !DB.db.prepare('SELECT 1 FROM lego_variants WHERE catalog_version=? AND id=?')
+      .get(Repo.LEGO_CATALOG_VERSION, 'nextjs');
+    assert.equal(gone, true);
+    Repo.ensureLegoCatalog();
+    assert.ok(Admin.listVariants().some(row => row.id === 'nextjs'));
+    assert.equal(Admin.isLockedVariant('nextjs'), true);
+  });
+
+  test('create and delete custom technology; locked technology re-seeds', () => {
+    Repo.ensureLegoCatalog();
+    const key = Admin.createTechnology({
+      key: 'custom-tech-probe',
+      en: 'Custom technology for admin CRUD.',
+      fr: 'Technologie perso pour le CRUD admin.',
+    });
+    assert.equal(key, 'custom-tech-probe');
+    assert.equal(Admin.isLockedTechnology(key), false);
+    assert.equal(Admin.listTechnologyDescriptions()[key]?.en, 'Custom technology for admin CRUD.');
+    Admin.deleteTechnology(key);
+    assert.equal(Admin.listTechnologyDescriptions()[key], undefined);
+
+    Admin.deleteTechnology('react');
+    const gone = !DB.db.prepare(
+      'SELECT 1 FROM lego_technology_descriptions WHERE catalog_version=? AND technology_key=? LIMIT 1'
+    ).get(Repo.LEGO_CATALOG_VERSION, 'react');
+    assert.equal(gone, true);
+    Repo.ensureLegoCatalog();
+    assert.ok(Admin.listTechnologyDescriptions().react?.en);
+    assert.equal(Admin.isLockedTechnology('react'), true);
+  });
+
+  test('create and delete dependency edge', () => {
+    Repo.ensureLegoCatalog();
+    const edge = Admin.createDependency({
+      from: 'webApp',
+      to: 'secrets',
+      strength: 'optional',
+      why_en: 'Probe dependency why EN.',
+      why_fr: 'Raison dépendance probe FR.',
+      protocol_id: 'rest',
+      kind: 'sync',
+    });
+    assert.deepEqual(edge, { from: 'webApp', to: 'secrets' });
+    assert.ok(Admin.listDependencies().some(row => row.from === 'webApp' && row.to === 'secrets'));
+    Admin.deleteDependency('webApp', 'secrets');
+    assert.equal(
+      Admin.listDependencies().some(row => row.from === 'webApp' && row.to === 'secrets'),
+      false,
+    );
+  });
+
+  test('create and delete custom brick; locked brick re-seeds', () => {
+    Repo.ensureLegoCatalog();
+    const id = Admin.createAdminBrick({
+      id: 'customProbeBrick',
+      icon: 'box',
+      layer: 'services',
+      defaultScope: 'product',
+      roleEn: 'Custom probe brick role.',
+      roleFr: 'Rôle brique probe personnalisée.',
+      purposeEn: 'Purpose EN.',
+      purposeFr: 'But FR.',
+      concernTags: ['governance'],
+    });
+    assert.equal(id, 'customProbeBrick');
+    assert.equal(Admin.isLockedBrick(id), false);
+    assert.ok(Repo.legoCatalog('en').bricks[id]);
+    Admin.deleteAdminBrick(id);
+    assert.equal(Repo.legoCatalog('en').bricks[id], undefined);
+
+    Admin.deleteAdminBrick('identity');
+    const gone = !DB.db.prepare('SELECT 1 FROM lego_bricks WHERE catalog_version=? AND id=?')
+      .get(Repo.LEGO_CATALOG_VERSION, 'identity');
+    assert.equal(gone, true);
+    Repo.ensureLegoCatalog();
+    assert.ok(Repo.legoCatalog('en').bricks.identity);
+    assert.equal(Admin.isLockedBrick('identity'), true);
+  });
+
+  test('createVariant rejects orphan maps_to', () => {
+    Repo.ensureLegoCatalog();
+    assert.throws(
+      () => Admin.createVariant({
+        label: 'Broken maps_to',
+        intent: 'web-app',
+        mode: 'client',
+        maps_to: 'missing-brick-id',
+      }),
+      /does not exist/,
+    );
+  });
+
+  test('createIntent rejects invalid hosting mode', () => {
+    Repo.ensureLegoCatalog();
+    assert.throws(
+      () => Admin.createIntent({
+        label: 'Bad mode',
+        modes: ['orbital' as 'cloud'],
+      }),
+      /Invalid hosting mode/,
+    );
+  });
+});
+
+describe('F-REG R1 regression: orphan_variant', { concurrency: 1 }, () => {
+  test('variantRefIssues emits orphan_variant for missing maps_to', () => {
+    const issues = Admin.variantRefIssues(
+      [{ id: 'freg-orphan', maps_to: 'no-brick' }],
+      new Set(['identity']),
+    );
+    assert.ok(
+      issues.some(i => i.code === 'orphan_variant' && i.entityId === 'freg-orphan'),
+      'orphan_variant gate must remain',
+    );
+  });
+});

--- a/src/lib/lego/admin-catalog.ts
+++ b/src/lib/lego/admin-catalog.ts
@@ -1,0 +1,943 @@
+import { db, now, plain, plainAll } from '../db';
+import { ICON_KEYS, slugify } from '../defaults';
+import { isConcernTag, type ConcernTag } from '../document/concerns';
+import { CATALOG_SEED } from './seed-data';
+import { ensureLegoCatalog, LEGO_CATALOG_VERSION } from './repository';
+
+import type { SeedHostingMode } from './seed-data';
+import type { HostingMode, LegoDependencyStrength, LegoIntent, LegoVariant } from './types';
+
+export const LOCKED_SCOPE_IDS = CATALOG_SEED.scopes.map(([id]) => id);
+export const LOCKED_INTENT_IDS = CATALOG_SEED.intents.map(intent => intent.id);
+export const LOCKED_VARIANT_IDS = CATALOG_SEED.variants.map(variant => variant.id);
+export const LOCKED_TECHNOLOGY_KEYS = Object.keys(CATALOG_SEED.technologyDescriptions);
+export const LOCKED_BRICK_IDS = [
+  ...new Set([
+    ...Object.keys(CATALOG_SEED.icons),
+    ...Object.keys(CATALOG_SEED.rolePhrases),
+    ...Object.keys(CATALOG_SEED.roleScopes),
+  ]),
+];
+
+export function isLockedScope(id: string): boolean {
+  return (LOCKED_SCOPE_IDS as readonly string[]).includes(id);
+}
+
+export function isLockedIntent(id: string): boolean {
+  return (LOCKED_INTENT_IDS as readonly string[]).includes(id);
+}
+
+export function isLockedVariant(id: string): boolean {
+  return (LOCKED_VARIANT_IDS as readonly string[]).includes(id);
+}
+
+export function isLockedTechnology(key: string): boolean {
+  return LOCKED_TECHNOLOGY_KEYS.includes(key);
+}
+
+export function isLockedBrick(id: string): boolean {
+  return LOCKED_BRICK_IDS.includes(id);
+}
+
+function catalogEntityId(raw: string, taken: string[]): string {
+  const trimmed = raw.trim();
+  if (/^[a-zA-Z][a-zA-Z0-9_-]*$/.test(trimmed) && !taken.includes(trimmed)) return trimmed;
+  return slugify(trimmed, taken);
+}
+
+export type ScopeAdminUpdate = { labelEn?: string; labelFr?: string };
+export type ScopeAdminCreate = { id?: string; labelEn: string; labelFr: string };
+export type IntentAdminUpdate = { label?: string; modes?: SeedHostingMode[]; shapes?: string[] };
+export type IntentAdminCreate = {
+  id?: string;
+  label: string;
+  modes?: SeedHostingMode[];
+  shapes?: string[];
+};
+export type VariantAdminUpdate = { label?: string; intent?: string; mode?: SeedHostingMode; maps_to?: string };
+export type VariantAdminCreate = {
+  id?: string;
+  label: string;
+  intent: string;
+  mode: SeedHostingMode;
+  maps_to: string;
+};
+export type DependencyAdminPatch = {
+  strength?: LegoDependencyStrength;
+  why_en?: string;
+  why_fr?: string;
+  protocol_id?: string;
+  kind?: 'sync' | 'async' | 'batch';
+};
+export type DependencyAdminCreate = {
+  from: string;
+  to: string;
+  strength?: LegoDependencyStrength;
+  why_en?: string;
+  why_fr?: string;
+  protocol_id?: string;
+  kind?: 'sync' | 'async' | 'batch';
+};
+export type TechnologyDescriptionUpdate = { en?: string; fr?: string };
+export type TechnologyAdminCreate = { key?: string; en: string; fr: string };
+export type BrickAdminCreate = {
+  id?: string;
+  icon?: string;
+  layer?: string;
+  defaultScope: string;
+  roleEn: string;
+  roleFr: string;
+  purposeEn?: string;
+  purposeFr?: string;
+  concernTags?: ConcernTag[];
+};
+
+const HOSTING_MODES = new Set<SeedHostingMode>(['client', 'baas', 'cloud', 'selfhosted']);
+
+function intentExists(intentId: string): boolean {
+  return Boolean(
+    db.prepare('SELECT 1 FROM lego_intents WHERE catalog_version=? AND id=?')
+      .get(LEGO_CATALOG_VERSION, intentId)
+  );
+}
+
+function variantExists(variantId: string): boolean {
+  return Boolean(
+    db.prepare('SELECT 1 FROM lego_variants WHERE catalog_version=? AND id=?')
+      .get(LEGO_CATALOG_VERSION, variantId)
+  );
+}
+
+function dependencyExists(from: string, to: string): boolean {
+  return Boolean(
+    db.prepare('SELECT 1 FROM lego_dependencies WHERE catalog_version=? AND from_brick=? AND to_brick=?')
+      .get(LEGO_CATALOG_VERSION, from, to)
+  );
+}
+
+function validateHostingModes(modes: SeedHostingMode[]): CatalogIssue[] {
+  const issues: CatalogIssue[] = [];
+  for (const mode of modes) {
+    if (!HOSTING_MODES.has(mode)) {
+      issues.push({ code: 'invalid_mode', message: `Invalid hosting mode "${mode}"`, field: 'modes' });
+    }
+  }
+  return issues;
+}
+
+/** Lists catalog scopes with EN/FR labels. */
+export function listScopes(): { id: string; labelEn: string; labelFr: string }[] {
+  ensureLegoCatalog();
+  return rows<{ id: string; label_en: string; label_fr: string }>(
+    'SELECT id, label_en, label_fr FROM lego_scopes WHERE catalog_version=? ORDER BY rowid',
+    LEGO_CATALOG_VERSION,
+  ).map(row => ({ id: row.id, labelEn: row.label_en, labelFr: row.label_fr }));
+}
+
+/** Updates a scope label and marks the catalog dirty. */
+export function updateScope(scopeId: string, payload: ScopeAdminUpdate): string {
+  ensureLegoCatalog();
+  if (!scopeExists(scopeId)) throw new Error(`Scope "${scopeId}" does not exist`);
+  if (payload.labelEn !== undefined && !payload.labelEn.trim()) throw new Error('English label cannot be empty');
+  if (payload.labelFr !== undefined && !payload.labelFr.trim()) throw new Error('French label cannot be empty');
+
+  const current = plain<{ label_en: string; label_fr: string }>(
+    db.prepare('SELECT label_en, label_fr FROM lego_scopes WHERE catalog_version=? AND id=?')
+      .get(LEGO_CATALOG_VERSION, scopeId)
+  );
+  db.prepare('UPDATE lego_scopes SET label_en=?, label_fr=? WHERE catalog_version=? AND id=?').run(
+    payload.labelEn ?? current.label_en,
+    payload.labelFr ?? current.label_fr,
+    LEGO_CATALOG_VERSION,
+    scopeId,
+  );
+  markCatalogDirty();
+  return scopeId;
+}
+
+/** Creates a catalog scope and marks the catalog dirty. */
+export function createScope(payload: ScopeAdminCreate): string {
+  ensureLegoCatalog();
+  if (!payload.labelEn.trim()) throw new Error('English label cannot be empty');
+  if (!payload.labelFr.trim()) throw new Error('French label cannot be empty');
+
+  const taken = listScopes().map(scope => scope.id);
+  const scopeId = catalogEntityId(payload.id?.trim() || payload.labelEn, taken);
+  if (scopeExists(scopeId)) throw new Error(`Scope "${scopeId}" already exists`);
+
+  db.prepare('INSERT INTO lego_scopes (catalog_version, id, label_en, label_fr) VALUES (?, ?, ?, ?)').run(
+    LEGO_CATALOG_VERSION,
+    scopeId,
+    payload.labelEn.trim(),
+    payload.labelFr.trim(),
+  );
+  markCatalogDirty();
+  return scopeId;
+}
+
+/** Deletes a catalog scope when no brick still uses it as default_scope. Affinities/aliases cascade. */
+export function deleteScope(scopeId: string): string {
+  ensureLegoCatalog();
+  if (!scopeExists(scopeId)) throw new Error(`Scope "${scopeId}" does not exist`);
+
+  const brickRaw = db.prepare('SELECT id FROM lego_bricks WHERE catalog_version=? AND default_scope_id=? LIMIT 1')
+    .get(LEGO_CATALOG_VERSION, scopeId);
+  if (brickRaw) {
+    const brickRef = plain<{ id: string }>(brickRaw);
+    throw new Error(`Cannot delete scope "${scopeId}" — still used as default scope by brick "${brickRef.id}"`);
+  }
+
+  db.prepare('DELETE FROM lego_scopes WHERE catalog_version=? AND id=?').run(LEGO_CATALOG_VERSION, scopeId);
+  markCatalogDirty();
+  return scopeId;
+}
+
+/** Lists catalog intents. */
+export function listIntents(): LegoIntent[] {
+  ensureLegoCatalog();
+  const version = LEGO_CATALOG_VERSION;
+  return rows<{ id: string; label: string }>('SELECT id, label FROM lego_intents WHERE catalog_version=? ORDER BY rowid', version).map(value => ({
+    ...value,
+    modes: rows<{ mode: string }>('SELECT mode FROM lego_intent_modes WHERE catalog_version=? AND intent_id=? ORDER BY position', version, value.id).map(row => row.mode as HostingMode),
+    shapes: rows<{ shape: string }>('SELECT shape FROM lego_intent_shapes WHERE catalog_version=? AND intent_id=? ORDER BY position', version, value.id).map(row => row.shape),
+  }));
+}
+
+/** Returns one catalog intent by id. */
+export function getIntent(intentId: string): LegoIntent | null {
+  return listIntents().find(intent => intent.id === intentId) ?? null;
+}
+
+/** Updates a catalog intent and marks the catalog dirty. */
+export function updateIntent(intentId: string, payload: IntentAdminUpdate): string {
+  ensureLegoCatalog();
+  if (!intentExists(intentId)) throw new Error(`Intent "${intentId}" does not exist`);
+  if (payload.label !== undefined && !payload.label.trim()) throw new Error('Intent label cannot be empty');
+  if (payload.modes !== undefined) {
+    const modeIssues = validateHostingModes(payload.modes);
+    if (modeIssues.length > 0) throw new Error(modeIssues.map(issue => issue.message).join('; '));
+  }
+
+  db.exec('BEGIN IMMEDIATE');
+  try {
+    if (payload.label !== undefined) {
+      db.prepare('UPDATE lego_intents SET label=? WHERE catalog_version=? AND id=?')
+        .run(payload.label, LEGO_CATALOG_VERSION, intentId);
+    }
+    if (payload.modes !== undefined) {
+      db.prepare('DELETE FROM lego_intent_modes WHERE catalog_version=? AND intent_id=?')
+        .run(LEGO_CATALOG_VERSION, intentId);
+      const mode = db.prepare('INSERT INTO lego_intent_modes VALUES (?, ?, ?, ?)');
+      payload.modes.forEach((modeValue, position) => mode.run(LEGO_CATALOG_VERSION, intentId, modeValue, position));
+    }
+    if (payload.shapes !== undefined) {
+      db.prepare('DELETE FROM lego_intent_shapes WHERE catalog_version=? AND intent_id=?')
+        .run(LEGO_CATALOG_VERSION, intentId);
+      const shape = db.prepare('INSERT INTO lego_intent_shapes VALUES (?, ?, ?, ?)');
+      payload.shapes.forEach((shapeValue, position) => shape.run(LEGO_CATALOG_VERSION, intentId, shapeValue, position));
+    }
+    markCatalogDirty();
+    db.exec('COMMIT');
+  } catch (error) {
+    db.exec('ROLLBACK');
+    throw error;
+  }
+  return intentId;
+}
+
+/** Creates a catalog intent and marks the catalog dirty. */
+export function createIntent(payload: IntentAdminCreate): string {
+  ensureLegoCatalog();
+  if (!payload.label.trim()) throw new Error('Intent label cannot be empty');
+  const modes = payload.modes ?? ['cloud'];
+  const modeIssues = validateHostingModes(modes);
+  if (modeIssues.length > 0) throw new Error(modeIssues.map(issue => issue.message).join('; '));
+
+  const taken = listIntents().map(intent => intent.id);
+  const intentId = catalogEntityId(payload.id?.trim() || payload.label, taken);
+  if (intentExists(intentId)) throw new Error(`Intent "${intentId}" already exists`);
+
+  db.exec('BEGIN IMMEDIATE');
+  try {
+    db.prepare('INSERT INTO lego_intents (catalog_version, id, label) VALUES (?, ?, ?)')
+      .run(LEGO_CATALOG_VERSION, intentId, payload.label.trim());
+    const mode = db.prepare('INSERT INTO lego_intent_modes VALUES (?, ?, ?, ?)');
+    modes.forEach((modeValue, position) => mode.run(LEGO_CATALOG_VERSION, intentId, modeValue, position));
+    if (payload.shapes?.length) {
+      const shape = db.prepare('INSERT INTO lego_intent_shapes VALUES (?, ?, ?, ?)');
+      payload.shapes.forEach((shapeValue, position) => shape.run(LEGO_CATALOG_VERSION, intentId, shapeValue, position));
+    }
+    markCatalogDirty();
+    db.exec('COMMIT');
+  } catch (error) {
+    db.exec('ROLLBACK');
+    throw error;
+  }
+  return intentId;
+}
+
+/** Deletes a catalog intent (cascades dependent variants; locked rows re-seed on ensure). */
+export function deleteIntent(intentId: string): string {
+  ensureLegoCatalog();
+  if (!intentExists(intentId)) throw new Error(`Intent "${intentId}" does not exist`);
+
+  db.exec('BEGIN IMMEDIATE');
+  try {
+    db.prepare('DELETE FROM lego_variants WHERE catalog_version=? AND intent_id=?')
+      .run(LEGO_CATALOG_VERSION, intentId);
+    db.prepare('DELETE FROM lego_intent_shapes WHERE catalog_version=? AND intent_id=?')
+      .run(LEGO_CATALOG_VERSION, intentId);
+    db.prepare('DELETE FROM lego_intent_modes WHERE catalog_version=? AND intent_id=?')
+      .run(LEGO_CATALOG_VERSION, intentId);
+    db.prepare('DELETE FROM lego_intents WHERE catalog_version=? AND id=?')
+      .run(LEGO_CATALOG_VERSION, intentId);
+    markCatalogDirty();
+    db.exec('COMMIT');
+  } catch (error) {
+    db.exec('ROLLBACK');
+    throw error;
+  }
+  return intentId;
+}
+
+/** Lists catalog variants. */
+export function listVariants(): LegoVariant[] {
+  ensureLegoCatalog();
+  return rows<{ id: string; intent: string; label: string; mode: LegoVariant['mode']; maps_to: string }>(
+    'SELECT id, intent_id AS intent, label, mode, brick_id AS maps_to FROM lego_variants WHERE catalog_version=? ORDER BY rowid',
+    LEGO_CATALOG_VERSION,
+  );
+}
+
+/** Updates a catalog variant and marks the catalog dirty. */
+export function updateVariant(variantId: string, payload: VariantAdminUpdate): string {
+  ensureLegoCatalog();
+  if (!variantExists(variantId)) throw new Error(`Variant "${variantId}" does not exist`);
+  if (payload.label !== undefined && !payload.label.trim()) throw new Error('Variant label cannot be empty');
+  if (payload.intent !== undefined && !intentExists(payload.intent)) throw new Error(`Intent "${payload.intent}" does not exist`);
+  if (payload.maps_to !== undefined && !brickExists(payload.maps_to)) throw new Error(`Brick "${payload.maps_to}" does not exist`);
+  if (payload.mode !== undefined && !HOSTING_MODES.has(payload.mode)) throw new Error(`Invalid hosting mode "${payload.mode}"`);
+
+  const current = plain<{ intent_id: string; label: string; mode: LegoVariant['mode']; brick_id: string }>(
+    db.prepare('SELECT intent_id, label, mode, brick_id FROM lego_variants WHERE catalog_version=? AND id=?')
+      .get(LEGO_CATALOG_VERSION, variantId)
+  );
+  db.prepare('UPDATE lego_variants SET intent_id=?, label=?, mode=?, brick_id=? WHERE catalog_version=? AND id=?').run(
+    payload.intent ?? current.intent_id,
+    payload.label ?? current.label,
+    payload.mode ?? current.mode,
+    payload.maps_to ?? current.brick_id,
+    LEGO_CATALOG_VERSION,
+    variantId,
+  );
+  markCatalogDirty();
+  return variantId;
+}
+
+/** Creates a catalog variant and marks the catalog dirty. */
+export function createVariant(payload: VariantAdminCreate): string {
+  ensureLegoCatalog();
+  if (!payload.label.trim()) throw new Error('Variant label cannot be empty');
+  if (!intentExists(payload.intent)) throw new Error(`Intent "${payload.intent}" does not exist`);
+  if (!brickExists(payload.maps_to)) throw new Error(`Brick "${payload.maps_to}" does not exist`);
+  if (!HOSTING_MODES.has(payload.mode)) throw new Error(`Invalid hosting mode "${payload.mode}"`);
+
+  const taken = listVariants().map(variant => variant.id);
+  const variantId = catalogEntityId(payload.id?.trim() || payload.label, taken);
+  if (variantExists(variantId)) throw new Error(`Variant "${variantId}" already exists`);
+
+  db.prepare(
+    'INSERT INTO lego_variants (catalog_version, id, intent_id, label, mode, brick_id) VALUES (?, ?, ?, ?, ?, ?)'
+  ).run(
+    LEGO_CATALOG_VERSION,
+    variantId,
+    payload.intent,
+    payload.label.trim(),
+    payload.mode,
+    payload.maps_to,
+  );
+  markCatalogDirty();
+  return variantId;
+}
+
+/** Deletes a catalog variant. */
+export function deleteVariant(variantId: string): string {
+  ensureLegoCatalog();
+  if (!variantExists(variantId)) throw new Error(`Variant "${variantId}" does not exist`);
+  db.prepare('DELETE FROM lego_variants WHERE catalog_version=? AND id=?')
+    .run(LEGO_CATALOG_VERSION, variantId);
+  markCatalogDirty();
+  return variantId;
+}
+
+/** Lists catalog dependency suggestions. */
+export function listDependencies() {
+  ensureLegoCatalog();
+  return rows<{ from: string; to: string; strength: LegoDependencyStrength; why_en: string; why_fr: string; protocol_id: string; kind: 'sync' | 'async' | 'batch' }>(
+    'SELECT from_brick AS "from", to_brick AS "to", strength, why_en, why_fr, protocol_id, kind FROM lego_dependencies WHERE catalog_version=? ORDER BY rowid',
+    LEGO_CATALOG_VERSION,
+  );
+}
+
+/** Updates a dependency edge and marks the catalog dirty. */
+export function updateDependency(from: string, to: string, patch: DependencyAdminPatch): { from: string; to: string } {
+  ensureLegoCatalog();
+  if (!dependencyExists(from, to)) throw new Error(`Dependency from "${from}" to "${to}" does not exist`);
+  if (!brickExists(from) || !brickExists(to)) throw new Error('Dependency endpoints must reference existing bricks');
+
+  const current = plain<{ strength: LegoDependencyStrength; why_en: string; why_fr: string; protocol_id: string; kind: 'sync' | 'async' | 'batch' }>(
+    db.prepare('SELECT strength, why_en, why_fr, protocol_id, kind FROM lego_dependencies WHERE catalog_version=? AND from_brick=? AND to_brick=?')
+      .get(LEGO_CATALOG_VERSION, from, to)
+  );
+  db.prepare(
+    'UPDATE lego_dependencies SET strength=?, why_en=?, why_fr=?, protocol_id=?, kind=? WHERE catalog_version=? AND from_brick=? AND to_brick=?'
+  ).run(
+    patch.strength ?? current.strength,
+    patch.why_en ?? current.why_en,
+    patch.why_fr ?? current.why_fr,
+    patch.protocol_id ?? current.protocol_id,
+    patch.kind ?? current.kind,
+    LEGO_CATALOG_VERSION,
+    from,
+    to,
+  );
+  markCatalogDirty();
+  return { from, to };
+}
+
+/** Creates a dependency edge and marks the catalog dirty. */
+export function createDependency(payload: DependencyAdminCreate): { from: string; to: string } {
+  ensureLegoCatalog();
+  const from = payload.from.trim();
+  const to = payload.to.trim();
+  if (!from || !to) throw new Error('from and to are required');
+  if (from === to) throw new Error('Dependency endpoints must be different bricks');
+  if (!brickExists(from) || !brickExists(to)) throw new Error('Dependency endpoints must reference existing bricks');
+  if (dependencyExists(from, to)) throw new Error(`Dependency from "${from}" to "${to}" already exists`);
+
+  const strength = payload.strength ?? 'recommended';
+  const kind = payload.kind ?? 'sync';
+  if (!['required', 'recommended', 'optional'].includes(strength)) {
+    throw new Error(`Invalid strength "${strength}"`);
+  }
+  if (!['sync', 'async', 'batch'].includes(kind)) {
+    throw new Error(`Invalid kind "${kind}"`);
+  }
+
+  db.prepare(
+    'INSERT INTO lego_dependencies (catalog_version, from_brick, to_brick, strength, why_en, why_fr, protocol_id, kind) VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
+  ).run(
+    LEGO_CATALOG_VERSION,
+    from,
+    to,
+    strength,
+    (payload.why_en ?? '').trim() || `Depends on ${to}`,
+    (payload.why_fr ?? '').trim() || `Dépend de ${to}`,
+    (payload.protocol_id ?? '').trim() || 'http',
+    kind,
+  );
+  markCatalogDirty();
+  return { from, to };
+}
+
+/** Deletes a dependency edge and marks the catalog dirty. */
+export function deleteDependency(from: string, to: string): { from: string; to: string } {
+  ensureLegoCatalog();
+  if (!dependencyExists(from, to)) throw new Error(`Dependency from "${from}" to "${to}" does not exist`);
+  db.prepare('DELETE FROM lego_dependencies WHERE catalog_version=? AND from_brick=? AND to_brick=?')
+    .run(LEGO_CATALOG_VERSION, from, to);
+  markCatalogDirty();
+  return { from, to };
+}
+
+/** Lists technology descriptions keyed by technology id. */
+export function listTechnologyDescriptions(): Record<string, { en: string; fr: string }> {
+  ensureLegoCatalog();
+  const version = LEGO_CATALOG_VERSION;
+  const keys = rows<{ technology_key: string }>(
+    'SELECT DISTINCT technology_key FROM lego_technology_descriptions WHERE catalog_version=? ORDER BY technology_key',
+    version,
+  ).map(row => row.technology_key);
+  const result: Record<string, { en: string; fr: string }> = {};
+  for (const key of keys) {
+    const en = plain<{ description: string } | undefined>(
+      db.prepare('SELECT description FROM lego_technology_descriptions WHERE catalog_version=? AND technology_key=? AND lang=?')
+        .get(version, key, 'en')
+    )?.description ?? '';
+    const fr = plain<{ description: string } | undefined>(
+      db.prepare('SELECT description FROM lego_technology_descriptions WHERE catalog_version=? AND technology_key=? AND lang=?')
+        .get(version, key, 'fr')
+    )?.description ?? '';
+    result[key] = { en, fr };
+  }
+  return result;
+}
+
+/** Updates technology descriptions and marks the catalog dirty. */
+export function updateTechnologyDescription(key: string, payload: TechnologyDescriptionUpdate): string {
+  ensureLegoCatalog();
+  if (!key.trim()) throw new Error('Technology key cannot be empty');
+  if (payload.en !== undefined && !payload.en.trim()) throw new Error('English description cannot be empty');
+  if (payload.fr !== undefined && !payload.fr.trim()) throw new Error('French description cannot be empty');
+
+  const version = LEGO_CATALOG_VERSION;
+  const exists = Boolean(
+    db.prepare('SELECT 1 FROM lego_technology_descriptions WHERE catalog_version=? AND technology_key=? LIMIT 1')
+      .get(version, key)
+  );
+  if (!exists) throw new Error(`Technology "${key}" does not exist`);
+
+  for (const lang of ['en', 'fr'] as const) {
+    const value = lang === 'en' ? payload.en : payload.fr;
+    if (value === undefined) continue;
+    db.prepare('UPDATE lego_technology_descriptions SET description=? WHERE catalog_version=? AND technology_key=? AND lang=?')
+      .run(value, version, key, lang);
+  }
+  markCatalogDirty();
+  return key;
+}
+
+/** Creates technology descriptions and marks the catalog dirty. */
+export function createTechnologyDescription(payload: TechnologyAdminCreate): string {
+  ensureLegoCatalog();
+  if (!payload.en.trim()) throw new Error('English description cannot be empty');
+  if (!payload.fr.trim()) throw new Error('French description cannot be empty');
+
+  const existing = Object.keys(listTechnologyDescriptions());
+  const rawKey = payload.key?.trim() || payload.en.slice(0, 40);
+  const key = /^[a-z0-9][a-z0-9 ._-]*$/i.test(rawKey) && !existing.includes(rawKey)
+    ? rawKey.toLowerCase()
+    : slugify(rawKey, existing);
+  if (!key.trim()) throw new Error('Technology key cannot be empty');
+  if (existing.includes(key)) throw new Error(`Technology "${key}" already exists`);
+
+  const version = LEGO_CATALOG_VERSION;
+  db.exec('BEGIN IMMEDIATE');
+  try {
+    db.prepare(
+      'INSERT INTO lego_technology_descriptions (catalog_version, technology_key, lang, description) VALUES (?, ?, ?, ?)'
+    ).run(version, key, 'en', payload.en.trim());
+    db.prepare(
+      'INSERT INTO lego_technology_descriptions (catalog_version, technology_key, lang, description) VALUES (?, ?, ?, ?)'
+    ).run(version, key, 'fr', payload.fr.trim());
+    markCatalogDirty();
+    db.exec('COMMIT');
+  } catch (error) {
+    db.exec('ROLLBACK');
+    throw error;
+  }
+  return key;
+}
+
+/** Deletes technology descriptions for a key. */
+export function deleteTechnologyDescription(key: string): string {
+  ensureLegoCatalog();
+  if (!key.trim()) throw new Error('Technology key cannot be empty');
+  const exists = Boolean(
+    db.prepare('SELECT 1 FROM lego_technology_descriptions WHERE catalog_version=? AND technology_key=? LIMIT 1')
+      .get(LEGO_CATALOG_VERSION, key)
+  );
+  if (!exists) throw new Error(`Technology "${key}" does not exist`);
+
+  db.prepare('DELETE FROM lego_technology_descriptions WHERE catalog_version=? AND technology_key=?')
+    .run(LEGO_CATALOG_VERSION, key);
+  markCatalogDirty();
+  return key;
+}
+
+/** Alias for Designer CRUD naming. */
+export const createTechnology = createTechnologyDescription;
+/** Alias for Designer CRUD naming. */
+export const deleteTechnology = deleteTechnologyDescription;
+
+export type CatalogIssue = {
+  code: string;
+  message: string;
+  field?: string;
+  entityId?: string;
+};
+
+export type BrickAdminUpdate = {
+  icon?: string;
+  layer?: string;
+  defaultScope?: string;
+  concernTags?: ConcernTag[];
+  purposeEn?: string;
+  purposeFr?: string;
+  roleEn?: string;
+  roleFr?: string;
+};
+
+const ICON_KEY_SET = new Set<string>(ICON_KEYS);
+
+function rows<T>(sql: string, ...values: any[]) {
+  return plainAll<T>(db.prepare(sql).all(...values));
+}
+
+function markCatalogDirty(): void {
+  db.prepare(
+    'UPDATE admin_catalog_state SET dirty=1, updated_at=? WHERE catalog_version=?'
+  ).run(now(), LEGO_CATALOG_VERSION);
+}
+
+function brickExists(brickId: string): boolean {
+  return Boolean(
+    db.prepare('SELECT 1 FROM lego_bricks WHERE catalog_version=? AND id=?')
+      .get(LEGO_CATALOG_VERSION, brickId)
+  );
+}
+
+function scopeExists(scopeId: string): boolean {
+  return Boolean(
+    db.prepare('SELECT 1 FROM lego_scopes WHERE catalog_version=? AND id=?')
+      .get(LEGO_CATALOG_VERSION, scopeId)
+  );
+}
+
+function readBrickText(brickId: string, lang: 'en' | 'fr'): { role: string; purpose: string } | null {
+  const row = plain<{ role: string; purpose: string } | undefined>(
+    db.prepare('SELECT role, purpose FROM lego_brick_texts WHERE catalog_version=? AND brick_id=? AND lang=?')
+      .get(LEGO_CATALOG_VERSION, brickId, lang)
+  );
+  return row ?? null;
+}
+
+/** Brick-level i18n and field validation before save. */
+export function validateAdminBrick(brickId: string, payload: BrickAdminUpdate = {}): CatalogIssue[] {
+  ensureLegoCatalog();
+  const issues: CatalogIssue[] = [];
+
+  if (!brickExists(brickId)) {
+    issues.push({ code: 'brick_not_found', message: `Brick "${brickId}" does not exist`, entityId: brickId });
+    return issues;
+  }
+
+  if (payload.icon !== undefined && !ICON_KEY_SET.has(payload.icon)) {
+    issues.push({ code: 'invalid_icon', message: `Icon "${payload.icon}" is not in ICON_KEYS`, field: 'icon', entityId: brickId });
+  }
+
+  if (payload.layer !== undefined && !payload.layer.trim()) {
+    issues.push({ code: 'empty_layer', message: 'Layer cannot be empty', field: 'layer', entityId: brickId });
+  }
+
+  if (payload.defaultScope !== undefined && !scopeExists(payload.defaultScope)) {
+    issues.push({
+      code: 'invalid_scope',
+      message: `Scope "${payload.defaultScope}" does not exist`,
+      field: 'defaultScope',
+      entityId: brickId,
+    });
+  }
+
+  if (payload.concernTags !== undefined) {
+    for (const tag of payload.concernTags) {
+      if (!isConcernTag(tag)) {
+        issues.push({ code: 'invalid_concern_tag', message: `Invalid concern tag "${tag}"`, field: 'concernTags', entityId: brickId });
+      }
+    }
+  }
+
+  const roleEn = payload.roleEn ?? readBrickText(brickId, 'en')?.role ?? '';
+  const roleFr = payload.roleFr ?? readBrickText(brickId, 'fr')?.role ?? '';
+  if (!roleEn.trim()) {
+    issues.push({ code: 'missing_role', message: 'English role is required', field: 'roleEn', entityId: brickId });
+  }
+  if (!roleFr.trim()) {
+    issues.push({ code: 'missing_role', message: 'French role is required', field: 'roleFr', entityId: brickId });
+  }
+
+  return issues;
+}
+
+/** Updates a catalog brick and marks the catalog dirty. */
+export function updateAdminBrick(brickId: string, payload: BrickAdminUpdate): string {
+  ensureLegoCatalog();
+  const issues = validateAdminBrick(brickId, payload);
+  if (issues.length > 0) {
+    throw new Error(issues.map(issue => issue.message).join('; '));
+  }
+
+  db.exec('BEGIN IMMEDIATE');
+  try {
+    if (payload.icon !== undefined || payload.layer !== undefined || payload.defaultScope !== undefined) {
+      const current = plain<{ icon: string; layer_id: string; default_scope_id: string }>(
+        db.prepare('SELECT icon, layer_id, default_scope_id FROM lego_bricks WHERE catalog_version=? AND id=?')
+          .get(LEGO_CATALOG_VERSION, brickId)
+      );
+      db.prepare(
+        'UPDATE lego_bricks SET icon=?, layer_id=?, default_scope_id=? WHERE catalog_version=? AND id=?'
+      ).run(
+        payload.icon ?? current.icon,
+        payload.layer ?? current.layer_id,
+        payload.defaultScope ?? current.default_scope_id,
+        LEGO_CATALOG_VERSION,
+        brickId,
+      );
+    }
+
+    for (const lang of ['en', 'fr'] as const) {
+      const roleKey = lang === 'en' ? 'roleEn' : 'roleFr';
+      const purposeKey = lang === 'en' ? 'purposeEn' : 'purposeFr';
+      if (payload[roleKey] !== undefined || payload[purposeKey] !== undefined) {
+        const current = readBrickText(brickId, lang)!;
+        db.prepare(
+          'UPDATE lego_brick_texts SET role=?, purpose=? WHERE catalog_version=? AND brick_id=? AND lang=?'
+        ).run(
+          payload[roleKey] ?? current.role,
+          payload[purposeKey] ?? current.purpose,
+          LEGO_CATALOG_VERSION,
+          brickId,
+          lang,
+        );
+      }
+    }
+
+    if (payload.concernTags !== undefined) {
+      db.prepare('DELETE FROM lego_brick_concern_tags WHERE catalog_version=? AND brick_id=?')
+        .run(LEGO_CATALOG_VERSION, brickId);
+      const insert = db.prepare('INSERT INTO lego_brick_concern_tags VALUES (?, ?, ?)');
+      for (const tag of payload.concernTags) insert.run(LEGO_CATALOG_VERSION, brickId, tag);
+    }
+
+    markCatalogDirty();
+    db.exec('COMMIT');
+  } catch (error) {
+    db.exec('ROLLBACK');
+    throw error;
+  }
+
+  return brickId;
+}
+
+/** Creates a catalog brick with EN/FR texts and marks the catalog dirty. */
+export function createAdminBrick(payload: BrickAdminCreate): string {
+  ensureLegoCatalog();
+  if (!payload.roleEn.trim()) throw new Error('English role is required');
+  if (!payload.roleFr.trim()) throw new Error('French role is required');
+  if (!scopeExists(payload.defaultScope)) throw new Error(`Scope "${payload.defaultScope}" does not exist`);
+
+  const icon = payload.icon ?? 'box';
+  if (!ICON_KEY_SET.has(icon)) throw new Error(`Icon "${icon}" is not in ICON_KEYS`);
+
+  const layer = (payload.layer ?? 'services').trim();
+  if (!layer) throw new Error('Layer cannot be empty');
+
+  if (payload.concernTags) {
+    for (const tag of payload.concernTags) {
+      if (!isConcernTag(tag)) throw new Error(`Invalid concern tag "${tag}"`);
+    }
+  }
+
+  const taken = rows<{ id: string }>('SELECT id FROM lego_bricks WHERE catalog_version=?', LEGO_CATALOG_VERSION)
+    .map(row => row.id);
+  const brickId = catalogEntityId(payload.id?.trim() || payload.roleEn.slice(0, 40), taken);
+  if (brickExists(brickId)) throw new Error(`Brick "${brickId}" already exists`);
+
+  const version = LEGO_CATALOG_VERSION;
+  db.exec('BEGIN IMMEDIATE');
+  try {
+    db.prepare(
+      'INSERT INTO lego_bricks (catalog_version, id, icon, layer_id, default_scope_id, capabilities_json) VALUES (?, ?, ?, ?, ?, ?)'
+    ).run(version, brickId, icon, layer, payload.defaultScope, '[]');
+
+    const text = db.prepare(
+      'INSERT INTO lego_brick_texts (catalog_version, brick_id, lang, role, responsibilities_json, notes_json, purpose) VALUES (?, ?, ?, ?, ?, ?, ?)'
+    );
+    const phrase = db.prepare(
+      'INSERT INTO lego_capability_phrases (catalog_version, brick_id, lang, phrase) VALUES (?, ?, ?, ?)'
+    );
+    text.run(version, brickId, 'en', payload.roleEn.trim(), '[]', '[]', (payload.purposeEn ?? payload.roleEn).trim());
+    text.run(version, brickId, 'fr', payload.roleFr.trim(), '[]', '[]', (payload.purposeFr ?? payload.roleFr).trim());
+    phrase.run(version, brickId, 'en', payload.roleEn.trim());
+    phrase.run(version, brickId, 'fr', payload.roleFr.trim());
+
+    if (payload.concernTags?.length) {
+      const insert = db.prepare('INSERT INTO lego_brick_concern_tags VALUES (?, ?, ?)');
+      for (const tag of payload.concernTags) insert.run(version, brickId, tag);
+    }
+
+    markCatalogDirty();
+    db.exec('COMMIT');
+  } catch (error) {
+    db.exec('ROLLBACK');
+    throw error;
+  }
+  return brickId;
+}
+
+/** Deletes a catalog brick (cascades variants/deps; locked rows re-seed on ensure). */
+export function deleteAdminBrick(brickId: string): string {
+  ensureLegoCatalog();
+  if (!brickExists(brickId)) throw new Error(`Brick "${brickId}" does not exist`);
+
+  db.exec('BEGIN IMMEDIATE');
+  try {
+    db.prepare('DELETE FROM lego_variants WHERE catalog_version=? AND brick_id=?')
+      .run(LEGO_CATALOG_VERSION, brickId);
+    db.prepare('DELETE FROM lego_dependencies WHERE catalog_version=? AND (from_brick=? OR to_brick=?)')
+      .run(LEGO_CATALOG_VERSION, brickId, brickId);
+    db.prepare('DELETE FROM lego_bricks WHERE catalog_version=? AND id=?')
+      .run(LEGO_CATALOG_VERSION, brickId);
+    markCatalogDirty();
+    db.exec('COMMIT');
+  } catch (error) {
+    db.exec('ROLLBACK');
+    throw error;
+  }
+  return brickId;
+}
+
+/** Variant maps_to issues (ISC-A5). Exported for unit tests — SQLite FK prevents orphan rows in DB. */
+export function variantRefIssues(
+  variants: { id: string; maps_to: string }[],
+  brickIds: Set<string>,
+): CatalogIssue[] {
+  const issues: CatalogIssue[] = [];
+  for (const variant of variants) {
+    if (brickIds.has(variant.maps_to)) continue;
+    issues.push({
+      code: 'orphan_variant',
+      message: `Variant "${variant.id}" maps to missing brick "${variant.maps_to}"`,
+      field: 'maps_to',
+      entityId: variant.id,
+    });
+  }
+  return issues;
+}
+
+/** Dependency endpoint issues. */
+export function dependencyRefIssues(
+  dependencies: { from_brick: string; to_brick: string }[],
+  brickIds: Set<string>,
+): CatalogIssue[] {
+  const issues: CatalogIssue[] = [];
+  for (const dep of dependencies) {
+    if (!brickIds.has(dep.from_brick)) {
+      issues.push({
+        code: 'orphan_dependency',
+        message: `Dependency from missing brick "${dep.from_brick}"`,
+        field: 'from',
+        entityId: dep.from_brick,
+      });
+    }
+    if (!brickIds.has(dep.to_brick)) {
+      issues.push({
+        code: 'orphan_dependency',
+        message: `Dependency to missing brick "${dep.to_brick}"`,
+        field: 'to',
+        entityId: dep.to_brick,
+      });
+    }
+  }
+  return issues;
+}
+
+/** Full-catalog publish validation (ISC-A5 and i18n gates). */
+export function validateCatalogPublish(): CatalogIssue[] {
+  ensureLegoCatalog();
+  const version = LEGO_CATALOG_VERSION;
+  const issues: CatalogIssue[] = [];
+  const brickIds = new Set(
+    rows<{ id: string }>('SELECT id FROM lego_bricks WHERE catalog_version=?', version).map(row => row.id)
+  );
+
+  issues.push(
+    ...variantRefIssues(
+      rows<{ id: string; maps_to: string }>(
+        'SELECT id, brick_id AS maps_to FROM lego_variants WHERE catalog_version=?',
+        version,
+      ),
+      brickIds,
+    ),
+  );
+
+  issues.push(
+    ...dependencyRefIssues(
+      rows<{ from_brick: string; to_brick: string }>(
+        'SELECT from_brick, to_brick FROM lego_dependencies WHERE catalog_version=?',
+        version,
+      ),
+      brickIds,
+    ),
+  );
+
+  for (const brick of rows<{ id: string }>(
+    'SELECT id FROM lego_bricks WHERE catalog_version=?',
+    version,
+  )) {
+    for (const lang of ['en', 'fr'] as const) {
+      const text = readBrickText(brick.id, lang);
+      if (!text?.role?.trim()) {
+        issues.push({
+          code: 'missing_role',
+          message: `Brick "${brick.id}" missing ${lang.toUpperCase()} role`,
+          field: lang === 'en' ? 'roleEn' : 'roleFr',
+          entityId: brick.id,
+        });
+      }
+    }
+  }
+
+  for (const row of rows<{ brick_id: string; tag: string }>(
+    'SELECT brick_id, tag FROM lego_brick_concern_tags WHERE catalog_version=?',
+    version,
+  )) {
+    if (!isConcernTag(row.tag)) {
+      issues.push({
+        code: 'invalid_concern_tag',
+        message: `Brick "${row.brick_id}" has invalid concern tag "${row.tag}"`,
+        field: 'concernTags',
+        entityId: row.brick_id,
+      });
+    }
+  }
+
+  return issues;
+}
+
+export type PublishCatalogResult =
+  | { ok: true; publishedAt: string }
+  | { ok: false; issues: CatalogIssue[] };
+
+/** Validates and publishes the catalog snapshot. */
+export function publishCatalog(): PublishCatalogResult {
+  ensureLegoCatalog();
+  const issues = validateCatalogPublish();
+  if (issues.length > 0) return { ok: false, issues };
+
+  const publishedAt = now();
+  db.prepare(
+    'UPDATE admin_catalog_state SET dirty=0, published_at=?, updated_at=? WHERE catalog_version=?'
+  ).run(publishedAt, publishedAt, LEGO_CATALOG_VERSION);
+
+  return { ok: true, publishedAt };
+}
+
+export type CatalogAdminState = {
+  dirty: boolean;
+  publishedAt: string | null;
+  version: string;
+  issueCount?: number;
+};
+
+/** Returns admin publish state for the active catalog version. */
+export function getCatalogAdminState(): CatalogAdminState {
+  ensureLegoCatalog();
+  const row = plain<{ dirty: number; published_at: string | null } | undefined>(
+    db.prepare('SELECT dirty, published_at FROM admin_catalog_state WHERE catalog_version=?')
+      .get(LEGO_CATALOG_VERSION)
+  );
+  return {
+    dirty: Boolean(row?.dirty),
+    publishedAt: row?.published_at ?? null,
+    version: LEGO_CATALOG_VERSION,
+  };
+}
+
+/** Convenience: admin state; full publish validation only when requested. */
+export function getCatalogAdminStateWithIssues(options?: { validate?: boolean }): CatalogAdminState & { issues?: CatalogIssue[] } {
+  const state = getCatalogAdminState();
+  if (!options?.validate) return state;
+  const issues = validateCatalogPublish();
+  return { ...state, issueCount: issues.length, issues };
+}

--- a/src/lib/lego/client.ts
+++ b/src/lib/lego/client.ts
@@ -1,16 +1,27 @@
 'use client';
 
 import { api } from '@/lib/api';
-import type { LegoCatalogSnapshot, LegoLanguage } from './types';
+import type { LegoBrick, LegoCatalogSnapshot, LegoLanguage } from './types';
 
 const snapshots = new Map<LegoLanguage, Promise<LegoCatalogSnapshot>>();
 
+function normalizeBrick(brick: LegoBrick): LegoBrick {
+  return {
+    ...brick,
+    purpose: brick.purpose || brick.role,
+    concernTags: brick.concernTags ?? []
+  };
+}
+
 function normalizeSnapshot(snapshot: LegoCatalogSnapshot): LegoCatalogSnapshot {
+  const bricks = Object.fromEntries(
+    Object.entries(snapshot.bricks ?? {}).map(([id, brick]) => [id, normalizeBrick(brick)])
+  );
   return {
     ...snapshot,
     dependencies: snapshot.dependencies ?? [],
     aliases: snapshot.aliases ?? {},
-    bricks: snapshot.bricks ?? {},
+    bricks,
     intents: snapshot.intents ?? [],
     variants: snapshot.variants ?? [],
     scopes: snapshot.scopes ?? [],
@@ -18,12 +29,24 @@ function normalizeSnapshot(snapshot: LegoCatalogSnapshot): LegoCatalogSnapshot {
   };
 }
 
+function snapshotNeedsRefresh(snapshot: LegoCatalogSnapshot): boolean {
+  if (!Array.isArray(snapshot.dependencies)) return true;
+  return Object.values(snapshot.bricks ?? {}).some(
+    brick => !Array.isArray(brick.concernTags)
+  );
+}
+
+export function invalidateLegoCatalogCache(lang?: LegoLanguage): void {
+  if (lang) snapshots.delete(lang);
+  else snapshots.clear();
+}
+
 export function loadLegoCatalog(lang: LegoLanguage = 'en'): Promise<LegoCatalogSnapshot> {
   const cached = snapshots.get(lang);
   if (cached) {
     return cached.then(snapshot => {
-      if (Array.isArray(snapshot.dependencies)) return normalizeSnapshot(snapshot);
-      /* Stale in-memory payload from before the dependencies field existed. */
+      if (!snapshotNeedsRefresh(snapshot)) return normalizeSnapshot(snapshot);
+      /* Stale in-memory payload from before dependencies or concernTags existed. */
       snapshots.delete(lang);
       return loadLegoCatalog(lang);
     });

--- a/src/lib/lego/lego.test.ts
+++ b/src/lib/lego/lego.test.ts
@@ -73,6 +73,8 @@ test('placement derives metadata from snapshot', () => {
   const placed = placeVariant(en, { variantId: 'cognito', existingIds: [] });
   assert.equal(placed.brick, 'identity');
   assert.equal(placed.role, en.bricks.identity.role);
+  assert.equal(placed.purpose, en.bricks.identity.purpose);
+  assert.deepEqual(placed.concernTags, ['iam', 'security']);
   assert.equal(placed.icon, 'lock');
   const prose = brickProse(fr, 'identity');
   assert.equal(prose.role, fr.bricks.identity.role);
@@ -100,6 +102,14 @@ test('plates receive their mappability and placements from snapshot', () => {
   assert(doc.technologies.some(technology => technology.name === 'Next.js'));
   const invalid = blankArchitecture('Atomic');
   assert.equal(insertPlate(invalid, { pattern, bindings: [PLATE_CREATE] }, en), null);
+});
+
+test('placeVariant tolerates bricks without concernTags (stale catalog cache)', () => {
+  const stale = structuredClone(en);
+  delete (stale.bricks.identity as { concernTags?: unknown }).concernTags;
+  const component = placeVariant(stale, { variantId: 'auth0', existingIds: [] });
+  assert.equal(component.concernTags, undefined);
+  assert.ok(component.purpose);
 });
 
 test('plate wires consecutive surviving steps across a skipped binding', () => {

--- a/src/lib/lego/place.ts
+++ b/src/lib/lego/place.ts
@@ -40,6 +40,8 @@ export function placeVariant(snapshot: LegoCatalogSnapshot, input: PlaceVariantI
     name: variant.label,
     brick: variant.maps_to as BrickId,
     role: prose.role,
+    purpose: brick.purpose || prose.role,
+    concernTags: brick.concernTags?.length ? [...brick.concernTags] : undefined,
     group: input.scope || brick.defaultScope,
     layer: brick.layer,
     icon: brick.icon,

--- a/src/lib/lego/repository.test.ts
+++ b/src/lib/lego/repository.test.ts
@@ -25,7 +25,7 @@ after(() => {
 /** Exact counts from `legoCatalogCounts()` after a fresh seed. */
 const EXPECTED_COUNTS = {
   lego_scopes: 18,
-  lego_bricks: 26,
+  lego_bricks: 40,
   lego_intents: 12,
   lego_variants: 154,
   lego_technology_descriptions: 38,
@@ -79,4 +79,29 @@ test('FR snapshot exposes Produit scope and a French identity.role distinct from
     fr.bricks.identity.role,
     'Prouve qui sont les appelants et émet des jetons que d’autres services font confiance.'
   );
+});
+
+test('concernTags for identity brick are loaded from SQLite after seed', () => {
+  R.ensureLegoCatalog();
+  const tagCount = DB.plain<{ count: number }>(
+    DB.db.prepare('SELECT count(*) AS count FROM lego_brick_concern_tags WHERE catalog_version=? AND brick_id=?')
+      .get(R.LEGO_CATALOG_VERSION, 'identity')
+  ).count;
+  assert.ok(tagCount >= 2, 'identity concern tags are persisted in lego_brick_concern_tags');
+
+  const snap = R.legoCatalog('en');
+  assert.deepEqual(snap.bricks.identity?.concernTags, ['iam', 'security']);
+});
+
+test('legoCatalog retains locked intent and variant counts from DB', () => {
+  const snap = R.legoCatalog('en');
+  assert.equal(snap.intents.length, 12);
+  assert.equal(snap.variants.length, 154);
+});
+
+test('purpose is exposed on bricks and falls back to role when unset', () => {
+  const snap = R.legoCatalog('en');
+  const identity = snap.bricks.identity;
+  assert.ok(identity?.purpose);
+  assert.equal(identity?.purpose, identity?.role);
 });

--- a/src/lib/lego/repository.ts
+++ b/src/lib/lego/repository.ts
@@ -1,29 +1,170 @@
 import { db, plain, plainAll } from '../db';
 import { CATALOG_SEED } from './seed-data';
 import type { LegoCatalogSnapshot, LegoLanguage } from './types';
+import type { ConcernTag } from '../document/concerns';
 
-export const LEGO_CATALOG_VERSION = '2026-08-16.2';
+export const LEGO_CATALOG_VERSION = '2026-08-18.1';
 export type { LegoCatalogSnapshot, LegoLanguage } from './types';
 
 function rows<T>(sql: string, ...values: any[]) { return plainAll<T>(db.prepare(sql).all(...values)); }
 
+function catalogBrickIds(): Set<string> {
+  return new Set([
+    ...Object.keys(CATALOG_SEED.icons),
+    ...Object.keys(CATALOG_SEED.rolePhrases),
+    ...Object.keys(CATALOG_SEED.roleScopes),
+  ]);
+}
+
+/** Removes dependency edges whose endpoints are not seeded bricks. */
+function pruneOrphanDependencies(): void {
+  const version = LEGO_CATALOG_VERSION;
+  db.prepare(`
+    DELETE FROM lego_dependencies
+    WHERE catalog_version=?
+      AND (
+        from_brick NOT IN (SELECT id FROM lego_bricks WHERE catalog_version=?)
+        OR to_brick NOT IN (SELECT id FROM lego_bricks WHERE catalog_version=?)
+      )
+  `).run(version, version, version);
+}
+
 /** Inserts dependency rows when the catalog version already existed before
  * `lego_dependencies` was part of the seed (early return would skip them). */
 function ensureDependencyRows(): void {
-  const count = plain<{ count: number }>(
-    db.prepare('SELECT count(*) AS count FROM lego_dependencies WHERE catalog_version=?').get(LEGO_CATALOG_VERSION)
-  )?.count ?? 0;
-  if (count > 0) return;
+  ensureMissingDependencies();
+}
+
+/** INSERT OR IGNORE valid dependency edges from seed that are not yet in DB. */
+function ensureMissingDependencies(): void {
+  const brickIds = catalogBrickIds();
+  const validDependencies = CATALOG_SEED.dependencies.filter(
+    dep => brickIds.has(dep.from) && brickIds.has(dep.to),
+  );
   const dependency = db.prepare('INSERT OR IGNORE INTO lego_dependencies VALUES (?, ?, ?, ?, ?, ?, ?, ?)');
-  for (const value of CATALOG_SEED.dependencies) {
+  for (const value of validDependencies) {
     dependency.run(LEGO_CATALOG_VERSION, value.from, value.to, value.strength, value.why_en, value.why_fr, value.protocol_id, value.kind);
   }
+  pruneOrphanDependencies();
+}
+
+/** Re-inserts locked scopes missing after admin delete. */
+function ensureMissingScopes(): void {
+  const scope = db.prepare('INSERT OR IGNORE INTO lego_scopes VALUES (?, ?, ?, ?)');
+  for (const [id, en, fr] of CATALOG_SEED.scopes) {
+    scope.run(LEGO_CATALOG_VERSION, id, en, fr);
+  }
+  const alias = db.prepare('INSERT OR IGNORE INTO lego_scope_aliases VALUES (?, ?, ?)');
+  for (const [name, id] of Object.entries(CATALOG_SEED.scopeAliases)) {
+    alias.run(LEGO_CATALOG_VERSION, name, id);
+  }
+}
+
+/** Re-inserts seed brick↔scope affinities (requires bricks + scopes present). */
+function ensureMissingAffinities(): void {
+  const affinity = db.prepare('INSERT OR IGNORE INTO lego_brick_scope_affinities VALUES (?, ?, ?)');
+  for (const [brickId, scopeIds] of Object.entries(CATALOG_SEED.roleScopes)) {
+    for (const scopeId of scopeIds) affinity.run(LEGO_CATALOG_VERSION, brickId, scopeId);
+  }
+}
+
+/** Re-inserts locked intents (modes/shapes) missing after admin delete. */
+function ensureMissingIntents(): void {
+  const intent = db.prepare('INSERT OR IGNORE INTO lego_intents VALUES (?, ?, ?)');
+  const mode = db.prepare('INSERT OR IGNORE INTO lego_intent_modes VALUES (?, ?, ?, ?)');
+  const shape = db.prepare('INSERT OR IGNORE INTO lego_intent_shapes VALUES (?, ?, ?, ?)');
+  for (const value of CATALOG_SEED.intents) {
+    intent.run(LEGO_CATALOG_VERSION, value.id, value.label);
+    value.modes.forEach((modeValue, position) => mode.run(LEGO_CATALOG_VERSION, value.id, modeValue, position));
+    value.shapes?.forEach((shapeValue, position) => shape.run(LEGO_CATALOG_VERSION, value.id, shapeValue, position));
+  }
+}
+
+/** Re-inserts locked variants missing after admin delete. */
+function ensureMissingVariants(): void {
+  const variant = db.prepare('INSERT OR IGNORE INTO lego_variants VALUES (?, ?, ?, ?, ?, ?)');
+  for (const value of CATALOG_SEED.variants) {
+    variant.run(LEGO_CATALOG_VERSION, value.id, value.intent, value.label, value.mode, value.maps_to);
+  }
+}
+
+/** Re-inserts locked technology descriptions missing after admin delete. */
+function ensureMissingTechnologies(): void {
+  const technology = db.prepare('INSERT OR IGNORE INTO lego_technology_descriptions VALUES (?, ?, ?, ?)');
+  for (const [key, value] of Object.entries(CATALOG_SEED.technologyDescriptions)) {
+    technology.run(LEGO_CATALOG_VERSION, key, 'en', value.en);
+    technology.run(LEGO_CATALOG_VERSION, key, 'fr', value.fr);
+  }
+}
+
+/** Inserts brick rows (with texts, phrases, affinities, concern tags) missing from DB. */
+function ensureMissingBrickRows(): void {
+  const version = LEGO_CATALOG_VERSION;
+  const existing = new Set(
+    plainAll<{ id: string }>(db.prepare('SELECT id FROM lego_bricks WHERE catalog_version=?').all(version)).map(row => row.id)
+  );
+  const ids = catalogBrickIds();
+  const missing = [...ids].filter(id => !existing.has(id));
+  if (missing.length === 0) return;
+
+  const brick = db.prepare('INSERT OR IGNORE INTO lego_bricks VALUES (?, ?, ?, ?, ?, ?)');
+  const text = db.prepare('INSERT OR IGNORE INTO lego_brick_texts VALUES (?, ?, ?, ?, ?, ?, ?)');
+  const affinity = db.prepare('INSERT OR IGNORE INTO lego_brick_scope_affinities VALUES (?, ?, ?)');
+  const phrase = db.prepare('INSERT OR IGNORE INTO lego_capability_phrases VALUES (?, ?, ?, ?)');
+  const tag = db.prepare('INSERT OR IGNORE INTO lego_brick_concern_tags VALUES (?, ?, ?)');
+
+  for (const id of missing) {
+    brick.run(version, id, CATALOG_SEED.icons[id] || 'box', CATALOG_SEED.layers[id] || 'services', CATALOG_SEED.defaultScopes[id] || 'product', JSON.stringify(CATALOG_SEED.capabilities[id] || []));
+    for (const lang of ['en', 'fr'] as const) {
+      const metadata = (lang === 'fr' ? CATALOG_SEED.frenchBrickMetadata : CATALOG_SEED.brickMetadata)[id] || { features: [], notes: [] };
+      const role = (lang === 'fr' ? CATALOG_SEED.frenchRolePhrases : CATALOG_SEED.rolePhrases)[id] || (lang === 'fr' ? `Fournit la capacité ${id} dans cette architecture.` : `Provides the ${id} capability in this architecture.`);
+      text.run(version, id, lang, role, JSON.stringify(metadata.features), JSON.stringify(metadata.notes), '');
+      phrase.run(version, id, lang, CATALOG_SEED.roleCapabilities[id]?.[lang] || (lang === 'fr' ? 'la capacité d’architecture sélectionnée' : 'the selected architecture capability'));
+    }
+    for (const scopeId of CATALOG_SEED.roleScopes[id] || []) affinity.run(version, id, scopeId);
+    for (const value of CATALOG_SEED.concernTags[id] || []) tag.run(version, id, value);
+  }
+}
+
+/** Inserts concern-tag rows when the catalog version already existed before
+ * `lego_brick_concern_tags` was part of the seed (early return would skip them). */
+function ensureConcernTagRows(): void {
+  const count = plain<{ count: number }>(
+    db.prepare('SELECT count(*) AS count FROM lego_brick_concern_tags WHERE catalog_version=?').get(LEGO_CATALOG_VERSION)
+  )?.count ?? 0;
+  if (count > 0) return;
+  const tag = db.prepare('INSERT OR IGNORE INTO lego_brick_concern_tags VALUES (?, ?, ?)');
+  for (const [brickId, tags] of Object.entries(CATALOG_SEED.concernTags)) {
+    for (const value of tags) tag.run(LEGO_CATALOG_VERSION, brickId, value);
+  }
+}
+
+function seedConcernTags(): void {
+  const tag = db.prepare('INSERT OR IGNORE INTO lego_brick_concern_tags VALUES (?, ?, ?)');
+  for (const [brickId, tags] of Object.entries(CATALOG_SEED.concernTags)) {
+    for (const value of tags) tag.run(LEGO_CATALOG_VERSION, brickId, value);
+  }
+}
+
+/** Ensures admin publish-tracking row exists for the active catalog version. */
+function ensureAdminCatalogState(): void {
+  db.prepare(
+    'INSERT OR IGNORE INTO admin_catalog_state (catalog_version, dirty, published_at, updated_at) VALUES (?, 0, NULL, datetime(\'now\'))'
+  ).run(LEGO_CATALOG_VERSION);
 }
 
 /** Seeds once transactionally; runtime callers only read the SQLite snapshot. */
 export function ensureLegoCatalog(): void {
   if (db.prepare('SELECT 1 FROM lego_catalog_versions WHERE version=?').get(LEGO_CATALOG_VERSION)) {
-    ensureDependencyRows();
+    ensureMissingScopes();
+    ensureMissingBrickRows();
+    ensureMissingAffinities();
+    ensureMissingIntents();
+    ensureMissingVariants();
+    ensureMissingTechnologies();
+    ensureMissingDependencies();
+    ensureConcernTagRows();
+    ensureAdminCatalogState();
     return;
   }
   db.exec('BEGIN IMMEDIATE');
@@ -34,7 +175,7 @@ export function ensureLegoCatalog(): void {
     const alias = db.prepare('INSERT OR IGNORE INTO lego_scope_aliases VALUES (?, ?, ?)');
     for (const [name, id] of Object.entries(CATALOG_SEED.scopeAliases)) alias.run(LEGO_CATALOG_VERSION, name, id);
     const brick = db.prepare('INSERT OR IGNORE INTO lego_bricks VALUES (?, ?, ?, ?, ?, ?)');
-    const text = db.prepare('INSERT OR IGNORE INTO lego_brick_texts VALUES (?, ?, ?, ?, ?, ?)');
+    const text = db.prepare('INSERT OR IGNORE INTO lego_brick_texts VALUES (?, ?, ?, ?, ?, ?, ?)');
     const affinity = db.prepare('INSERT OR IGNORE INTO lego_brick_scope_affinities VALUES (?, ?, ?)');
     const phrase = db.prepare('INSERT OR IGNORE INTO lego_capability_phrases VALUES (?, ?, ?, ?)');
     const ids = new Set([...Object.keys(CATALOG_SEED.icons), ...Object.keys(CATALOG_SEED.rolePhrases), ...Object.keys(CATALOG_SEED.roleScopes)]);
@@ -43,11 +184,12 @@ export function ensureLegoCatalog(): void {
       for (const lang of ['en', 'fr'] as const) {
         const metadata = (lang === 'fr' ? CATALOG_SEED.frenchBrickMetadata : CATALOG_SEED.brickMetadata)[id] || { features: [], notes: [] };
         const role = (lang === 'fr' ? CATALOG_SEED.frenchRolePhrases : CATALOG_SEED.rolePhrases)[id] || (lang === 'fr' ? `Fournit la capacité ${id} dans cette architecture.` : `Provides the ${id} capability in this architecture.`);
-        text.run(LEGO_CATALOG_VERSION, id, lang, role, JSON.stringify(metadata.features), JSON.stringify(metadata.notes));
+        text.run(LEGO_CATALOG_VERSION, id, lang, role, JSON.stringify(metadata.features), JSON.stringify(metadata.notes), '');
         phrase.run(LEGO_CATALOG_VERSION, id, lang, CATALOG_SEED.roleCapabilities[id]?.[lang] || (lang === 'fr' ? 'la capacité d’architecture sélectionnée' : 'the selected architecture capability'));
       }
       for (const scopeId of CATALOG_SEED.roleScopes[id] || []) affinity.run(LEGO_CATALOG_VERSION, id, scopeId);
     }
+    seedConcernTags();
     const intent = db.prepare('INSERT OR IGNORE INTO lego_intents VALUES (?, ?, ?)');
     const mode = db.prepare('INSERT OR IGNORE INTO lego_intent_modes VALUES (?, ?, ?, ?)');
     const shape = db.prepare('INSERT OR IGNORE INTO lego_intent_shapes VALUES (?, ?, ?, ?)');
@@ -63,6 +205,7 @@ export function ensureLegoCatalog(): void {
       technology.run(LEGO_CATALOG_VERSION, key, 'en', value.en); technology.run(LEGO_CATALOG_VERSION, key, 'fr', value.fr);
     }
     ensureDependencyRows();
+    ensureAdminCatalogState();
     db.exec('COMMIT');
   } catch (error) { db.exec('ROLLBACK'); throw error; }
 }
@@ -72,8 +215,26 @@ export function legoCatalog(lang: LegoLanguage = 'en'): LegoCatalogSnapshot {
   const scopes = rows<{ id: string; label: string }>(`SELECT id, ${lang === 'fr' ? 'label_fr' : 'label_en'} AS label FROM lego_scopes WHERE catalog_version=? ORDER BY rowid`, version);
   const aliases = Object.fromEntries(rows<{ alias: string; scope_id: string }>('SELECT alias, scope_id FROM lego_scope_aliases WHERE catalog_version=?', version).map(row => [row.alias, row.scope_id]));
   const affinities = rows<{ brick_id: string; scope_id: string }>('SELECT brick_id, scope_id FROM lego_brick_scope_affinities WHERE catalog_version=?', version);
-  const brickRows = rows<{ id: string; icon: string; layer_id: string; default_scope_id: string; capabilities_json: string; role: string; responsibilities_json: string; notes_json: string; phrase: string }>(`SELECT b.id,b.icon,b.layer_id,b.default_scope_id,b.capabilities_json,t.role,t.responsibilities_json,t.notes_json,p.phrase FROM lego_bricks b JOIN lego_brick_texts t ON t.catalog_version=b.catalog_version AND t.brick_id=b.id JOIN lego_capability_phrases p ON p.catalog_version=b.catalog_version AND p.brick_id=b.id AND p.lang=t.lang WHERE b.catalog_version=? AND t.lang=?`, version, lang);
-  const bricks = Object.fromEntries(brickRows.map(row => [row.id, { id: row.id, icon: row.icon, layer: row.layer_id, defaultScope: row.default_scope_id, capabilities: JSON.parse(row.capabilities_json), role: row.role, responsibilities: JSON.parse(row.responsibilities_json), notes: JSON.parse(row.notes_json), affinities: affinities.filter(value => value.brick_id === row.id).map(value => value.scope_id), capabilityPhrase: row.phrase }]));
+  const concernTagsByBrick = rows<{ brick_id: string; tag: ConcernTag }>('SELECT brick_id, tag FROM lego_brick_concern_tags WHERE catalog_version=? ORDER BY rowid', version)
+    .reduce<Record<string, ConcernTag[]>>((acc, row) => {
+      (acc[row.brick_id] ??= []).push(row.tag);
+      return acc;
+    }, {});
+  const brickRows = rows<{ id: string; icon: string; layer_id: string; default_scope_id: string; capabilities_json: string; role: string; purpose: string; responsibilities_json: string; notes_json: string; phrase: string }>(`SELECT b.id,b.icon,b.layer_id,b.default_scope_id,b.capabilities_json,t.role,t.purpose,t.responsibilities_json,t.notes_json,p.phrase FROM lego_bricks b JOIN lego_brick_texts t ON t.catalog_version=b.catalog_version AND t.brick_id=b.id JOIN lego_capability_phrases p ON p.catalog_version=b.catalog_version AND p.brick_id=b.id AND p.lang=t.lang WHERE b.catalog_version=? AND t.lang=?`, version, lang);
+  const bricks = Object.fromEntries(brickRows.map(row => [row.id, {
+    id: row.id,
+    icon: row.icon,
+    layer: row.layer_id,
+    defaultScope: row.default_scope_id,
+    capabilities: JSON.parse(row.capabilities_json),
+    role: row.role,
+    purpose: row.purpose || row.role,
+    concernTags: [...(concernTagsByBrick[row.id] || [])],
+    responsibilities: JSON.parse(row.responsibilities_json),
+    notes: JSON.parse(row.notes_json),
+    affinities: affinities.filter(value => value.brick_id === row.id).map(value => value.scope_id),
+    capabilityPhrase: row.phrase
+  }]));
   const intents = rows<{ id: string; label: string }>('SELECT id,label FROM lego_intents WHERE catalog_version=? ORDER BY rowid', version).map(value => ({ ...value, modes: rows<{ mode: string }>('SELECT mode FROM lego_intent_modes WHERE catalog_version=? AND intent_id=? ORDER BY position', version, value.id).map(row => row.mode as LegoCatalogSnapshot['intents'][number]['modes'][number]), shapes: rows<{ shape: string }>('SELECT shape FROM lego_intent_shapes WHERE catalog_version=? AND intent_id=? ORDER BY position', version, value.id).map(row => row.shape) }));
   const variants = rows<{ id: string; intent: string; label: string; mode: LegoCatalogSnapshot['variants'][number]['mode']; maps_to: string }>('SELECT id,intent_id AS intent,label,mode,brick_id AS maps_to FROM lego_variants WHERE catalog_version=? ORDER BY rowid', version);
   const dependencies = rows<LegoCatalogSnapshot['dependencies'][number]>('SELECT from_brick AS "from", to_brick AS "to", strength, why_en, why_fr, protocol_id, kind FROM lego_dependencies WHERE catalog_version=? ORDER BY rowid', version) ?? [];

--- a/src/lib/lego/seed-data.ts
+++ b/src/lib/lego/seed-data.ts
@@ -210,6 +210,8 @@ const ROLE_SCOPES: Record<string, readonly string[]> = {
   staticHosting: ['front', 'edge'],
   cdn: ['edge'],
   apiGateway: ['edge', 'app', 'services'],
+  waf: ['edge', 'tenancy'],
+  loadBalancer: ['edge', 'app'],
   identity: ['tenancy', 'vendor'],
   functions: ['app', 'services', 'modules'],
   containers: ['app', 'services'],
@@ -220,46 +222,85 @@ const ROLE_SCOPES: Record<string, readonly string[]> = {
   nosql: ['data', 'index'],
   cache: ['data', 'quality'],
   objects: ['data', 'ingestion'],
+  warehouse: ['data', 'index'],
   search: ['data', 'index'],
   vector: ['data', 'index'],
   queue: ['data', 'bus', 'processing'],
   pubsub: ['data', 'bus', 'producers'],
   stream: ['data', 'bus', 'processing'],
+  streamProcessing: ['data', 'processing', 'destinations'],
+  schemaRegistry: ['data', 'bus', 'quality'],
+  embeddings: ['answering', 'index'],
   llm: ['answering'],
+  rerank: ['answering', 'index'],
+  guardrails: ['answering', 'quality'],
+  ocr: ['ingestion', 'processing'],
+  secrets: ['platform', 'tenancy'],
+  config: ['platform', 'quality'],
   observability: ['platform', 'quality'],
   tracing: ['platform', 'quality'],
+  backup: ['platform', 'data'],
+  registry: ['platform'],
   cicd: ['platform'],
   gitops: ['platform'],
+  audit: ['platform', 'quality'],
   email: ['vendor']
 };
 
 const ICONS: Record<string, string> = {
   webApp: 'web', mobileApp: 'mobile', apiGateway: 'plug', cdn: 'globe',
+  waf: 'shield', loadBalancer: 'route',
   staticHosting: 'web', identity: 'lock', functions: 'bolt', containers: 'docker',
   kubernetes: 'layers', jobs: 'clock', orchestration: 'hub', sql: 'db', nosql: 'cube',
-  cache: 'bolt', objects: 'save', search: 'search', vector: 'hub', queue: 'box',
-  pubsub: 'bell', stream: 'chart', llm: 'ai', observability: 'chart', email: 'mail',
-  cicd: 'git', gitops: 'cloudup'
+  cache: 'bolt', objects: 'save', warehouse: 'chart', search: 'search', vector: 'hub',
+  queue: 'box', pubsub: 'bell', stream: 'chart', streamProcessing: 'cog',
+  schemaRegistry: 'layers', embeddings: 'ai', llm: 'ai', rerank: 'layers',
+  guardrails: 'shield', ocr: 'scan', secrets: 'key', config: 'flag',
+  observability: 'chart', tracing: 'eye', backup: 'cloudup', registry: 'docker',
+  email: 'mail', cicd: 'git', gitops: 'cloudup', audit: 'file'
 };
 
 const LAYERS: Record<string, string> = {
   webApp: 'clients', mobileApp: 'clients', cdn: 'edge', staticHosting: 'edge',
-  apiGateway: 'edge', identity: 'edge', functions: 'services', containers: 'services',
-  kubernetes: 'services', jobs: 'services', orchestration: 'services', llm: 'services',
-  sql: 'data', nosql: 'data', cache: 'data', objects: 'data', search: 'data',
-  vector: 'data', queue: 'data', pubsub: 'data', stream: 'data',
-  observability: 'platform', email: 'platform', cicd: 'platform', gitops: 'platform'
+  apiGateway: 'edge', waf: 'edge', loadBalancer: 'edge', identity: 'edge',
+  functions: 'services', containers: 'services', kubernetes: 'services',
+  jobs: 'services', orchestration: 'services', streamProcessing: 'services',
+  embeddings: 'services', llm: 'services', rerank: 'services', guardrails: 'services',
+  ocr: 'services',
+  sql: 'data', nosql: 'data', cache: 'data', objects: 'data', warehouse: 'data',
+  search: 'data', vector: 'data', queue: 'data', pubsub: 'data', stream: 'data',
+  schemaRegistry: 'data',
+  secrets: 'platform', config: 'platform', observability: 'platform', tracing: 'platform',
+  backup: 'platform', registry: 'platform', email: 'platform', cicd: 'platform',
+  gitops: 'platform', audit: 'platform'
 };
 
 const SCOPES: Record<string, string> = {
-  identity: 'vendor', email: 'vendor', observability: 'platform', cicd: 'platform', gitops: 'platform'
+  identity: 'vendor', email: 'vendor',
+  secrets: 'platform', config: 'platform', observability: 'platform', tracing: 'platform',
+  backup: 'platform', registry: 'platform', cicd: 'platform', gitops: 'platform', audit: 'platform'
 };
 
 const CAPABILITIES: Record<string, string[]> = {
-  webApp: ['SPA'], mobileApp: ['SPA'], identity: ['OIDC', 'JWT'], llm: ['LLM'],
+  webApp: ['SPA'], mobileApp: ['SPA'], identity: ['OIDC', 'JWT', 'SAML', 'SCIM'],
+  waf: ['WAF'], loadBalancer: ['TLS', 'Health checks'],
   sql: ['Relational DB'], nosql: ['Document store', 'Key-value'], cache: ['Key-value'],
-  objects: ['Object storage'], queue: ['Queue', 'Dead-letter queue'], pubsub: ['Event bus', 'Dead-letter queue'],
-  apiGateway: ['HTTP API', 'JWT', 'WAF'], functions: ['Functions', 'Worker']
+  objects: ['Object storage'], warehouse: ['Columnar / warehouse'],
+  search: ['Full-text search'], vector: ['Vector search', 'Full-text search'],
+  queue: ['Queue', 'Dead-letter queue'], pubsub: ['Event bus', 'Dead-letter queue'],
+  stream: ['Event log / stream'], streamProcessing: ['Stream processing'],
+  schemaRegistry: ['Schema contract'],
+  embeddings: ['Embedding model'], llm: ['LLM'], rerank: ['Rerank'],
+  guardrails: ['Content safety', 'PII detection'], ocr: ['OCR'],
+  secrets: ['Secrets'], config: ['Config', 'Secrets'],
+  observability: ['Logs', 'Metrics', 'Alerts'], tracing: ['Traces', 'Metrics'],
+  backup: ['Backup / PITR'], registry: ['OCI registry', 'Image scanning'],
+  audit: ['Audit log'],
+  apiGateway: ['HTTP API', 'JWT', 'WAF'], functions: ['Functions', 'Worker'],
+  containers: ['Container', 'HTTP API', 'Worker'], kubernetes: ['Kubernetes', 'Container'],
+  jobs: ['Scheduler', 'Worker'], orchestration: ['Workflow'],
+  staticHosting: ['SPA', 'CDN'], cdn: ['CDN', 'TLS', 'WAF'],
+  cicd: ['CI', 'Infrastructure as code'], gitops: ['GitOps', 'CI'], email: ['Email']
 };
 
 const BRICK_METADATA: Record<string, { features: string[]; notes: string[] }> = {
@@ -288,7 +329,21 @@ const BRICK_METADATA: Record<string, { features: string[]; notes: string[] }> = 
   tracing: { features: ['Trace requests across service boundaries', 'Expose latency and failure paths'], notes: ['Sampling and data-retention policy need explicit ownership.'] },
   email: { features: ['Send transactional messages', 'Deliver service notifications'], notes: ['Sender reputation and delivery failures require monitoring.'] },
   cicd: { features: ['Build and test changes', 'Deliver deployable artifacts'], notes: ['Deployment approvals and rollback policy remain product decisions.'] },
-  gitops: { features: ['Reconcile declared infrastructure state', 'Promote changes through version control'], notes: ['Repository access and reconciliation boundaries need governance.'] }
+  gitops: { features: ['Reconcile declared infrastructure state', 'Promote changes through version control'], notes: ['Repository access and reconciliation boundaries need governance.'] },
+  waf: { features: ['Block common web attacks (injection, bots, bad IPs)', 'Apply request rules before traffic reaches apps'], notes: ['False positives can break legit clients — tune rules with observability.'] },
+  loadBalancer: { features: ['Distribute traffic across healthy instances', 'Health-check backends and fail over'], notes: ['Health checks and sticky sessions must match how the app actually behaves.'] },
+  warehouse: { features: ['Run analytical queries over large historical datasets', 'Separate analytics load from the operational database'], notes: ['ETL freshness and PII in analytics copies are usual compliance gaps.'] },
+  streamProcessing: { features: ['Transform or aggregate streams in near real time', 'Emit derived events or write sinks continuously'], notes: ['Watermarks, late data, and state checkpoints are the hard parts.'] },
+  schemaRegistry: { features: ['Version event/message schemas centrally', 'Prevent incompatible producers/consumers'], notes: ['Without enforced compatibility checks, the registry becomes documentation theater.'] },
+  embeddings: { features: ['Turn text or other inputs into vectors', 'Feed vector search and RAG pipelines'], notes: ['Model and chunking choices dominate quality — brick alone is incomplete.'] },
+  rerank: { features: ['Reorder retrieved candidates by relevance to a query', 'Improve RAG/search quality after a first retrieval'], notes: ['Adds latency and cost; measure lift vs plain retrieval.'] },
+  guardrails: { features: ['Filter unsafe or policy-breaking model inputs/outputs', 'Reduce prompt-injection and toxic content risk'], notes: ['Rules drift; false blocks hurt UX — need monitoring and allowlists.'] },
+  ocr: { features: ['Extract text from images and PDFs', 'Feed downstream search, RAG, or workflows'], notes: ['Quality varies by language, layout, and scan quality.'] },
+  secrets: { features: ['Store API keys and credentials outside the repo', 'Inject secrets into runtimes at deploy/runtime'], notes: ['Rotation and least-privilege grants are usually the unfinished part.'] },
+  config: { features: ['Centralize non-secret app settings by environment', 'Change flags/settings without rebuilding images when possible'], notes: ['Config vs secrets boundary is often blurred in practice.'] },
+  backup: { features: ['Take recoverable copies of stateful data', 'Support restore and retention policies'], notes: ['Untested restores are a known gap — schedule restore drills.'] },
+  registry: { features: ['Store versioned container (or artifact) images', 'Feed deploy pipelines with immutable artifacts'], notes: ['Image retention, scanning, and promotion between envs are often missing.'] },
+  audit: { features: ['Record who did what, when, for security and compliance', 'Keep tamper-resistant operational history'], notes: ['Retention, immutability, and who can query audits are policy gaps.'] }
 };
 
 const ROLE_PHRASES: Record<string, string> = {
@@ -317,7 +372,65 @@ const ROLE_PHRASES: Record<string, string> = {
   tracing: 'Follows a request across services to find latency and failures.',
   email: 'Sends transactional email to users.',
   cicd: 'Builds, tests, and deploys changes through an automated pipeline.',
-  gitops: 'Keeps cluster desired state in git and reconciles toward it.'
+  gitops: 'Keeps cluster desired state in git and reconciles toward it.',
+  waf: 'Request filter that blocks common web attacks before apps see traffic.',
+  loadBalancer: 'Distributes traffic across instances and terminates or forwards TLS.',
+  warehouse: 'Analytical store optimized for reporting and large scans, not OLTP.',
+  streamProcessing: 'Transforms or aggregates event streams in near real time.',
+  schemaRegistry: 'Holds shared event/API schemas and compatibility rules.',
+  embeddings: 'Turns text or media into vectors for retrieval and similarity.',
+  rerank: 'Reorders retrieval candidates so the best context reaches the LLM.',
+  guardrails: 'Filters prompts and outputs for safety, PII, and policy.',
+  ocr: 'Extracts text from images and scanned documents.',
+  secrets: 'Stores and delivers credentials and keys to runtimes safely.',
+  config: 'Centralizes non-secret configuration for services and feature flags.',
+  backup: 'Copies and restores durable data for disaster recovery.',
+  registry: 'Stores container (or package) images for deployable artifacts.',
+  audit: 'Records who did what and when for security and compliance evidence.'
+};
+
+
+const CONCERN_TAGS: Record<string, readonly import('../document/concerns').ConcernTag[]> = {
+  webApp: ['network'],
+  mobileApp: ['network'],
+  apiGateway: ['network', 'security'],
+  cdn: ['network'],
+  staticHosting: ['network'],
+  identity: ['iam', 'security'],
+  functions: ['ops'],
+  containers: ['ops'],
+  kubernetes: ['ops', 'tenancy'],
+  jobs: ['ops'],
+  orchestration: ['ops'],
+  sql: ['data', 'dr'],
+  nosql: ['data', 'dr'],
+  cache: ['data'],
+  objects: ['data'],
+  search: ['data'],
+  vector: ['data'],
+  queue: ['ops', 'data'],
+  pubsub: ['ops', 'data'],
+  stream: ['ops', 'data'],
+  llm: ['governance', 'cost'],
+  observability: ['observability', 'ops'],
+  tracing: ['observability'],
+  email: ['ops'],
+  cicd: ['ops'],
+  gitops: ['ops', 'governance'],
+  waf: ['security', 'network'],
+  loadBalancer: ['network', 'ops'],
+  warehouse: ['data', 'cost'],
+  streamProcessing: ['ops', 'data'],
+  schemaRegistry: ['governance', 'data'],
+  embeddings: ['governance', 'cost'],
+  rerank: ['governance', 'cost'],
+  guardrails: ['governance', 'security'],
+  ocr: ['data', 'governance'],
+  secrets: ['security', 'ops'],
+  config: ['ops', 'governance'],
+  backup: ['dr', 'data'],
+  registry: ['ops', 'security'],
+  audit: ['governance', 'security']
 };
 
 const FRENCH_ROLE_PHRASES: Record<string, string> = {
@@ -346,7 +459,21 @@ const FRENCH_ROLE_PHRASES: Record<string, string> = {
   tracing: 'Suit une requête à travers les services pour trouver latence et pannes.',
   email: 'Envoie des emails transactionnels aux utilisateurs.',
   cicd: 'Build, teste et déploie les changements via un pipeline automatisé.',
-  gitops: 'Garde l’état désiré du cluster dans git et réconcilie vers lui.'
+  gitops: 'Garde l’état désiré du cluster dans git et réconcilie vers lui.',
+  waf: 'Filtre de requêtes qui bloque les attaques web courantes avant les apps.',
+  loadBalancer: 'Répartit le trafic entre instances et termine ou relaie le TLS.',
+  warehouse: 'Store analytique optimisé reporting et grands scans, pas OLTP.',
+  streamProcessing: 'Transforme ou agrège des flux d’événements en quasi temps réel.',
+  schemaRegistry: 'Détient les schémas d’événements/API partagés et les règles de compatibilité.',
+  embeddings: 'Transforme texte ou média en vecteurs pour retrieval et similarité.',
+  rerank: 'Réordonne les candidats de retrieval pour que le meilleur contexte atteigne le LLM.',
+  guardrails: 'Filtre prompts et sorties pour sûreté, PII et politique.',
+  ocr: 'Extrait le texte d’images et de documents scannés.',
+  secrets: 'Stocke et délivre identifiants et clés aux runtimes en sécurité.',
+  config: 'Centralise la configuration non secrète des services et feature flags.',
+  backup: 'Copie et restaure les données durables pour la reprise après sinistre.',
+  registry: 'Stocke les images conteneur (ou packages) pour artefacts déployables.',
+  audit: 'Enregistre qui a fait quoi et quand pour preuves sécu et conformité.'
 };
 
 const FRENCH_BRICK_METADATA: Record<string, { features: string[]; notes: string[] }> = {
@@ -384,7 +511,21 @@ const FRENCH_BRICK_METADATA: Record<string, { features: string[]; notes: string[
   tracing: { features: ['Tracer les requêtes entre frontières de services', 'Exposer latence et chemins d’échec'], notes: ['Sampling et rétention des données doivent être décidés.'] },
   email: { features: ['Envoyer des messages transactionnels', 'Livrer des notifications de service'], notes: ['Réputation expéditeur et échecs de livraison demandent du monitoring.'] },
   cicd: { features: ['Builder et tester les changements', 'Livrer des artefacts déployables'], notes: ['Approbations de déploiement et rollback restent des décisions produit.'] },
-  gitops: { features: ['Réconcilier l’état infra déclaré', 'Promouvoir les changements via git'], notes: ['Accès dépôt et frontières de réconciliation demandent une gouvernance.'] }
+  gitops: { features: ['Réconcilier l’état infra déclaré', 'Promouvoir les changements via git'], notes: ['Accès dépôt et frontières de réconciliation demandent une gouvernance.'] },
+  waf: { features: ['Bloquer les attaques web courantes (injection, bots, IPs)', 'Appliquer des règles avant que le trafic n’atteigne les apps'], notes: ['Les faux positifs peuvent casser des clients légitimes — régler avec de l’observabilité.'] },
+  loadBalancer: { features: ['Répartir le trafic entre instances saines', 'Surveiller la santé des backends et basculer'], notes: ['Health checks et sessions sticky doivent coller au comportement réel de l’app.'] },
+  warehouse: { features: ['Lancer des requêtes analytiques sur de gros historiques', 'Séparer la charge analytique de la base opérationnelle'], notes: ['Fraîcheur ETL et PII dans les copies analytiques sont des trous conformité habituels.'] },
+  streamProcessing: { features: ['Transformer/agréger des flux en quasi temps réel', 'Émettre des événements dérivés ou écrire des sinks en continu'], notes: ['Watermarks, données tardives et checkpoints d’état sont le dur.'] },
+  schemaRegistry: { features: ['Versionner centralement les schémas d’événements/messages', 'Éviter producteurs/consommateurs incompatibles'], notes: ['Sans contrôles de compatibilité imposés, le registry devient du théâtre documentaire.'] },
+  embeddings: { features: ['Transformer texte ou autres entrées en vecteurs', 'Alimenter recherche vectorielle et pipelines RAG'], notes: ['Choix de modèle et de découpage dominent la qualité — la brique seule est incomplète.'] },
+  rerank: { features: ['Réordonner les candidats récupérés selon la pertinence', 'Améliorer la qualité RAG/search après un premier retrieval'], notes: ['Ajoute latence et coût ; mesurer le gain vs retrieval simple.'] },
+  guardrails: { features: ['Filtrer entrées/sorties modèle dangereuses ou hors politique', 'Réduire injection de prompts et contenu toxique'], notes: ['Les règles dérivent ; les faux blocages blessent l’UX — monitoring et allowlists.'] },
+  ocr: { features: ['Extraire le texte d’images et de PDF', 'Alimenter search, RAG ou workflows en aval'], notes: ['La qualité varie selon langue, mise en page et qualité de scan.'] },
+  secrets: { features: ['Stocker clés API et credentials hors du dépôt', 'Injecter les secrets dans les runtimes au deploy/runtime'], notes: ['Rotation et grants least-privilege sont souvent la partie inachevée.'] },
+  config: { features: ['Centraliser les settings non secrets par environnement', 'Changer flags/settings sans rebuild d’image quand possible'], notes: ['La frontière config vs secrets est souvent floue en pratique.'] },
+  backup: { features: ['Prendre des copies récupérables des données à état', 'Supporter restore et politiques de rétention'], notes: ['Restores non testés = trou connu — planifier des drills de restore.'] },
+  registry: { features: ['Stocker des images de conteneurs (ou artefacts) versionnées', 'Alimenter les pipelines avec des artefacts immuables'], notes: ['Rétention d’images, scan et promotion entre envs souvent absents.'] },
+  audit: { features: ['Enregistrer qui a fait quoi, quand, pour sécurité et conformité', 'Garder un historique opérationnel difficile à altérer'], notes: ['Rétention, immutabilité et qui peut requêter les audits sont des trous de politique.'] }
 };
 
 const ROLE_CAPABILITIES: Record<string, { en: string; fr: string }> = {
@@ -413,7 +554,21 @@ const ROLE_CAPABILITIES: Record<string, { en: string; fr: string }> = {
   tracing: { en: 'distributed request tracing', fr: 'le traçage distribué des requêtes' },
   email: { en: 'transactional email delivery', fr: 'l’envoi d’e-mails transactionnels' },
   cicd: { en: 'automated build, test, and delivery', fr: 'l’automatisation du build, des tests et de la livraison' },
-  gitops: { en: 'declarative infrastructure reconciliation', fr: 'la réconciliation déclarative de l’infrastructure' }
+  gitops: { en: 'declarative infrastructure reconciliation', fr: 'la réconciliation déclarative de l’infrastructure' },
+  waf: { en: 'web application firewall protection', fr: 'la protection par pare-feu applicatif web' },
+  loadBalancer: { en: 'traffic distribution and TLS termination', fr: 'la répartition de trafic et la terminaison TLS' },
+  warehouse: { en: 'analytical data warehousing', fr: 'l’entrepôt de données analytique' },
+  streamProcessing: { en: 'real-time stream transformation', fr: 'la transformation de flux en temps réel' },
+  schemaRegistry: { en: 'centralized schema governance', fr: 'la gouvernance centralisée des schémas' },
+  embeddings: { en: 'vector embedding generation', fr: 'la génération d’embeddings vectoriels' },
+  rerank: { en: 'retrieval result reranking', fr: 'le reranking des résultats de retrieval' },
+  guardrails: { en: 'AI safety and policy filtering', fr: 'le filtrage de sûreté et de politique IA' },
+  ocr: { en: 'optical character recognition', fr: 'la reconnaissance optique de caractères' },
+  secrets: { en: 'secure credential storage and delivery', fr: 'le stockage et la délivrance sécurisés de credentials' },
+  config: { en: 'centralized configuration management', fr: 'la gestion centralisée de configuration' },
+  backup: { en: 'durable data backup and restore', fr: 'la sauvegarde et la restauration de données durables' },
+  registry: { en: 'container image registry', fr: 'le registre d’images conteneur' },
+  audit: { en: 'security and compliance audit logging', fr: 'la journalisation d’audit sécurité et conformité' }
 };
 
 const TECHNOLOGY_DESCRIPTIONS: Record<string, { en: string; fr: string }> = {
@@ -477,7 +632,7 @@ const DEPENDENCIES: readonly LegoDependencySuggestion[] = [
   { from: 'audit', to: 'objects', strength: 'optional', why_en: 'Audit trails are often archived to object storage.', why_fr: 'Les pistes d’audit partent souvent en object storage.', protocol_id: 'object', kind: 'sync' }
 ];
 
-export const CATALOG_SEED = { intents: INTENTS, variants: VARIANTS, scopes: LOCKED_SCOPES, scopeAliases: SCOPE_ALIASES, roleScopes: ROLE_SCOPES, icons: ICONS, layers: LAYERS, defaultScopes: SCOPES, capabilities: CAPABILITIES, brickMetadata: BRICK_METADATA, frenchBrickMetadata: FRENCH_BRICK_METADATA, rolePhrases: ROLE_PHRASES, frenchRolePhrases: FRENCH_ROLE_PHRASES, roleCapabilities: ROLE_CAPABILITIES, technologyDescriptions: TECHNOLOGY_DESCRIPTIONS, dependencies: DEPENDENCIES } as const;
+export const CATALOG_SEED = { intents: INTENTS, variants: VARIANTS, scopes: LOCKED_SCOPES, scopeAliases: SCOPE_ALIASES, roleScopes: ROLE_SCOPES, icons: ICONS, layers: LAYERS, defaultScopes: SCOPES, capabilities: CAPABILITIES, brickMetadata: BRICK_METADATA, frenchBrickMetadata: FRENCH_BRICK_METADATA, rolePhrases: ROLE_PHRASES, frenchRolePhrases: FRENCH_ROLE_PHRASES, concernTags: CONCERN_TAGS, roleCapabilities: ROLE_CAPABILITIES, technologyDescriptions: TECHNOLOGY_DESCRIPTIONS, dependencies: DEPENDENCIES } as const;
 
 export function buildCatalogSnapshot(lang: LegoLanguage = 'en'): LegoCatalogSnapshot {
   const metadata = lang === 'fr' ? CATALOG_SEED.frenchBrickMetadata : CATALOG_SEED.brickMetadata;
@@ -489,6 +644,8 @@ export function buildCatalogSnapshot(lang: LegoLanguage = 'en'): LegoCatalogSnap
     defaultScope: CATALOG_SEED.defaultScopes[id] || 'product',
     capabilities: [...(CATALOG_SEED.capabilities[id] || [])],
     role: phrases[id] || id,
+    purpose: phrases[id] || id,
+    concernTags: [...(CATALOG_SEED.concernTags[id] || [])],
     responsibilities: [...(metadata[id]?.features || [])],
     notes: [...(metadata[id]?.notes || [])],
     affinities: [...(CATALOG_SEED.roleScopes[id] || [])],

--- a/src/lib/lego/types.ts
+++ b/src/lib/lego/types.ts
@@ -35,6 +35,10 @@ export interface LegoBrick {
   defaultScope: string;
   capabilities: string[];
   role: string;
+  /** One- or two-sentence catalog purpose for ADD context and glossary. */
+  purpose: string;
+  /** CAF chapter gating tags — snapshotted onto components at placement. */
+  concernTags: import('../document/concerns').ConcernTag[];
   responsibilities: string[];
   notes: string[];
   affinities: string[];

--- a/src/lib/seed.ts
+++ b/src/lib/seed.ts
@@ -1,5 +1,7 @@
 import { createFolder, createProject, isEmpty, listFolders } from './store';
 import { ensureLegoCatalog } from './lego/repository';
+import { contentFromAdmin } from './admin/flags';
+import { getFeaturedPublishedProjectTemplate, instantiateProjectTemplate } from './admin/project-templates';
 import demo from './seed/demo.json';
 import type { Architecture } from './types';
 
@@ -13,6 +15,21 @@ export function ensureSeed(): void {
   if (!isEmpty() || listFolders().length) return;
 
   const examples = createFolder('Examples', null, '#0099A0');
+
+  if (contentFromAdmin()) {
+    const featured = getFeaturedPublishedProjectTemplate();
+    if (featured) {
+      const seedName = featured.meta.seedName ?? featured.nameEn;
+      createProject({
+        name: seedName,
+        folderId: examples.id,
+        description: featured.meta.descriptionEn ?? featured.meta.taglineEn,
+        accent: featured.meta.accent,
+        data: instantiateProjectTemplate(featured, seedName),
+      });
+      return;
+    }
+  }
 
   createProject({
     name: 'Acme — two platforms',

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,4 +1,5 @@
 import { db, uid, now, plain, plainAll } from './db';
+import { applyResolvedFlowCopy } from './admin/flow-copy.server';
 import { blankArchitecture, normalizeArchitecture } from './defaults';
 import type {
   Architecture, FolderRecord, ProjectRecord, ProjectSummary, ProjectWithData, RevisionRecord
@@ -138,9 +139,10 @@ export function createProject(input: {
   data?: Partial<Architecture>;
 }): ProjectWithData {
   const id = uid('p_');
-  const doc = input.data
+  let doc = input.data
     ? normalizeArchitecture(input.data)
     : blankArchitecture(input.name);
+  doc = applyResolvedFlowCopy(doc);
   doc.meta.name = doc.meta.name || input.name;
 
   const max = plain<{ m: number | null }>(

--- a/src/lib/templates/index.ts
+++ b/src/lib/templates/index.ts
@@ -92,6 +92,8 @@ export interface InstantiateOptions {
   projectName: string;
   /** ISO date, injected so tests and snapshots stay deterministic. */
   today?: string;
+  /** Last check date for vendor service names. Defaults to `SERVICES_VERIFIED_ON`. */
+  verifiedOn?: string;
 }
 
 export function instantiate(tpl: Template, opts: InstantiateOptions): Architecture {
@@ -196,7 +198,10 @@ export function instantiate(tpl: Template, opts: InstantiateOptions): Architectu
 
   /* 5 — sections, plus the generated deployment table */
   const sections: Section[] = (tpl.sections || []).map(s => resolveDeep<Section>(s, lang));
-  if (resolved) sections.push(deploymentSection(tpl, { lang, target: resolved, targetLabel, omitted, displayName, overrideOf }));
+  if (resolved) sections.push(deploymentSection(tpl, {
+    lang, target: resolved, targetLabel, omitted, displayName, overrideOf,
+    verifiedOn: opts.verifiedOn ?? SERVICES_VERIFIED_ON,
+  }));
 
   /* The technology table is a by-product of the resolved components: on a cloud
    * target it is exactly the list of services the document commits to. It is
@@ -243,7 +248,8 @@ export function instantiate(tpl: Template, opts: InstantiateOptions): Architectu
     components,
     technologies,
     flows,
-    sections
+    sections,
+    decisions: []
   };
 
   return normalizeArchitecture(doc);
@@ -255,6 +261,7 @@ function deploymentSection(tpl: Template, ctx: {
   lang: Lang; target: Exclude<CloudTarget, 'agnostic'>; targetLabel: string;
   omitted: Set<string>; displayName: (id: string) => string;
   overrideOf: (id: string) => { name?: unknown; tech?: string[]; note?: unknown } | undefined;
+  verifiedOn: string;
 }): Section {
   const { lang, targetLabel, omitted } = ctx;
   const layerOrder = new Map(tpl.layers.map((l, i) => [l.id, i]));
@@ -275,7 +282,7 @@ function deploymentSection(tpl: Template, ctx: {
 
   const dropped = tpl.components.filter(c => omitted.has(c.id)).map(c => t(c.name, lang));
   const notes = [
-    fill(STR.verified[lang], { date: SERVICES_VERIFIED_ON }),
+    fill(STR.verified[lang], { date: ctx.verifiedOn }),
     ...(dropped.length ? [fill(STR.omitted[lang], { target: targetLabel, list: list(dropped, lang) })] : [])
   ];
 
@@ -326,8 +333,8 @@ function collectTechnologies(
 /* ---------------------------------------------------------------- summaries */
 
 /** Metadata for the picker: both languages, no component bodies. */
-export function templateSummaries(): TemplateSummary[] {
-  return TEMPLATES.map(tpl => {
+export function templateSummariesFrom(templates: Template[]): TemplateSummary[] {
+  return templates.map(tpl => {
     const counts = Object.fromEntries(
       TARGETS.map(target => [
         target,
@@ -342,6 +349,7 @@ export function templateSummaries(): TemplateSummary[] {
 
     return {
       id: tpl.id,
+      kind: 'architecture' as const,
       icon: tpl.icon,
       accent: tpl.accent,
       accentDark: tpl.accentDark,
@@ -353,4 +361,8 @@ export function templateSummaries(): TemplateSummary[] {
       counts
     };
   });
+}
+
+export function templateSummaries(): TemplateSummary[] {
+  return templateSummariesFrom(TEMPLATES);
 }

--- a/src/lib/templates/resolve.server.ts
+++ b/src/lib/templates/resolve.server.ts
@@ -1,0 +1,56 @@
+import { contentFromAdmin } from '../admin/flags';
+import {
+  getPublishedArchitectureTemplate,
+  getPublishedArchitectureTemplates,
+} from '../admin/architecture-templates';
+import { getPublishedServices } from '../admin/cloud-services';
+import { applyResolvedFlowCopy } from '../admin/flow-copy.server';
+import {
+  getTemplate,
+  instantiate,
+  SERVICES,
+  SERVICES_VERIFIED_ON,
+  templateSummaries,
+  templateSummariesFrom,
+  type InstantiateOptions,
+  type Template,
+  type TemplateSummary,
+} from './index';
+import type { ServiceRow } from './services';
+
+/** Server-only: published admin template when flag on, else code registry. */
+export function resolveGetTemplate(id: string): Template | undefined {
+  if (contentFromAdmin()) {
+    const fromAdmin = getPublishedArchitectureTemplate(id);
+    if (fromAdmin) return fromAdmin;
+  }
+  return getTemplate(id);
+}
+
+export function resolveTemplateSummaries(): TemplateSummary[] {
+  if (contentFromAdmin()) {
+    const fromAdmin = getPublishedArchitectureTemplates();
+    if (fromAdmin.length > 0) return templateSummariesFrom(fromAdmin);
+  }
+  return templateSummaries();
+}
+
+export type ResolvedServices = {
+  services: Record<string, ServiceRow>;
+  verifiedOn: string;
+};
+
+export function resolveServices(): ResolvedServices {
+  if (contentFromAdmin()) {
+    const published = getPublishedServices();
+    if (published) return published;
+  }
+  return { services: SERVICES, verifiedOn: SERVICES_VERIFIED_ON };
+}
+
+/** Instantiate using the published verified-on date when admin content is live. */
+export function instantiateResolved(tpl: Template, opts: InstantiateOptions) {
+  const { verifiedOn } = resolveServices();
+  const doc = instantiate(tpl, { ...opts, verifiedOn: opts.verifiedOn ?? verifiedOn });
+  return applyResolvedFlowCopy(doc);
+}

--- a/src/lib/templates/types.ts
+++ b/src/lib/templates/types.ts
@@ -192,6 +192,8 @@ export interface Template {
 /** What the picker needs. No component bodies, no editorial content. */
 export interface TemplateSummary {
   id: string;
+  /** Architecture templates resolve per cloud target; project templates are full snapshots. */
+  kind?: 'architecture' | 'project';
   icon: string;
   accent: string;
   accentDark: string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -87,6 +87,10 @@ export interface Component {
   tech?: string[];
   url?: string;
   role?: string;
+  /** Snapshotted catalog purpose at placement; preferred over `role` in ADD. */
+  purpose?: string;
+  /** Snapshotted CAF gating tags at placement. */
+  concernTags?: import('./document/concerns').ConcernTag[];
   /** Stable Lego catalog identity; `role` remains human-readable prose. */
   brick?: import('./lego/bricks').BrickId;
   features?: string[];
@@ -107,6 +111,17 @@ export interface Flow {
   id: string; name: string; group?: string; sub?: string; note?: string; steps: FlowStep[];
 }
 
+/** One architecture decision record (Nygard ADR), stored in the document JSON. */
+export interface ArchitectureDecision {
+  id: string;
+  title: string;
+  context: string;
+  decision: string;
+  consequences: string;
+  status: 'proposed' | 'accepted' | 'superseded';
+  supersedes?: string;
+}
+
 export type SectionType = 'cards' | 'timeline' | 'table' | 'compare' | 'text';
 
 /** Where a section sits in the printable design document.
@@ -116,7 +131,11 @@ export type SectionType = 'cards' | 'timeline' | 'table' | 'compare' | 'text';
  * chapter renumbers the rest instead of leaving a hole. Its first segment picks
  * the part (1 to 5); anything else, or no slot at all, lands in the appendices.
  * The viewer ignores this field entirely. */
-export interface DocSlot { chapter?: string }
+export interface DocSlot {
+  chapter?: string;
+  /** Auto-added from brick `concernTags` gating — removed when the gate closes. */
+  gated?: boolean;
+}
 
 export interface Section {
   id: string;
@@ -167,6 +186,7 @@ export interface Architecture {
   technologies: Technology[];
   flows: Flow[];
   sections: Section[];
+  decisions: ArchitectureDecision[];
 }
 
 /* ------------------------------------------------------------------ records */


### PR DESCRIPTION
## Summary

- Local-first **Admin CMS** at `/admin`: draft → publish for Lego catalogue, project & architecture templates, ADD sections, flow patterns, cloud services, system copy, and content bundles.
- Runtime opt-in via **`CONTENT_FROM_ADMIN=1`** (published-only resolve); flag off keeps prior seed/code paths.
- Atelier chrome (same tokens as the editor); topbar owns the page title (no double H1).
- Regression pack **F-REG** (`npm run test:admin`) plus full `npm test` CI gate unchanged.
- Merged latest `main` (zones/envs, docker, Ask) with conflict resolution on Editor/ADS, document plan, SectionsEditor, defaults, and globals.

## Test plan

- [x] `npm run typecheck` (or `npx tsc --noEmit`)
- [x] `npm run test:admin`
- [x] `npm test`
- [x] `npm run build`
- [x] Manual: `npm run dev` → `/admin` → Catalogue (create/save/delete custom) → Publish wizard → Locale
- [x] Optional: `CONTENT_FROM_ADMIN=1` → create project from published template / check ADD title after publish
- [x] Optional: `node scripts/admin-smoke.mjs` with server up

## Notes

- Reviewer map: `docs/add/README.md`
- Out of scope: auth on `/admin`, hydrate B2 density (deferred), Playwright